### PR TITLE
feature/improve vars setting

### DIFF
--- a/create_acme.yml
+++ b/create_acme.yml
@@ -5,11 +5,10 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
+
+    - import_tasks: tasks/set_vars.yml
 
     - name: Create all openshift-acme OpenShift objects
       openshift_raw:

--- a/create_config.yml
+++ b/create_config.yml
@@ -2,10 +2,8 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
 
+    - import_tasks: tasks/set_vars.yml
     - import_tasks: tasks/create_config.yml

--- a/create_object.yml
+++ b/create_object.yml
@@ -13,16 +13,12 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
   vars:
     object_template: ""
 
   tasks:
 
-    - name: Print project details
-      debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
+    - import_tasks: tasks/set_vars.yml
 
     - name: Print OpenShift object template path
       debug: msg="Object template {{ object_template }}"

--- a/create_project.yml
+++ b/create_project.yml
@@ -4,20 +4,16 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
 
-  - name: Print project details
-    debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
+    - import_tasks: tasks/set_vars.yml
 
-  - name: Make sure the project exists in OpenShift and is up-to-date
-    openshift_raw:
-      api_version: v1
-      kind: Project
-      name: "{{ project_name }}"
-      description: "{{ project_description|default(project_display_name)|default(project_name) }}"
-      display_name: "{{ project_display_name|default(project_name) }}"
-      state: present
+    - name: Make sure the project exists in OpenShift and is up-to-date
+      openshift_raw:
+        api_version: v1
+        kind: Project
+        name: "{{ project_name }}"
+        description: "{{ project_description|default(project_display_name)|default(project_name) }}"
+        display_name: "{{ project_display_name|default(project_name) }}"
+        state: present

--- a/create_secrets.yml
+++ b/create_secrets.yml
@@ -2,11 +2,10 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
+
+    - import_tasks: tasks/set_vars.yml
 
     # Find all files named "credentials.vault.yml" for a customer in an
     # environment. This file should be yaml formatted and it must define all

--- a/delete_project.yml
+++ b/delete_project.yml
@@ -1,0 +1,23 @@
+---
+# This playbook deletes an OpenShift project for a particular
+# customer/environment
+
+- hosts: local
+  gather_facts: False
+  vars_files:
+    - "group_vars/customer/{{ customer }}.yml"
+    - "group_vars/env_type/{{ env_type }}.yml"
+
+  tasks:
+
+  - name: Print project details
+    debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
+
+  - name: Delete the project
+    openshift_raw:
+      api_version: v1
+      kind: Project
+      name: "{{ project_name }}"
+      description: "{{ project_description|default(project_display_name)|default(project_name) }}"
+      display_name: "{{ project_display_name|default(project_name) }}"
+      state: absent

--- a/delete_project.yml
+++ b/delete_project.yml
@@ -4,20 +4,16 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
 
-  - name: Print project details
-    debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
+    - import_tasks: tasks/set_vars.yml
 
-  - name: Delete the project
-    openshift_raw:
-      api_version: v1
-      kind: Project
-      name: "{{ project_name }}"
-      description: "{{ project_description|default(project_display_name)|default(project_name) }}"
-      display_name: "{{ project_display_name|default(project_name) }}"
-      state: absent
+    - name: Delete the project
+      openshift_raw:
+        api_version: v1
+        kind: Project
+        name: "{{ project_name }}"
+        description: "{{ project_description|default(project_display_name)|default(project_name) }}"
+        display_name: "{{ project_display_name|default(project_name) }}"
+        state: absent

--- a/deploy.yml
+++ b/deploy.yml
@@ -4,11 +4,10 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
+
+    - import_tasks: tasks/set_vars.yml
 
     # Set the deployment stamp value for this deployment
     - name: Set deployment stamp

--- a/init_project.yml
+++ b/init_project.yml
@@ -1,15 +1,15 @@
 ---
+
 - import_playbook: create_project.yml
 - import_playbook: create_secrets.yml
 - import_playbook: create_acme.yml
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/customer/{{ customer }}.yml"
-    - "group_vars/env_type/{{ env_type }}.yml"
 
   tasks:
+
+    - import_tasks: tasks/set_vars.yml
 
     - name: Print project details
       debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"

--- a/load_fixtures.yml
+++ b/load_fixtures.yml
@@ -5,21 +5,18 @@
 
 - hosts: local
   gather_facts: False
-  vars_files:
-    - "group_vars/all/fixtures.yml"
   vars:
     load_fixtures_template: "templates/openshift/edxapp/job/load_fixtures.yml.j2"
 
   tasks:
 
-  - name: Print project details
-    debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"
+    - import_tasks: tasks/set_vars.yml
 
-  - name: Print Object template
-    debug: msg="Object template {{ load_fixtures_template }}"
+    - name: Print Object template
+      debug: msg="Object template {{ load_fixtures_template }}"
 
-  - name: Import demo course and create demo users
-    openshift_raw:
-      definition: "{{ lookup('template', load_fixtures_template) | from_yaml }}"
-      state: present
-      force: true
+    - name: Import demo course and create demo users
+      openshift_raw:
+        definition: "{{ lookup('template', load_fixtures_template) | from_yaml }}"
+        state: present
+        force: true

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -1,0 +1,14 @@
+---
+# tasks/set_vars.yml
+
+# TODO : set vars for apps here
+
+- name: Include customer env_type vars
+  include_vars:
+    file: "{{ item }}"
+  with_items:
+    - "group_vars/customer/{{ customer }}.yml"
+    - "group_vars/env_type/{{ env_type }}.yml"
+
+- name: Print project details
+  debug: msg="Project name {{ project_name }} - domain {{ domain_name }}"


### PR DESCRIPTION
## Purpose

To prepare issues #40, #44 and #47 we must set the `env_type` and `customer` vars after the `apps` default vars.
The default app vars must be set on `include_vars` but it's after `play vars_files` in [Ansible Variable Precedence](https://docs.ansible.com/ansible/latest/user_guide/playbooks_variables.html#variable-precedence-where-should-i-put-a-variable).

## Proposal

So we load `env_type` and `customers` vars on `include_vars` step, and in the future after the task who set apps vars.
