### PR TITLE
Use an environment variable to configure checking SSL in openshift_raw module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ module to make Ansible talk with OpenShift.
 
 As a DevOps using this project, you will need to adapt OpenShift object
 templates to suite your needs or constraints and run playbooks to push your
-changes to your OpenShift instance that orchestrate your OpenEdx services.
+changes to your OpenShift instance that orchestrates your OpenEdx services.
 
 ## Requirements
 
@@ -26,7 +26,7 @@ changes to your OpenShift instance that orchestrate your OpenEdx services.
 * [OpenShift](https://docs.openshift.org/latest/welcome/index.html) (or
   [MiniShift](https://docs.openshift.org/latest/minishift/getting-started/)): as
   Arnold should talk with someone, you'll need a running OpenShift instance to
-  use this project. For development or demo purpose, please read our
+  use this project. For development or demo purposes, please read our
   [instructions to install MiniShift](./docs/installation/minishift.md) on your machine in a
   few minutes.
 

--- a/create_acme.yml
+++ b/create_acme.yml
@@ -13,7 +13,6 @@
 
     - name: Create all openshift-acme OpenShift objects
       openshift_raw:
-        verify_ssl: "{{ should_verify_ssl }}"
         force: true
         namespace: "{{ project_name }}"
         definition: "{{ lookup('url', acme_git + item + '.yaml', split_lines=False) | from_yaml }}"
@@ -23,7 +22,6 @@
 
     - name: Add role to serviceaccount
       openshift_raw:
-        verify_ssl: "{{ should_verify_ssl }}"
         force: true
         state: present
         definition: "{{ lookup('template', 'templates/openshift/common/rolebinding/add-role-to-sa.yml.j2') | from_yaml }}"

--- a/create_object.yml
+++ b/create_object.yml
@@ -26,7 +26,6 @@
 
   - name: Create object
     openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
       definition: "{{ lookup('template', object_template) | from_yaml }}"
       state: present
       force: true

--- a/create_objects.yml
+++ b/create_objects.yml
@@ -18,7 +18,6 @@
 
   - name: Make sure required project objects exist in OpenShift and are up-to-date
     openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
       definition: "{{ lookup('template', 'templates/' + item + '.j2') | from_yaml }}"
       state: present
     with_items:
@@ -38,7 +37,6 @@
 
   - name: Make sure all redirected routes exist or force recreation
     openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
       force: true
       definition: "{{ lookup('template', 'templates/openshift/common/route/routes_aliases.yml.j2') | from_yaml }}"
       state: present

--- a/create_project.yml
+++ b/create_project.yml
@@ -14,7 +14,6 @@
 
   - name: Make sure the project exists in OpenShift and is up-to-date
     openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
       api_version: v1
       kind: Project
       name: "{{ project_name }}"

--- a/create_secrets.yml
+++ b/create_secrets.yml
@@ -56,7 +56,6 @@
 
     # Create all project secrets (for every group)
     - name: Actually create the secrets in OpenShift
-      verify_ssl: "{{ should_verify_ssl }}"
       openshift_raw:
         state: present
         force: true

--- a/deploy.yml
+++ b/deploy.yml
@@ -25,7 +25,6 @@
 
   - name: Deploy new stack to OpenShift
     openshift_raw:
-      verify_ssl: "{{ should_verify_ssl }}"
       definition: "{{ lookup('template', 'templates/' + item + '.j2') | from_yaml }}"
       state: present
     with_items:

--- a/docs/installation/minishift.md
+++ b/docs/installation/minishift.md
@@ -7,7 +7,7 @@ test Arnold or work on it.
 
 ## Pre-requisite: install & configure an hypervisor
 
-MiniShift needs an hypervisor to work with: it uses KVM by default by can also run on
+MiniShift needs an hypervisor to work with: it uses KVM by default but can also run on
 [VirtualBox](https://www.virtualbox.org/wiki/Downloads). 
 
 We recommend using VirtualBox because developers are more likely to have it on their

--- a/env.d/development
+++ b/env.d/development
@@ -13,3 +13,4 @@ K8S_AUTH_API_KEY=
 # OpenShift console IP as given by: minishift ip
 # Protocol should be https and port 8443
 K8S_AUTH_HOST=
+K8S_AUTH_VERIFY_SSL=no

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -1,5 +1,4 @@
 ---
-should_verify_ssl: false
 env_type: development  # default to be overriden on command line
 customer: patient0  # default to be overriden on command line
 project_name: "{{ env_type }}-{{ customer }}"

--- a/group_vars/env_type/preproduction.yml
+++ b/group_vars/env_type/preproduction.yml
@@ -1,3 +1,2 @@
 # Variables specific to the pre-production environment
 django_configuration: PreProduction
-should_verify_ssl: true

--- a/group_vars/env_type/production.yml
+++ b/group_vars/env_type/production.yml
@@ -1,4 +1,3 @@
 # Variables specific to the production environment
 django_configuration: Production
-should_verify_ssl: true
 acme_env: live

--- a/group_vars/env_type/staging.yml
+++ b/group_vars/env_type/staging.yml
@@ -1,3 +1,2 @@
 # Variables specific to the staging environment
 django_configuration: Staging
-should_verify_ssl: true

--- a/tasks/create_config.yml
+++ b/tasks/create_config.yml
@@ -43,7 +43,6 @@
 
 - name: Actually create the config maps in OpenShift
   openshift_raw:
-    verify_ssl: "{{ should_verify_ssl }}"
     state: present
     name: "{{ item.key }}-{{ deployment_stamp }}"
     namespace: "{{ project_name }}"


### PR DESCRIPTION
## Purpose

The openshift_raw module can be configured via an environment variable to check SSL certificates before connecting to an OpenShift instance or not. This avoids having to set it on each object in our playbooks.

## Proposal

-  [x] Add K8S_AUTH_VERIFY_SSL=no to our default environment file
- [x] Remove all verify_ssl parameters in playbooks