### PR TITLE
🚑(minishift) fix wrong variable name

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -45,7 +45,7 @@ function _run-minishift() {
 
     local opts="--memory=4GB"
     if [ $USE_KVM -eq 0 ]; then
-        opts="$ops --vm-driver=virtualbox"
+        opts="$opts --vm-driver=virtualbox"
     fi
 
     echo "Starting minishift with options: ${opts}"


### PR DESCRIPTION
Bug : with VirtualBox the 4GB memory opt was erased instead of be overridden.