### PR TITLE
🔥(vars) remove legacy template paths

### DIFF
--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -108,48 +108,4 @@ richie_database:
   host: "{{ postgresql.host }}"
   port: "{{ postgresql.port }}"
   name: richie
-
-# Openshift template files
-openshift_deployments:
-  - edxapp/templates/dc/cms.yml
-  - edxapp/templates/dc/lms.yml
-  - edxapp/templates/dc/memcached.yml
-  - edxapp/templates/dc/nginx.yml
-  - redirect/templates/dc/nginx.yml
-  - richie/templates/dc/elasticsearch.yml
-  - richie/templates/dc/nginx.yml
-  - richie/templates/dc/richie.yml
-openshift_endpoints:
-  - _common/templates/ep/mongodb.yml
-  - _common/templates/ep/mysql.yml
-  - _common/templates/ep/postgresql.yml
-openshift_jobs:
-  - edxapp/templates/job/collectstatic_cms.yml
-  - edxapp/templates/job/collectstatic_lms.yml
-  - edxapp/templates/job/db_migrate.yml
-  - richie/templates/job/collectstatic.yml
-  - richie/templates/job/db_migrate.yml
-  - richie/templates/job/regenerate_indexes.yml
-openshift_routes:
-  - edxapp/templates/route/cms.yml
-  - edxapp/templates/route/lms.yml
-  - richie/templates/route/richie.yml
-openshift_services:
-  - _common/templates/svc/mongodb.yml
-  - _common/templates/svc/mysql.yml
-  - _common/templates/svc/postgresql.yml
-  - edxapp/templates/svc/cms.yml
-  - edxapp/templates/svc/lms.yml
-  - edxapp/templates/svc/memcached.yml
-  - edxapp/templates/svc/nginx.yml
-  - redirect/templates/svc/nginx.yml
-  - richie/templates/svc/elasticsearch.yml
-  - richie/templates/svc/nginx.yml
-  - richie/templates/svc/richie.yml
-openshift_volumes:
-  - edxapp/templates/pvc/data.yml
-  - edxapp/templates/pvc/media.yml
-  - edxapp/templates/pvc/static.yml
-  - richie/templates/pvc/media.yml
-  - richie/templates/pvc/static.yml
 ## _END_ to be deprecated ##

--- a/group_vars/all/openshift_routes.yml
+++ b/group_vars/all/openshift_routes.yml
@@ -1,14 +1,6 @@
 ---
 # URL
 domain_name: dev.openfun.fr
-lms_host: "{{ project_name }}-lms.{{ domain_name }}"
-cms_host: "{{ project_name }}-cms.{{ domain_name }}"
-richie_host: "{{ project_name }}-richie.{{ domain_name }}"
-
-openshift_routes:
-  - edxapp/route/cms.yml
-  - edxapp/route/lms.yml
-  - richie/route/richie.yml
 
 # OpenShift routes_aliases exemple
 # openshift_routes_aliases:       # routes to be redirected

--- a/group_vars/customer/hello/main.yml
+++ b/group_vars/customer/hello/main.yml
@@ -17,23 +17,3 @@ hello_msg:  "Hello OpenShift! by Arnold"
 
 nginx_ports:
   - "{{ aliases_port }}"
-
-# Openshift template files
-openshift_deployments:
-  - openshift/hello/dc/hello.yml
-  - openshift/richie/dc/elasticsearch.yml
-  - openshift/richie/dc/nginx.yml
-  - openshift/richie/dc/richie.yml
-openshift_endpoints:
-openshift_jobs:
-openshift_routes:
-  - openshift/hello/route/hello.yml
-  - openshift/richie/route/richie.yml
-openshift_services:
-  - openshift/hello/svc/hello.yml
-  - openshift/richie/svc/elasticsearch.yml
-  - openshift/richie/svc/nginx.yml
-  - openshift/richie/svc/richie.yml
-openshift_volumes:
-  - openshift/richie/pvc/media.yml
-  - openshift/richie/pvc/static.yml

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -5,21 +5,3 @@ django_configuration: Development
 # Use development images in the development environment
 edxapp_tag: "ginkgo.1-1.0.3-dev"
 richie_tag: "0.1.0-alpha.3-alpine-dev"
-
-# Override Openshift template files because databases are containers
-# instead of external services reachable via endpoints
-openshift_deployments:
-  - _common/templates/dc/mongodb.yml
-  - _common/templates/dc/mysql.yml
-  - _common/templates/dc/postgresql.yml
-  - edxapp/templates/dc/cms.yml
-  - edxapp/templates/dc/lms.yml
-  - edxapp/templates/dc/memcached.yml
-  - edxapp/templates/dc/nginx.yml
-  - richie/templates/dc/elasticsearch.yml
-  - richie/templates/dc/nginx.yml
-  - richie/templates/dc/richie.yml
-  - redirect/templates/dc/nginx.yml
-
-openshift_endpoints:
-    # No endpoints required for the development environment

--- a/group_vars/env_type/feature.yml
+++ b/group_vars/env_type/feature.yml
@@ -3,17 +3,3 @@
 # Only in feature environment do we add the feature title to the hosts
 lms_host: "{{ project_name }}-lms--{{ feature_title }}.{{ domain_name }}"
 cms_host: "{{ project_name }}-cms--{{ feature_title }}.{{ domain_name }}"
-
-# Override Openshift template files because databases are containers
-# instead of external services reachable via endpoints
-openshift_deployments:
-  - _common/templates/dc/nginx.yml
-  - _common/templates/dc/mongodb.yml
-  - _common/templates/dc/mysql.yml
-  - _common/templates/dc/postgresql.yml
-  - edxapp/templates/dc/cms.yml
-  - edxapp/templates/dc/lms.yml
-  - edxapp/templates/dc/memcached.yml
-  - richie/templates/dc/richie.yml
-openshift_endpoints:
-    # No endpoints required for the feature environments


### PR DESCRIPTION
## Purpose

Now that we auto-discover applications and their templates, we do not need to list openshift templates as overridable vars.

## Proposal

Remove all the things.

## Remark

This is the first cleanup PR about applications variables. I'll propose a series or PRs (one per application).