### PR TITLE
🎨(scripts) improve OpenShift's env setting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,14 +118,12 @@ jobs:
           name: Test oc client installation
           command: |
             docker run --rm \
-              -e OC_LOGIN=false \
               "${ARNOLD_IMAGE}" \
               oc version
       - run:
           name: Test ansible installation
           command: |
             docker run --rm \
-              -e OC_LOGIN=false \
               "${ARNOLD_IMAGE}" \
               ansible --version
 
@@ -173,7 +171,6 @@ jobs:
           name: Run unit tests for local plugins
           command: |
             docker run --rm \
-              -e OC_LOGIN=false \
               --tmpfs /app/.pytest_cache \
               "${ARNOLD_IMAGE}" \
               python -m pytest --no-cov

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -3,5 +3,9 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Set OpenShift's environment (you'll need to be logged in to an OpenShift
+# server)
+_set_openshift_env
+
 # Run ansible-playbook
 _docker_run ansible-playbook "$@"

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -3,5 +3,9 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Set OpenShift's environment (you'll need to be logged in to an OpenShift
+# server)
+_set_openshift_env
+
 # Run ansible-playbook
 _docker_run ansible-playbook bootstrap.yml --ask-vault-pass "$@"

--- a/bin/deploy
+++ b/bin/deploy
@@ -3,5 +3,9 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Set OpenShift's environment (you'll need to be logged in to an OpenShift
+# server)
+_set_openshift_env
+
 # Run ansible-playbook
 _docker_run ansible-playbook deploy.yml "$@"

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -28,8 +28,8 @@ if ! whoami &> /dev/null; then
   fi
 fi
 
-# OpenShift login only if $OC_LOGIN is not false
-if ${OC_LOGIN:-true} ; then
+# Login to OpenShift only if $K8S_AUTH_HOST is defined
+if [[ ! -z ${K8S_AUTH_HOST} ]]; then
   oc_login
 fi
 

--- a/bin/init
+++ b/bin/init
@@ -3,5 +3,9 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Set OpenShift's environment (you'll need to be logged in to an OpenShift
+# server)
+_set_openshift_env
+
 # Run ansible-playbook
 _docker_run ansible-playbook init_project.yml --ask-vault-pass "$@"

--- a/bin/lint
+++ b/bin/lint
@@ -11,7 +11,6 @@ _docker_run() {
     local docker_volume_opts=""
   fi
   docker run --rm -it \
-    -e OC_LOGIN=false \
     ${docker_volume_opts} \
     "${ARNOLD_IMAGE}" \
     "$@"

--- a/bin/pytest
+++ b/bin/pytest
@@ -3,8 +3,6 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-export OC_LOGIN=false
-
 # Run pytest
 #
 # nota bene: we run `python -m pytest` instead of the `pytest` command to add

--- a/bin/switch
+++ b/bin/switch
@@ -3,5 +3,9 @@
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
+# Set OpenShift's environment (you'll need to be logged in to an OpenShift
+# server)
+_set_openshift_env
+
 # Run ansible-playbook
 _docker_run ansible-playbook switch.yml "$@"


### PR DESCRIPTION
## Purpose

The `OC_LOGIN` flag to inactivate OpenShift's login via the `oc` client is too complex/ugly.

## Proposal

Define an `_set_openshift_env` routine and use it whenever we require to login to our OpenShift server.