### PR TITLE
Allow application filtering to select apps to work on

### DIFF
--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -4,7 +4,28 @@
 - name: Lookup applications and set the apps var
   set_fact: apps="{{ lookup('pipe', 'python plugins/utils/lookup_apps.py') | from_yaml }}"
 
-- name: Display looked up applications
+# If the playbook is invoqued with the apps_filter extra var, we restrict apps
+# to the list passed as an argument, e.g.:
+#
+#     $ ansible-playbook foo.yml -e "apps_filter='richie,edxapp'"
+#
+# This task will build the jmespath query to restrict apps to the selected
+# one(s), e.g.:
+#
+#    [?name=='richie' || name=='edxapp']
+- name: Set app filtering query
+  set_fact:
+    # We use escaped double quotes in the first regex_replace filter to be able
+    # to add single quotes around app name in the query
+    apps_filter_query: "{{ apps_filter.split(',') | map('regex_replace', '(.*)', \"name=='\\1'\") | join(' || ') | regex_replace('(.*)', '[?\\1]') }}"
+  when: apps_filter is defined
+
+- name: Filter apps
+  set_fact:
+    apps: "{{ apps | json_query(apps_filter_query) }}"
+  when: apps_filter_query is defined
+
+- name: Display selected applications
   debug: var=apps
 
 - name: Include customer env_type vars


### PR DESCRIPTION
## Purpose

When working with Arnold, we often want to deploy a single application (or a subset of all available applications). Since Arnold now auto-discovers applications and works with all of those apps, it wasn't possible to easily achieve app selection.

## Proposal

This work implements an application filter given an extra var passed to playbooks, _e.g._:

```bash
$ ansible-playbook foo.yml -e "filter_apps='richie,redirect'"
```
