### PR TITLE
Feature/fix bin dev

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -50,7 +50,8 @@ function _run-minishift() {
     fi
 
     echo "Starting minishift with options: ${opts}"
-    minishift start "${opts}"
+    # shellcheck disable=SC2086
+    minishift start ${opts}
     minishift status
 
     echo -e "\n**** MiniShift is up and running ****"


### PR DESCRIPTION
## Bug

bin/dev fail after lint correction


## Fix

In bin/dev we build a command line.
So we must ignore the shellsheck SC2086 rule to split on spaces
The docker image dind used in gitlab-ci don't contain bash.              
We add bash because it used on shell scripts launch in the CI jobs.