### PR TITLE
Improve quick-start docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,11 +107,15 @@ $ oc login -u system:admin
 
 Open your web browser with the console url (_e.g._ something similar to
 [https://192.168.99.100:8443](https://192.168.99.100:8443)), add a security
-exception to for the missing SSL certificate, login and be amazed by OpenShift
-web console.
+exception to for the missing SSL certificate, login with **developer**
+credentials (see `minishift` output above) and be amazed by OpenShift web
+console.
 
 Now let's have fun (sic!) by creating an OpenShift project for a customer in a
 particular environment with a new helper:
+
+> When running this command, you'll be asked for a **vault password**. The
+> default value for this demo is: `arnold`.
 
 ```bash
 $ bin/init

--- a/env.d/base
+++ b/env.d/base
@@ -1,5 +1,4 @@
 # ---- Ansible settings ----
-ANSIBLE_VAULT_PASS=
 ANSIBLE_RETRY_FILES_SAVE_PATH=
 
 # ---- OpenShift ----


### PR DESCRIPTION
Follow-up remarks from @rmoch tests:

* Remove `ANSIBLE_VAULT_PASS` unused variable
* Be more explicit about credentials to use to login to OpenShift's console
* Add missing vault password

Fix #11 