### PR TITLE
🚀(script) add deploy and init utilities

### DIFF
--- a/bin/deploy
+++ b/bin/deploy
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+# Run ansible-playbook
+_docker_run ansible-playbook deploy.yml "$@"

--- a/bin/init
+++ b/bin/init
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+# Run ansible-playbook
+_docker_run ansible-playbook init_project.yml --ask-vault-pass "$@"


### PR DESCRIPTION
The following two scripts have been extensively used as shortcuts during
the development of Arnold. As I think it might help others, let's add
them to the repository:

* bin/init: runs the init_project playbook, asking for the vault password
  (I always forget it)
* bin/deploy: runs the deploy playbook

In both cases, the script accepts ansible-playbook command arguments,
e.g.

    $ bin/deploy -e "env_type=staging"

Nota bene: for now those scripts are targetting a development stack
using MiniShift, you cannot use them in your CI or for production
purpose (we'll extensively document this).