### PR TITLE
✨(job) ease job restart

### DIFF
--- a/bin/job
+++ b/bin/job
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+function usage() {
+    echo "Usage: $0 <JOB_TEMPLATE_PATH> <DEPLOYMENT_STAMP>"
+    echo ""
+    echo "Arguments:"
+    echo "  JOB_TEMPLATE_PATH: path to the template of the job to create"
+    echo "  DEPLOYMENT_STAMP : the deployment stamp to target for this job"
+
+    exit 1
+}
+
+# _set_namespace_for_deployment_stamp: given a deployment_stamp, set the
+# namespace for the job to run, and, deduce the customer & env_type variables.
+# This requires that pods have already been deployed with the given
+# deployment_stamp.
+#
+# usage: _set_namespace_for_deployment_stamp <DEPLOYMENT_STAMP>
+function _set_namespace_for_deployment_stamp() {
+    _set_minishift_path
+
+    namespace=$(oc get -o jsonpath="{.items[0].metadata.namespace}" --no-headers pods -l deployment_stamp="$1")
+
+    # Use bash pattern substitution (variable/pattern/string) to remove either
+    # the env_type or customer from the namespace (e.g. development-patient0)
+    env_type=${namespace/-*/}
+    customer=${namespace/*-/}
+}
+
+function main() {
+
+    if [ -z "$2" ]; then
+        usage
+    fi
+
+    local job_template="$1"
+    local deployment_stamp="$2"
+
+    _set_namespace_for_deployment_stamp "$deployment_stamp"
+
+    echo "Will submit a new job to OpenShift:"
+    echo ""
+    echo "customer        : $customer"
+    echo "env_type        : $env_type"
+    echo "deployment stamp: $deployment_stamp"
+    echo "job             : $job_template"
+
+    _docker_run ansible-playbook create_object.yml \
+        -e "customer=$customer" \
+        -e "env_type=$env_type" \
+        -e "object_template=$job_template" \
+        -e "deployment_stamp=$deployment_stamp"
+}
+
+main "$@"

--- a/create_object.yml
+++ b/create_object.yml
@@ -7,7 +7,8 @@
 # Usage:
 #
 #   $ bin/ansible-playbook create_object.yml \
-#       -e "object_template=templates/openshift/edxapp/job/import_demo_course.yml.j2"
+#       -e "object_template=templates/openshift/edxapp/job/import_demo_course.yml.j2" \
+#       -e "deployment_stamp=d-180611-08h46m30s"
 #
 
 - hosts: local
@@ -20,14 +21,24 @@
 
   tasks:
 
-  - name: Print project details
-    debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
+    - name: Print project details
+      debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
 
-  - name: Print OpenShift object template path
-    debug: msg="Object template {{ object_template}}"
+    - name: Print OpenShift object template path
+      debug: msg="Object template {{ object_template }}"
 
-  - name: Create object
-    openshift_raw:
-      definition: "{{ lookup('template', object_template) | from_yaml }}"
-      state: present
-      force: true
+    - name: Print deployment stamp
+      debug: msg="Deployment stamp {{ deployment_stamp }}"
+
+    # Set the job stamp for this object (only used for jobs)
+    - name: Set job stamp
+      set_fact: job_stamp="j-{{ lookup('pipe', 'date +%y%m%d-%Hh%Mm%Ss') }}"
+
+    - name: Print job stamp
+      debug: msg="Job stamp {{ job_stamp }}"
+
+    - name: Create object
+      openshift_raw:
+        definition: "{{ lookup('template', object_template) | from_yaml }}"
+        state: present
+        force: true

--- a/deploy.yml
+++ b/deploy.yml
@@ -10,16 +10,16 @@
 
   tasks:
 
-    # Following a blue-green deployment strategy, for each deployment, we create a
-    # unique identifier (deployment_stamp) that will be used to create unique
-    # OpenShift object names & tags and connect them. This identifier contains the
-    # deployment datetime concatenated with a random hash (short uuid), e.g.
-    # 2018-05-16-13-15-48-ef726d57
-    - name: Set deployment flag
-      set_fact: deployment_stamp="{{ lookup('pipe', 'date +%F-%H-%M-%S-$(cat /proc/sys/kernel/random/uuid | cut -c -8)') }}"
+    # Set the deployment stamp value for this deployment
+    - name: Set deployment stamp
+      set_fact: deployment_stamp="d-{{ lookup('pipe', 'date +%y%m%d-%Hh%Mm%Ss') }}"
+
+    # Set the job stamp for this deployment
+    - name: Set job stamp
+      set_fact: job_stamp="j-{{ lookup('pipe', 'date +%y%m%d-%Hh%Mm%Ss') }}"
 
     - name: Print deployment details
-      debug: msg="Deploying {{ project_name }} - {{ domain_name }} ({{ deployment_stamp }})"
+      debug: msg="Deploying {{ project_name }} - {{ domain_name }} (deployment stamp '{{ deployment_stamp }}' job stamp '{{ job_stamp }}')"
 
     - import_tasks: tasks/create_config.yml
 

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -43,11 +43,20 @@ postgresql_tag:      "9.6"
 richie_image:        "fundocker/richie"
 richie_tag:          "0.1.0-alpha.3-alpine"
 
-# A deployment flag is used to make deployments unique (blue-green strategy).
-# This deployment flag should be a lower-case code name containing only
-# alpha-numeric characters or dashes. It defaults to "init" and will be
-# overriden for each deployment (see deploy.yml playbook).
-deployment_stamp: "init"
+# Following a blue-green deployment strategy, for each deployment, we create a
+# unique identifier (deployment_stamp) that will be used to create unique
+# OpenShift object names & tags and connect them. This identifier starts with a
+# "d" and contains the deployment datetime (with seconds precision), e.g.
+# d-180611-08h46m30s. Default value is null as it should never be used as is,
+# but initiated in a playbook using a "set_fact" task.
+deployment_stamp: null
+
+# Similarly to deployment stamps, we make job identifiers unique for each
+# running playbook (deploy, create_object) by adding the job datetime (with
+# seconds precision) to the job name, e.g.
+# richie-collecstatic-j-180611-08h46m30s. Default value is null as it should
+# never be used as is, but initiated in a playbook using a "set_fact" task.
+job_stamp: null
 
 # We allow multiple versions of the secrets for an application. When defining
 # new or modified secrets, you will need to update this value to ensure your DCs

--- a/templates/openshift/edxapp/job/collectstatic_cms.yml.j2
+++ b/templates/openshift/edxapp/job/collectstatic_cms.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: edxapp-collecstatic-cms-{{ deployment_stamp }}
+  name: edxapp-collecstatic-cms-{{ job_stamp }}
   namespace: "{{ project_name }}"
   labels:
     app: edxapp-cms

--- a/templates/openshift/edxapp/job/collectstatic_lms.yml.j2
+++ b/templates/openshift/edxapp/job/collectstatic_lms.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: edxapp-collecstatic-lms-{{ deployment_stamp }}
+  name: edxapp-collecstatic-lms-{{ job_stamp }}
   namespace: "{{ project_name }}"
   labels:
     app: edxapp-lms

--- a/templates/openshift/edxapp/job/db_migrate.yml.j2
+++ b/templates/openshift/edxapp/job/db_migrate.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: edxapp-dbmigrate-{{ deployment_stamp }}
+  name: edxapp-dbmigrate-{{ job_stamp }}
   namespace: "{{ project_name }}"
   labels:
     app: edxapp

--- a/templates/openshift/edxapp/job/load_fixtures.yml.j2
+++ b/templates/openshift/edxapp/job/load_fixtures.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: edxapp-load-fixtures-{{ deployment_stamp }}
+  name: edxapp-load-fixtures-{{ job_stamp }}
   namespace: "{{ project_name }}"
   labels:
     app: edxapp

--- a/templates/openshift/richie/job/collectstatic.yml.j2
+++ b/templates/openshift/richie/job/collectstatic.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "richie-collecstatic-{{ deployment_stamp }}"
+  name: "richie-collecstatic-{{ job_stamp }}"
   namespace: "{{ project_name }}"
   labels:
     app: richie

--- a/templates/openshift/richie/job/db_migrate.yml.j2
+++ b/templates/openshift/richie/job/db_migrate.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "richie-dbmigrate-{{ deployment_stamp }}"
+  name: "richie-dbmigrate-{{ job_stamp }}"
   namespace: "{{ project_name }}"
   labels:
     app: richie

--- a/templates/openshift/richie/job/regenerate_indexes.yml.j2
+++ b/templates/openshift/richie/job/regenerate_indexes.yml.j2
@@ -1,7 +1,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "richie-regenerate-indexes-{{ deployment_stamp }}"
+  name: "richie-regenerate-indexes-{{ job_stamp }}"
   namespace: "{{ project_name }}"
   labels:
     app: richie


### PR DESCRIPTION
## Purpose

At this time, as jobs are immutable, re-run a failed job is a painful task: one need to delete it using `oc` or the OpenShift console, and then re-create it _via_ the `create_object` playbook.

## Proposal

- [x] Add a unique `job_stamp` to jobs (short UUID)

This `job_stamp` is set during the deployment and when using the `create_object` playbook.

_nota bene_: I choose to keep using the create_object.yml playbook to restart jobs instead of creating a new one, as almost the entire playbook would have been duplicated.