### PR TITLE
🐛(plugin) add new key support for the merge filter

### DIFF
--- a/plugins/filter/merge.py
+++ b/plugins/filter/merge.py
@@ -7,6 +7,7 @@ from copy import deepcopy
 from ansible.errors import AnsibleFilterError
 
 
+# pylint: disable=invalid-name,too-many-branches
 def merge_with_app(base, new):
     """
         Merge data from the "new" application to the "base" application.
@@ -48,10 +49,20 @@ def merge_with_app(base, new):
             # Use the list(set()) trick to remove duplicated items
             base_service[k] = sorted(list(set(new_service[k] + base_service[k])))
 
+        # Add service missing keys (could be meta, such as host, etc.)
+        for k, v in new_service.iteritems():
+            if base_service.get(k) is None:
+                base_service[k] = v
+
     # Merge volumes (if any)
     if result.get("volumes") and new.get("volumes"):
         # Use the list(set()) trick to remove duplicated items
         result["volumes"] = sorted(list(set(new["volumes"] + result["volumes"])))
+
+    # Add new keys for this app
+    for k, v in new.iteritems():
+        if k not in result:
+            result[k] = v
 
     return result
 

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -247,6 +247,72 @@ class TestMergeWithAppFilter(unittest.TestCase):
 
         self.assertDictDeepEqual(merge_with_app(base, new), expected)
 
+    def test_services_merge_with_new_keys(self):
+        """Test app services merge with new keys (meta)"""
+
+        base = {
+            "name": "foo",
+            "services": [
+                {
+                    "name": "bar",
+                    "configs": ["bar.conf"],
+                    "templates": ["bar/dc.yml", "bar/svc.yml"],
+                },
+                {
+                    "name": "baz",
+                    "configs": ["baz.conf"],
+                    "templates": ["baz/dc.yml", "baz/svc.yml", "baz/ep.yml"],
+                },
+            ],
+            "volumes": ["volumes/foo_bar.yml", "volumes/foo_baz.yml"],
+        }
+
+        # As the "fun" service does not exist in the "base" app services, we
+        # expect that it won't be copied, but simply ignored.
+        new = {
+            "name": "foo",
+            "host": "foo.com",
+            "services": [
+                {
+                    "name": "bar",
+                    "configs": ["bar2.conf"],
+                    "templates": ["bar/dc.yml", "bar/ep.yml"],
+                    "subdomain": "bar",
+                },
+                {
+                    "name": "fun",
+                    "configs": ["fun.conf"],
+                    "templates": ["fun/dc.yml", "fun/svc.yml"],
+                },
+            ],
+            "volumes": ["volumes/foo_fun.yml"],
+        }
+
+        expected = {
+            "name": "foo",
+            "host": "foo.com",
+            "services": [
+                {
+                    "name": "bar",
+                    "configs": ["bar.conf", "bar2.conf"],
+                    "templates": ["bar/dc.yml", "bar/svc.yml", "bar/ep.yml"],
+                    "subdomain": "bar",
+                },
+                {
+                    "name": "baz",
+                    "configs": ["baz.conf"],
+                    "templates": ["baz/dc.yml", "baz/svc.yml", "baz/ep.yml"],
+                },
+            ],
+            "volumes": [
+                "volumes/foo_bar.yml",
+                "volumes/foo_baz.yml",
+                "volumes/foo_fun.yml",
+            ],
+        }
+
+        self.assertDictDeepEqual(merge_with_app(base, new), expected)
+
     def test_services_merge_with_no_config(self):
         """Test app services merge"""
 


### PR DESCRIPTION
## Purpose

Current merge plugin implementation only merges volumes or existing
configs and templates for services. When a new app configuration adds
new keys (meta-data) to qualify an app or a service, this new key was
dropped. 

## Proposal

Also merge new keys for apps and services.
