### PR TITLE
🎨(playbook) Create bootstrap playbook #55

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ in a particular environment with a new helper:
 > default value for this demo is: `arnold`.
 
 ```bash
-$ bin/init
+$ bin/bootstrap
 ```
 
 Tadaaa! Arnold has created a new OpenShift project called `patient0-development`
@@ -104,7 +104,7 @@ You could also try deploying the same services for another customer and/or envir
 overriding the default Ansible variables:
 
 ```bash
-$ bin/init -e "env_type=staging customer=campus"
+$ bin/bootstrap -e "env_type=staging customer=campus"
 ```
 
 If you want to run a new deployment for this project, there is also a helper for

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+# Run ansible-playbook
+_docker_run ansible-playbook bootstrap.yml --ask-vault-pass "$@"

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,0 +1,5 @@
+---
+
+- import_playbook: delete_project.yml
+- import_playbook: init_project.yml
+- import_playbook: deploy.yml

--- a/docs/developer_guide/getting_started.md
+++ b/docs/developer_guide/getting_started.md
@@ -13,7 +13,7 @@ particular environment with a new helper:
 > default value for this demo is: `arnold`.
 
 ```bash
-$ bin/init
+$ bin/bootstrap
 ```
 
 Tadaaa! Arnold has created a new OpenShift project called `patient0-development`
@@ -21,7 +21,7 @@ with a collection of services up and running. You can change the customer /
 environment to deploy by overriding default environment variables:
 
 ```bash
-$ bin/init -e "env_type=staging customer=campus"
+$ bin/bootstrap -e "env_type=staging customer=campus"
 ```
 
 If you want to run a new deployment for this project, there is also a helper for
@@ -53,10 +53,10 @@ $ docker run --rm -it \
     --env-file env.d/production \
     --env K8S_AUTH_API_KEY=$(oc whoami -t) \
     arnold \
-    ansible-playbook init_project.yml -e "env_type=production customer=patient0"
+    ansible-playbook bootstrap.yml -e "env_type=production customer=patient0"
 ```
 
-This command will run the `init_project.yml` Ansible playbook with the
+This command will run the `bootstrap.yml` Ansible playbook with the
 `-e "env_type=production customer=patient0"` argument that defines Ansible vars
 for this run.
 

--- a/docs/developer_guide/playbooks.md
+++ b/docs/developer_guide/playbooks.md
@@ -13,12 +13,57 @@ order they are supposed to be used.
 > `development` respectively. **In all cases, the `-e "customer=foo env_type=bar"` option is not required if you want to work with `patient0` in
 > `development`**.
 
+## `delete_project.yml`
+
+This playbook deletes a project with all OpenShift objects for a customer
+(default: `patient0`) in a particular environment (default: `development`).
+
+### Usage
+
+```bash
+# development
+$ bin/ansible-playbook delete_project.yml -e "customer=patient0 env_type=staging"
+
+# native command for production
+$ docker run --rm -it \
+    --env-file env.d/production \
+    arnold \
+    ansible-playbook delete_project.yml -e "customer=patient0 env_type=staging"
+```
+
+## `bootstrap.yml`
+
+This playbook is a "meta" playbook that creates a new project with all required
+OpenShift objects for a customer (default: `patient0`) in a particular
+environment (default: `development`).
+It executes sequentially the following playbooks:
+
+* `delete_project.yml`
+* `init_project.yml`
+* `deploy.yml`
+
+### Usage
+
+```bash
+# sugar development
+$ bin/bootstrap
+
+# development
+$ bin/ansible-playbook bootstrap.yml -e "customer=patient0 env_type=staging"
+
+# native command for production
+$ docker run --rm -it \
+    --env-file env.d/production \
+    arnold \
+    ansible-playbook bootstrap.yml -e "customer=patient0 env_type=staging"
+```
+
 ## `init_project.yml`
 
 This playbook is a "meta" playbook that creates a new project with all required
 OpenShift objects for a customer (default: `patient0`) in a particular
-environment (default: `development`). It executes sequentially the following
-playbooks:
+environment (default: `development`).
+It executes sequentially the following playbooks:
 
 * `create_project.yml`
 * `create_secrets.yml`
@@ -29,6 +74,9 @@ playbooks:
 ### Usage
 
 ```bash
+# sugar development
+$ bin/init
+
 # development
 $ bin/ansible-playbook init_project.yml -e "customer=patient0 env_type=staging"
 

--- a/docs/installation/install.md
+++ b/docs/installation/install.md
@@ -58,5 +58,5 @@ You can then specify the environment file when running a sugar script by setting
 `env-file` option as in the following example:
 
 ```bash
-$ bin/init --env-file=env.d/production
+$ bin/bootstrap --env-file=env.d/production
 ```


### PR DESCRIPTION
## Purpose

On each new project the Dev or Ops must do : 

1. init
2. deploy

## Proposal

To bootstrap a project with all apps on the current route, we can create a `bootstrap_project.yml` playbook who does these 3 steps. 

bin/ini now bootstrap the project.
bootstrap_project.yml do :
  - delete project
  - init project
  - deploy all apps
Issue #55