### PR TITLE
⬆️(edxapp) upgrade edxapp to 1.0.2

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -30,7 +30,7 @@ postgresql_ip:  192.168.0.1
 # Service flag should only contain alphanumeric (or '-') characters. It should
 # validate the following regexp: '[a-z]([-a-z0-9]*[a-z0-9])?'
 edxapp_image:      "fundocker/edxapp"
-edxapp_tag:        "ginkgo.1-1.0.1"
+edxapp_tag:        "ginkgo.1-1.0.2"
 mongodb_image:     "centos/mongodb-32-centos7"
 mongodb_tag:       "3.2"
 mysql_image:       "centos/mysql-57-centos7"


### PR DESCRIPTION
# Purpose

`fundocker/edxapp:ginkgo.1-1.0.1` is not compatible with the current Arnold version: it expects sensible settings to be in a file called `credentials.vaul.yml` where Arnold was copying it as `secrets.yml`.

# Proposal

`fundocker/edxapp:ginkgo.1-1.0.2` now expects these settings to be located where Arnold will generate it.

:warning: We should wait for the two following PR to be merged (and the `ginkgo.1-1.0.2` git tag) before merging this work:

* https://github.com/openfun/fun-platform/pull/24
* https://github.com/openfun/fun-platform/pull/25