### PR TITLE
Use development images for dev

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -30,7 +30,7 @@ postgresql_ip:  192.168.0.1
 # Service flag should only contain alphanumeric (or '-') characters. It should
 # validate the following regexp: '[a-z]([-a-z0-9]*[a-z0-9])?'
 edxapp_image:      "fundocker/edxapp"
-edxapp_tag:        "ginkgo.1-1.0.2"
+edxapp_tag:        "ginkgo.1-1.0.3"
 mongodb_image:     "centos/mongodb-32-centos7"
 mongodb_tag:       "3.2"
 mysql_image:       "centos/mysql-57-centos7"

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -2,6 +2,10 @@
 domain_name: "{{ lookup('env', 'MINISHIFT_IP') }}.nip.io"
 django_configuration: Development
 
+# Use development images in the development environment
+edxapp_tag: "ginkgo.1-1.0.3-dev"
+richie_tag: "0.1.0-alpha.3-alpine-dev"
+
 # Override Openshift template files because databases are containers
 # instead of external services reachable via endpoints
 openshift_deployments:


### PR DESCRIPTION
## Purpose

In the development environment, we want to have more tools installed on our images.

## Proposal

Use dev Docker images only for the `development` environment:

- [x] For edxapp
- [x] For Richie

Fix #27 