### PR TITLE
Allow limiting objects to specific environments

### DIFF
--- a/create_acme.yml
+++ b/create_acme.yml
@@ -19,6 +19,7 @@
         definition: "{{ lookup('url', acme_git + item + '.yaml', split_lines=False) | from_yaml }}"
       with_items:
         - "{{ acme_openshift_objects }}"
+      when: env_type != 'development'
 
     - name: Add role to serviceaccount
       openshift_raw:
@@ -29,6 +30,7 @@
       with_items:
         - "{{ openshift_rolesbinding }}"
       ignore_errors: true
+      when: env_type != 'development'
       # The rolebinding is created but openshift_raw fail
       # see this issue
       # https://github.com/ansible/ansible/issues/36845

--- a/create_objects.yml
+++ b/create_objects.yml
@@ -16,15 +16,6 @@
 
   - debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
 
-  - name: Create development-specific DCs
-    openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
-      definition: "{{ lookup('template', 'templates/' + item + '.j2') | from_yaml }}"
-      state: present
-    with_items:
-      - "{{ openshift_deployments.development }}"
-    when: env_type == "development"
-
   - name: Make sure required project objects exist in OpenShift and are up-to-date
     openshift_raw:
       verify_ssl: "{{ should_verify_ssl }}"
@@ -33,7 +24,7 @@
     with_items:
       - "{{ openshift_volumes }}"
       - "{{ openshift_endpoints }}"
-      - "{{ openshift_deployments.common }}"
+      - "{{ openshift_deployments }}"
       - "{{ openshift_services }}"
       - "{{ openshift_jobs }}"
       - "{{ openshift_routes }}"

--- a/deploy.yml
+++ b/deploy.yml
@@ -23,22 +23,13 @@
 
   - import_tasks: tasks/create_config.yml
 
-  - name: Deploy development-specific DCs
-    openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
-      definition: "{{ lookup('template', 'templates/' + item + '.j2') | from_yaml }}"
-      state: present
-    with_items:
-      - "{{ openshift_deployments.development }}"
-    when: env_type == "development"
-
   - name: Deploy new stack to OpenShift
     openshift_raw:
       verify_ssl: "{{ should_verify_ssl }}"
       definition: "{{ lookup('template', 'templates/' + item + '.j2') | from_yaml }}"
       state: present
     with_items:
-      - "{{ openshift_deployments.common }}"
+      - "{{ openshift_deployments }}"
       - "{{ openshift_services }}"
       - "{{ openshift_jobs }}"
       - "{{ openshift_routes }}"

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -74,16 +74,11 @@ richie_database:
 
 # Openshift template files
 openshift_deployments:
-  common:
-    - openshift/edxapp/dc/cms.yml
-    - openshift/edxapp/dc/lms.yml
-    - openshift/edxapp/dc/memcached.yml
-    - openshift/common/dc/nginx.yml
-    - openshift/common/dc/postgresql.yml
-    - openshift/richie/dc/richie.yml
-  development:
-    - openshift/common/dc/mongodb.yml
-    - openshift/common/dc/mysql.yml
+  - openshift/edxapp/dc/cms.yml
+  - openshift/edxapp/dc/lms.yml
+  - openshift/edxapp/dc/memcached.yml
+  - openshift/common/dc/nginx.yml
+  - openshift/richie/dc/richie.yml
 openshift_endpoints:
   - openshift/common/ep/mongodb.yml
   - openshift/common/ep/mysql.yml

--- a/group_vars/all/openshift_routes.yml
+++ b/group_vars/all/openshift_routes.yml
@@ -21,3 +21,4 @@ openshift_routes:
 #       - alias_1
 #       - alias_2
 openshift_routes_aliases:
+    # No route aliases

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -1,3 +1,17 @@
 # Variables specific to development environments
 domain_name: "{{ lookup('env', 'MINISHIFT_IP') }}.nip.io"
 django_configuration: Development
+
+# Override Openshift template files because databases are containers
+# instead of external services reachable via endpoints
+openshift_deployments:
+  - openshift/common/dc/nginx.yml
+  - openshift/common/dc/mongodb.yml
+  - openshift/common/dc/mysql.yml
+  - openshift/common/dc/postgresql.yml
+  - openshift/edxapp/dc/cms.yml
+  - openshift/edxapp/dc/lms.yml
+  - openshift/edxapp/dc/memcached.yml
+  - openshift/richie/dc/richie.yml
+openshift_endpoints:
+    # No endpoints required for the development environment

--- a/group_vars/env_type/feature.yml
+++ b/group_vars/env_type/feature.yml
@@ -3,3 +3,17 @@
 # Only in feature environment do we add the feature title to the hosts
 lms_host: "{{ project_name }}-lms--{{ feature_title }}.{{ domain_name }}"
 cms_host: "{{ project_name }}-cms--{{ feature_title }}.{{ domain_name }}"
+
+# Override Openshift template files because databases are containers
+# instead of external services reachable via endpoints
+openshift_deployments:
+  - openshift/common/dc/nginx.yml
+  - openshift/common/dc/mongodb.yml
+  - openshift/common/dc/mysql.yml
+  - openshift/common/dc/postgresql.yml
+  - openshift/edxapp/dc/cms.yml
+  - openshift/edxapp/dc/lms.yml
+  - openshift/edxapp/dc/memcached.yml
+  - openshift/richie/dc/richie.yml
+openshift_endpoints:
+    # No endpoints required for the feature environments


### PR DESCRIPTION
## Purpose

Some objects are created in environments where they should not **e.g.** endpoints in development/feature, acme in development/feature, database containers in staging/preproduction/production, etc.

## Proposal

Improve the structure of objects in group_vars  to allow this configuration:

- [x] endpoints should only be created in staging/preproduction/production
- [x] mysql and mongodb containers should only be created in feature/development
- [x] acme should not be created in development

Fixes https://github.com/openfun/arnold/issues/24