### PR TITLE
Add secrets versioning

### DIFF
--- a/docs/developer_guide/secrets.md
+++ b/docs/developer_guide/secrets.md
@@ -1,0 +1,136 @@
+# Handling project secrets
+
+Arnold uses OpenShift's `Secret` objects to securely inject services credentials
+to running pods. Those `Secret`s are generated from an encrypted YAML file that
+defines secret values (`credentials.vault.yml`) and a `Secret` object template
+(see `templates/openshift/common/secret/env_vars.yml.j2`).
+
+The encrypted YAML files are expected to be stored in:
+
+```
+group_vars/secret/{{ customer }}/{{ env_type }}/{{ application }}/credentials.vault.yml
+```
+
+Credentials files are securely encrypted using the `ansible-vault` tool before
+being versioned in Arnold's repository (see usage in the next sections). In
+plain text, the `credentials.vault.yml` file looks like:
+
+```yaml
+# customer: patient0
+# env_type: staging
+
+# centos/postgresql-96-centos7 image environment
+POSTGRESQL_USER: foo
+POSTGRESQL_PASSWORD: pass
+
+# application's environment
+DJANGO_SECRET_KEY: fakekey
+
+# We can also store complex values such as dictionaries...
+FOO_DICT:
+    - first_key: "bar"
+    - second_key: "baz"
+
+# ...or lists
+FOO_LIST:
+    - "bar"
+    - "baz"
+    - "spam"
+```
+
+## Generate a new secret
+
+Once you have generated a plain text YAML file with required credentials for
+your application (see example above), you will need to encrypt its content,
+version it and create or update secrets in OpenShift:
+
+```bash
+# Encrypt plain text credentials
+# Nota bene: you'll be asked to type the encryption password twice
+$ bin/run ansible-vault encrypt --ask-vault-pass path/to/credentials.vault.yaml
+
+# Add the file to the repository
+$ git add path/to/credentials.vault.yaml
+$ git commit -m "Add new secret for foo app"
+
+# Create or update the secret in OpenShift for the
+# "Patient 0" customer in "development" env_type.
+$ bin/ansible-playbook --ask-vault-pass create_secrets.yml
+
+# Alternatively, if you want to create a secret for
+# another customer/env_type
+$ bin/ansible-playbook --ask-vault-pass create_secrets.yml \
+    -e "customer=corporate" -e "env_type=staging"
+```
+
+> TODO: for production examples, use raw docker commands instead of the sugar
+> scripts
+
+## Update a secret
+
+To allow different versions of a `Secret` for a deployed application, `Secret`s
+have a `secret_id` attached to them and linked to DCs and jobs (see
+`group_vars/all/main.yml`).
+
+### Override a secret
+
+In case you need to override a secret (because of a typo in a password, etc.),
+here is the recipe to follow:
+
+```bash
+# Edit the credentials
+$ bin/run ansible-vault edit --ask-vault-pass path/to/credentials.vault.yaml
+
+# Commit changes
+$ git add path/to/credentials.vault.yaml
+$ git commit -m "Update secrets for foo app"
+
+# Update secrets
+$ bin/ansible-playbook --ask-vault-pass create_secrets.yml
+
+# Alternatively, if you want to update secrets for another
+# customer/env_type
+$ bin/ansible-playbook --ask-vault-pass create_secrets.yml \
+    -e "customer=corporate" -e "env_type=staging"
+```
+
+Updating a secret should raise a signal that re-deploys automatically all your
+DCs depending on this particular secret.
+
+### Create a new version of the secret
+
+When you want to create a new secret and keep compatibility with previously
+deployed secrets, we recommend you to upgrade the `secret_id` variable in
+`group_vars/all/main.yml` (this variable follows a semantic versioning schema),
+create the new secrets and then start a new deployment of your application.
+
+```bash
+# Edit the credentials
+$ bin/run ansible-vault edit --ask-vault-pass path/to/credentials.vault.yaml
+
+# Update secret version
+$ grep secret_id group_vars/all/main.yml
+secret_id: "1.0.0"
+
+$ vim group_vars/all/main.yml
+
+$ grep secret_id group_vars/all/main.yml
+secret_id: "1.1.0"
+
+# Commit changes
+$ git add group_vars/all/main.yml path/to/credentials.vault.yaml
+$ git commit -m "Update secrets for foo app"
+
+# Create a new version of the secrets
+$ bin/ansible-playbook --ask-vault-pass create_secrets.yml
+
+# Deploy
+$ bin/deploy
+
+# Alternatively, if you want to create a new version of
+# the secrets for another customer/env_type
+$ bin/ansible-playbook --ask-vault-pass create_secrets.yml \
+    -e "customer=corporate" -e "env_type=staging"
+
+$ bin/deploy -e "customer=corporate" -e "env_type=staging"
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,7 +33,8 @@ changes to your OpenShift instance that orchestrate your OpenEdx services.
 2.  [Getting started](./developer_guide/getting_started.md)
 3.  [Using Ansible playbooks](./developer_guide/playbooks.md)
 4.  [Working with routes](./developer_guide/routes_aliases.md)
-5.  [Hello customer](./developer_guide/hello.md)
+5.  [Handling secrets](./developer_guide/secrets.md)
+6.  [Hello customer](./developer_guide/hello.md)
 
 ### III. Contributing
 

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -49,6 +49,13 @@ richie_tag:          "0.1.0-alpha.3-alpine"
 # overriden for each deployment (see deploy.yml playbook).
 deployment_stamp: "init"
 
+# We allow multiple versions of the secrets for an application. When defining
+# new or modified secrets, you will need to update this value to ensure your DCs
+# and jobs point to the relevant version of the secrets for the next deployment.
+# Read more about secrets handling in the developers documentation:
+# docs/developer_guide/secrets.md
+secret_id: "1.0.0"
+
 # Services hosts
 lms_host: "{{ project_name }}-lms-{{ deployment_stamp }}.{{ domain_name }}"
 cms_host: "{{ project_name }}-cms-{{ deployment_stamp }}.{{ domain_name }}"

--- a/templates/openshift/common/dc/mongodb.yml.j2
+++ b/templates/openshift/common/dc/mongodb.yml.j2
@@ -30,4 +30,4 @@ spec:
               value: edxapp
           envFrom:
             - secretRef:
-                name: edxapp
+                name: edxapp-{{ secret_id }}

--- a/templates/openshift/common/dc/mysql.yml.j2
+++ b/templates/openshift/common/dc/mysql.yml.j2
@@ -30,4 +30,4 @@ spec:
               value: edxapp
           envFrom:
             - secretRef:
-                name: edxapp
+                name: edxapp-{{ secret_id }}

--- a/templates/openshift/common/dc/postgresql.yml.j2
+++ b/templates/openshift/common/dc/postgresql.yml.j2
@@ -30,4 +30,4 @@ spec:
               value: "{{ richie_database.name }}"
           envFrom:
             - secretRef:
-                name: richie
+                name: richie-{{ secret_id }}

--- a/templates/openshift/common/secret/env_vars.yml.j2
+++ b/templates/openshift/common/secret/env_vars.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ group }}
+  name: {{ group }}-{{ secret_id }}
   namespace: {{ project_name }}
 data:
 {% for key, value in env_vars.iteritems() %}

--- a/templates/openshift/edxapp/dc/cms.yml.j2
+++ b/templates/openshift/edxapp/dc/cms.yml.j2
@@ -74,7 +74,7 @@ spec:
           emptyDir: {}  # volume that lives as long as the pod lives
         - name: edxapp-secret
           secret:
-            secretName: edxapp
+            secretName: edxapp-{{ secret_id }}
         - name: edxapp-v-media
           persistentVolumeClaim:
             claimName: edxapp-pvc-media

--- a/templates/openshift/edxapp/dc/lms.yml.j2
+++ b/templates/openshift/edxapp/dc/lms.yml.j2
@@ -74,7 +74,7 @@ spec:
           emptyDir: {}  # volume that lives as long as the pod lives
         - name: edxapp-secret
           secret:
-            secretName: edxapp
+            secretName: edxapp-{{ secret_id }}
         - name: edxapp-v-media
           persistentVolumeClaim:
             claimName: edxapp-pvc-media

--- a/templates/openshift/edxapp/job/collectstatic_cms.yml.j2
+++ b/templates/openshift/edxapp/job/collectstatic_cms.yml.j2
@@ -65,7 +65,7 @@ spec:
         emptyDir: {}  # volume that lives as long as the pod lives
       - name: edxapp-secret
         secret:
-          secretName: edxapp
+          secretName: edxapp-{{ secret_id }}
       - name: edxapp-v-static
         persistentVolumeClaim:
           claimName: edxapp-pvc-static

--- a/templates/openshift/edxapp/job/collectstatic_lms.yml.j2
+++ b/templates/openshift/edxapp/job/collectstatic_lms.yml.j2
@@ -65,7 +65,7 @@ spec:
         emptyDir: {}  # volume that lives as long as the pod lives
       - name: edxapp-secret
         secret:
-          secretName: edxapp
+          secretName: edxapp-{{ secret_id }}
       - name: edxapp-v-static
         persistentVolumeClaim:
           claimName: edxapp-pvc-static

--- a/templates/openshift/edxapp/job/db_migrate.yml.j2
+++ b/templates/openshift/edxapp/job/db_migrate.yml.j2
@@ -77,7 +77,7 @@ spec:
         emptyDir: {}  # volume that lives as long as the pod lives
       - name: edxapp-secret
         secret:
-          secretName: edxapp
+          secretName: edxapp-{{ secret_id }}
       - name: edxapp-v-media
         persistentVolumeClaim:
           claimName: edxapp-pvc-media

--- a/templates/openshift/edxapp/job/load_fixtures.yml.j2
+++ b/templates/openshift/edxapp/job/load_fixtures.yml.j2
@@ -82,7 +82,7 @@ spec:
           emptyDir: {}  # volume that lives as long as the pod lives
         - name: edxapp-secret
           secret:
-            secretName: edxapp
+            secretName: edxapp-{{ secret_id }}
         - name: edxapp-v-media
           persistentVolumeClaim:
             claimName: edxapp-pvc-media

--- a/templates/openshift/richie/dc/richie.yml.j2
+++ b/templates/openshift/richie/dc/richie.yml.j2
@@ -40,7 +40,7 @@ spec:
               value: {{ elasticsearch.host }}
           envFrom:
             - secretRef:
-                name: richie
+                name: richie-{{ secret_id }}
           volumeMounts:
             - name: richie-v-media
               mountPath: /data/media

--- a/templates/openshift/richie/job/collectstatic.yml.j2
+++ b/templates/openshift/richie/job/collectstatic.yml.j2
@@ -33,7 +33,7 @@ spec:
             value: "{{ richie_host }}"
         envFrom:
           - secretRef:
-              name: richie
+              name: richie-{{ secret_id }}
         image: "{{ richie_image }}:{{ richie_tag }}"
         command: ["python", "manage.py", "collectstatic", "--noinput"]
         volumeMounts:

--- a/templates/openshift/richie/job/db_migrate.yml.j2
+++ b/templates/openshift/richie/job/db_migrate.yml.j2
@@ -33,7 +33,7 @@ spec:
             value: "{{ richie_host }}"
         envFrom:
           - secretRef:
-              name: richie
+              name: richie-{{ secret_id }}
         image: "{{ richie_image }}:{{ richie_tag }}"
         command: ["python", "manage.py", "migrate"]
       restartPolicy: Never

--- a/templates/openshift/richie/job/regenerate_indexes.yml.j2
+++ b/templates/openshift/richie/job/regenerate_indexes.yml.j2
@@ -35,7 +35,7 @@ spec:
             value: {{ elasticsearch.host }}
         envFrom:
           - secretRef:
-              name: richie
+              name: richie-{{ secret_id }}
         image: "{{ richie_image }}:{{ richie_tag }}"
         command: ["python", "manage.py", "regenerate_indexes"]
       restartPolicy: Never


### PR DESCRIPTION
## Purpose

Current secrets workflow does not allow different versions of a secret to be deployed and linked to particular DCs or jobs.

## Proposal

- [x] add a `secret_id` in `group_vars/all/main.yml`
- [x] use the `secret_id` in the secret name 
- [x] use the new secret name pattern in DCs and jobs requiring a secret
- [x] add documentation to handle secrets

## Known limitations

For now, the current implementation only supports a global versioning of secrets whatever the application, customer or env_type is concerned. There is room for improvement. Suggestions are very welcome.