### PR TITLE
🔥(util) remove unused .vault_pass.sh file

### DIFF
--- a/.vault_pass.sh
+++ b/.vault_pass.sh
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-echo $ANSIBLE_VAULT_PASS


### PR DESCRIPTION
.vault_pass.sh was used to ease ansible vault decryption from OpenShift.
It is no longer required.

Fix #10