### PR TITLE
Add celery workers to LMS and CMS for edxapp

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,9 +227,9 @@ jobs:
       - *run_openshift_cluster
 
       - run:
-          name: Test the "edxapp" application bootstrapping
+          name: Test the "edxapp" application bootstrapping (with redis enabled)
           command: |
-            bin/ci-bootstrap "edxapp"
+            bin/ci-bootstrap "edxapp,redis"
             bin/ci-test-service "cms" "Welcome to Open edX Studio"
 
   # FIXME: we have deactivated plugins test coverage as the container user is

--- a/apps/edxapp/templates/cms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/cms/_configs/settings.yml.j2
@@ -8,11 +8,10 @@ LMS_BASE: "{{ edxapp_lms_host }}"
 CMS_BASE: "{{ edxapp_cms_host }}"
 
 # Celery Broker
-# FIXME: we should use the redis_app_* default vars
 CELERY_BROKER_TRANSPORT: redis
-CELERY_BROKER_HOST: redis
+CELERY_BROKER_HOST: "{{ redis_app_host }}"
 CELERY_BROKER_VHOST: 0
-CELERY_BROKER_PORT: 6379
+CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # FIXME: for now, we haven't set a user/password to connect to redis. Once those
 # are set, you'll need to move the two following settings in edxapp secret
 CELERY_BROKER_USER: ""

--- a/apps/edxapp/templates/cms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/cms/_configs/settings.yml.j2
@@ -16,3 +16,8 @@ CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # are set, you'll need to move the two following settings in edxapp secret
 CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
+
+# Celery queues
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}"

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -1,0 +1,117 @@
+{#
+
+  LMS/CMS DCs base template used to create cms & lms wsgi servers + celery workers
+
+ #}
+
+{# The dc_name should be unique #}
+{%- set dc_name = "edxapp-%s-%s-%s" | format(service_variant, worker_type, deployment_stamp) -%}
+
+{# In case of a worker, we need to add the queue name to make the dc_name unique #}
+{%- if queue -%}
+  {% set dc_name = "%s-%s" | format(dc_name, (queue | regex_replace('\\.|_', '-'))) %}
+{%- endif -%}
+
+{#
+  The "command" macro is used to override target container's command, in edxapp
+  case, we override this command to run celery workers instead of the CMS/LMS
+  wsgi server.
+#}
+{%- macro command(service_variant, queue, concurrency=1) -%}
+  {%- if service_variant and queue %}
+        command:
+          - "/bin/bash"
+          - "-c"
+          - python manage.py {{ service_variant }} celery worker --loglevel=info --queues={{ queue }} --hostname={{ queue }}.%%h --concurrency={{ concurrency }}
+  {%- endif %}
+{%- endmacro -%}
+
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: edxapp
+    service: {{ service_variant }}
+    version: "{{ edxapp_image_tag }}"
+    worker_type: "{{ worker_type }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "{{ dc_name }}"
+  namespace: "{{ project_name }}"
+spec:
+  replicas: 1  # number of pods we want
+  template:
+    metadata:
+      labels:
+        app: edxapp
+        service: {{ service_variant }}
+        version: "{{ edxapp_image_tag }}"
+        worker_type: "{{ worker_type }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+        deploymentconfig: "{{ dc_name }}"
+    spec:
+      containers:
+      - name: {{ service_variant }}
+{{ command(service_variant, queue) }}
+        env:
+        - name: SERVICE_VARIANT
+          value: {{ service_variant }}
+        - name: DJANGO_SETTINGS_MODULE
+          value: {{ service_variant }}.envs.fun.docker_run
+        image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+        imagePullPolicy: IfNotPresent
+        volumeMounts:
+        - mountPath: /config
+          name: edxapp-config
+        - mountPath: /edx/var/edxapp/media
+          name: edxapp-v-media
+        - mountPath: /edx/app/edxapp/staticfiles
+          name: edxapp-v-static
+        - mountPath: /edx/app/edxapp/data
+          name: edxapp-v-data
+      initContainers:
+        # This initContainer has nothing mounted on its "/config" directory. We
+        # copy the content of its "/config" directory (fun-platform default
+        # settings) to the "/tmp/config" directory (edxapp-config volume). Then,
+        # we copy service variant configMaps that may override default
+        # configuration (docker_run*.py and settings.yml) in that same
+        # "/tmp/config" directory. And finally, we also copy sensible
+        # credentials from edxapp secret (credentials.vault.yml). When this
+        # initContainer shuts down, the "edxapp-config" volume has been filled
+        # with all project settings that will be used to run the service variant
+        # container. Please refer to the documentation to better understand our
+        # settings generation mecanism.
+        - name: init-create-config
+          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          imagePullPolicy: IfNotPresent
+          command:
+            - "/bin/bash"
+            - "-c"
+            - cp -r /config/* /tmp/config &&
+              cp -rL /tmp/configmap-{{ service_variant }}/* /tmp/config/{{ service_variant }}/ &&
+              cp /tmp/secret/credentials.vault.yml /tmp/config/{{ service_variant }}/secrets.yml
+          volumeMounts:
+            - mountPath: /tmp/config
+              name: edxapp-config
+            - mountPath: /tmp/configmap-{{ service_variant }}
+              name: edxapp-configmap-{{ service_variant }}
+            - mountPath: /tmp/secret
+              name: edxapp-secret
+      volumes:
+        - name: edxapp-configmap-{{ service_variant }}
+          configMap:
+            defaultMode: 420
+            name: edxapp-{{ service_variant }}-{{ deployment_stamp }}
+        - name: edxapp-config
+          emptyDir: {}  # volume that lives as long as the pod lives
+        - name: edxapp-secret
+          secret:
+            secretName: edxapp-{{ secret_id }}
+        - name: edxapp-v-media
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-media
+        - name: edxapp-v-static
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-static
+        - name: edxapp-v-data
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-data

--- a/apps/edxapp/templates/cms/dc.yml.j2
+++ b/apps/edxapp/templates/cms/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1  # number of pods we want
-  selector:
-    app: edxapp
-    deploymentconfig: edxapp-cms-{{ deployment_stamp }}
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/cms/dc_queue_default_priority.yml.j2
+++ b/apps/edxapp/templates/cms/dc_queue_default_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "cms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_cms_default_priority_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/cms/dc_queue_high_priority.yml.j2
+++ b/apps/edxapp/templates/cms/dc_queue_high_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "cms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_cms_high_priority_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/cms/dc_queue_low_priority.yml.j2
+++ b/apps/edxapp/templates/cms/dc_queue_low_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "cms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_cms_low_priority_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/cms/svc.yml.j2
+++ b/apps/edxapp/templates/cms/svc.yml.j2
@@ -16,5 +16,5 @@ spec:
     targetPort: {{ edxapp_django_port }}
   selector:
     app: edxapp
-    deploymentconfig: "edxapp-cms-{{ deployment_stamp }}"
+    deploymentconfig: "edxapp-cms-wsgi-{{ deployment_stamp }}"
   type: ClusterIP

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -16,3 +16,9 @@ CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # are set, you'll need to move the two following settings in edxapp secret
 CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
+
+# Celery queues
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}"
+HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}"

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -8,11 +8,10 @@ LMS_BASE: "{{ edxapp_lms_host }}"
 CMS_BASE: "{{ edxapp_cms_host }}"
 
 # Celery Broker
-# FIXME: we should use the redis_app_* default vars
 CELERY_BROKER_TRANSPORT: redis
-CELERY_BROKER_HOST: redis
+CELERY_BROKER_HOST: "{{ redis_app_host }}"
 CELERY_BROKER_VHOST: 0
-CELERY_BROKER_PORT: 6379
+CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # FIXME: for now, we haven't set a user/password to connect to redis. Once those
 # are set, you'll need to move the two following settings in edxapp secret
 CELERY_BROKER_USER: ""

--- a/apps/edxapp/templates/lms/dc.yml.j2
+++ b/apps/edxapp/templates/lms/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1  # number of pods we want
-  selector:
-    app: edxapp
-    deploymentconfig: edxapp-lms-{{ deployment_stamp }}
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/lms/dc_queue_default_priority.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_default_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_lms_default_priority_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_high_mem.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_high_mem.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_lms_high_mem_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_high_priority.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_high_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_lms_high_priority_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_low_priority.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_low_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
-{% set worker_type = "wsgi" %}
-{% set queue = "" %}
+{% set worker_type = "queue" %}
+{% set queue = edxapp_celery_lms_low_priority_queue %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/svc.yml.j2
+++ b/apps/edxapp/templates/lms/svc.yml.j2
@@ -16,5 +16,5 @@ spec:
     targetPort: {{ edxapp_django_port }}
   selector:
     app: edxapp
-    deploymentconfig: "edxapp-lms-{{ deployment_stamp }}"
+    deploymentconfig: "edxapp-lms-wsgi-{{ deployment_stamp }}"
   type: ClusterIP

--- a/apps/edxapp/templates/memcached/dc.yml.j2
+++ b/apps/edxapp/templates/memcached/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1  # number of pods we want
-  selector:
-    app: edxapp
-    deploymentconfig: edxapp-memcached-{{ deployment_stamp }}
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/mongodb/dc.yml.j2
+++ b/apps/edxapp/templates/mongodb/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    app: edxapp
-    deploymentconfig: "edxapp-mongodb-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/mysql/dc.yml.j2
+++ b/apps/edxapp/templates/mysql/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    app: edxapp
-    deploymentconfig: "edxapp-mysql-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/nginx/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    app: edxapp
-    deploymentconfig: "edxapp-nginx-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -6,7 +6,7 @@ edxapp_lms_host: "lms.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "ginkgo.1-1.0.4"
+edxapp_image_tag: "ginkgo.1-1.0.6"
 edxapp_django_port: 8000
 edxapp_sql_dump_url: "https://gist.github.com/jmaupetit/1f9d270d7d2106774fd94ba89a51ab78/raw/b0004f2825623d03de58710bf936db175e96bc90/edx-database-ginko.sql"
 
@@ -34,3 +34,13 @@ edxapp_nginx_image_name: "fundocker/openshift-nginx"
 edxapp_nginx_image_tag: "1.13"
 edxapp_nginx_cms_port: 8081
 edxapp_nginx_lms_port: 8071
+
+# -- celery/redis
+edxapp_celery_lms_high_priority_queue: "edx.lms.core.high"
+edxapp_celery_lms_default_priority_queue: "edx.lms.core.default"
+edxapp_celery_lms_low_priority_queue: "edx.lms.core.low"
+edxapp_celery_lms_high_mem_queue: "edx.lms.core.high_mem"
+
+edxapp_celery_cms_high_priority_queue: "edx.cms.core.high"
+edxapp_celery_cms_default_priority_queue: "edx.cms.core.default"
+edxapp_celery_cms_low_priority_queue: "edx.cms.core.low"

--- a/apps/hello/templates/hello/dc.yml.j2
+++ b/apps/hello/templates/hello/dc.yml.j2
@@ -8,8 +8,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1  # number of pods we want
-  selector:
-    deploymentconfig: "hello-hello-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/redirect/templates/nginx/dc.yml.j2
+++ b/apps/redirect/templates/nginx/dc.yml.j2
@@ -8,8 +8,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    deploymentconfig: redirect-nginx-{{ deployment_stamp }}
   template:
     metadata:
       labels:

--- a/apps/redis/templates/_volumes/data.yml.j2
+++ b/apps/redis/templates/_volumes/data.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: redis-pvc-data
+  namespace: "{{ project_name }}"
+  labels:
+    app: redis
+    version: "{{ redis_app_image_tag }}"
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: 2Gi

--- a/apps/redis/templates/app/dc.yml.j2
+++ b/apps/redis/templates/app/dc.yml.j2
@@ -15,8 +15,6 @@ spec:
   # is switched off before the new one starts.
   strategy:
     type: Recreate
-  selector:
-    app: redis
   template:
     metadata:
       labels:

--- a/apps/redis/templates/app/dc.yml.j2
+++ b/apps/redis/templates/app/dc.yml.j2
@@ -1,0 +1,38 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: redis
+    service: app
+    version: "{{ redis_app_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: redis-app
+  namespace: "{{ project_name }}"
+spec:
+  replicas: 1  # number of pods we want
+  # When upgrading, we don't want OpenShift to run several pods mounted on the same volume
+  # because Redis does not support that. Instead we need to make sure that the existing pod
+  # is switched off before the new one starts.
+  strategy:
+    type: Recreate
+  selector:
+    app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+        service: app
+        version: "{{ redis_app_image_tag }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+        deploymentconfig: redis-app
+    spec:
+      containers:
+        - name: redis
+          image: "{{ redis_app_image_name }}:{{ redis_app_image_tag }}"
+          volumeMounts:
+            - mountPath: /data
+              name: redis-v-data
+      volumes:
+        - name: redis-v-data
+          persistentVolumeClaim:
+            claimName: redis-pvc-data

--- a/apps/redis/templates/app/svc.yml.j2
+++ b/apps/redis/templates/app/svc.yml.j2
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: redis
+    service: app
+    version: "{{ redis_app_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  # name of the service should be host name in edxapp configuration
+  name: "{{ redis_app_host }}"
+  namespace: "{{ project_name }}"
+spec:
+  ports:
+  - name: "{{ redis_app_port }}-tcp"
+    port: {{ redis_app_port }}
+    protocol: TCP
+    targetPort: {{ redis_app_port }}
+  selector:
+    app: redis
+    deploymentconfig: "redis-app"
+  type: ClusterIP

--- a/apps/redis/vars/all/main.yml
+++ b/apps/redis/vars/all/main.yml
@@ -1,0 +1,6 @@
+# Application default configuration
+
+redis_app_image_name: redis
+redis_app_image_tag: 4
+redis_app_host: redis
+redis_app_port: 6379

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1  # number of pods we want
-  selector:
-    app: richie
-    deploymentconfig: "richie-app-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/richie/templates/elasticsearch/dc.yml.j2
+++ b/apps/richie/templates/elasticsearch/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    app: richie
-    deploymentconfig: "richie-elasticsearch-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/richie/templates/nginx/dc.yml.j2
+++ b/apps/richie/templates/nginx/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    app: richie
-    deploymentconfig: "richie-nginx-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/apps/richie/templates/postgresql/dc.yml.j2
+++ b/apps/richie/templates/postgresql/dc.yml.j2
@@ -10,9 +10,6 @@ metadata:
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
-  selector:
-    app: richie
-    deploymentconfig: "richie-postgresql-{{ deployment_stamp }}"
   template:
     metadata:
       labels:

--- a/create_object.yml
+++ b/create_object.yml
@@ -36,6 +36,11 @@
     - name: Print job stamp
       debug: msg="Job stamp {{ job_stamp }}"
 
+    - name: Print compiled template
+      debug:
+        msg: "{{ lookup('template', object_template) }}"
+        verbosity: 2
+
     - name: Create object
       openshift_raw:
         definition: "{{ lookup('template', object_template) | from_yaml }}"

--- a/group_vars/env_type/ci.yml
+++ b/group_vars/env_type/ci.yml
@@ -18,8 +18,6 @@ apps:
         host: "cms.{{ project_name}}.{{ domain_name }}"
         port: 8081
   - name: redis
-    services:
-      - name: app
 
 ## _____ soon deprecated below _________________________________________________
 hello_host: "{{ project_name }}.{{ domain_name }}"

--- a/group_vars/env_type/ci.yml
+++ b/group_vars/env_type/ci.yml
@@ -17,6 +17,9 @@ apps:
       - name: nginx
         host: "cms.{{ project_name}}.{{ domain_name }}"
         port: 8081
+  - name: redis
+    services:
+      - name: app
 
 ## _____ soon deprecated below _________________________________________________
 hello_host: "{{ project_name }}.{{ domain_name }}"

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -27,3 +27,6 @@ apps:
         host: "{{ edxapp_cms_host }}"
         port: "{{ edxapp_nginx_cms_port }}"
         # TODO: add edxapp LMS host here
+  - name: redis
+    services:
+      - name: app

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -28,5 +28,3 @@ apps:
         port: "{{ edxapp_nginx_cms_port }}"
         # TODO: add edxapp LMS host here
   - name: redis
-    services:
-      - name: app

--- a/plugins/filter/merge.py
+++ b/plugins/filter/merge.py
@@ -34,6 +34,9 @@ def merge_with_app(base, new):
 
     result = deepcopy(base)
 
+    if "services" not in new:
+        return result
+
     # Add or override services metadata
     for base_service in result["services"]:
         new_app_selected_services = [

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -14,10 +14,10 @@
 
 - name: Set OpenShift objects to manage
   set_fact:
-    deployments: "{{ templates | map('regex_search', '.*/dc.yml.j2$') | select('string') | list }}"
-    services: "{{ templates | map('regex_search', '.*/svc.yml.j2$') | select('string') | list }}"
-    jobs: "{{ templates | map('regex_search', '.*/job_.*.yml.j2$') | select('string') | list }}"
-    routes: "{{ templates | map('regex_search', '.*/route.yml.j2$') | select('string') | list }}"
+    deployments: "{{ templates | map('regex_search', '.*/dc.*\\.yml\\.j2$') | select('string') | list }}"
+    services: "{{ templates | map('regex_search', '.*/svc\\.yml\\.j2$') | select('string') | list }}"
+    jobs: "{{ templates | map('regex_search', '.*/job_.*\\.yml\\.j2$') | select('string') | list }}"
+    routes: "{{ templates | map('regex_search', '.*/route\\.yml\\.j2$') | select('string') | list }}"
   tags:
     - deploy
     - deployment
@@ -97,7 +97,7 @@
     ) == (
       deployments | flatten | length
     )
-  retries: 60
+  retries: 120
   delay: 5
 
 - name: Prepare jobs ordering

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -133,6 +133,21 @@ class TestMergeWithAppFilter(unittest.TestCase):
             merge_with_app({"name": ""}, {"name": ""})
         self.assertEqual(cm.exception.message, "input apps name cannot be empty")
 
+    def test_submitted_apps_with_no_services_key(self):
+        """Submitted apps may have no defined services key"""
+
+        base = {
+            "name": "foo",
+            "services": [
+                {"name": "bar", "templates": ["bar/dc.yml", "bar/svc.yml"]},
+                {"name": "baz", "templates": ["baz/dc.yml", "baz/ep.yml"]},
+            ],
+        }
+
+        new = {"name": "foo"}
+
+        self.assertDictDeepEqual(merge_with_app(base, new), base)
+
     def test_services_merge_with_empty_new_services(self):
         """
             Test app services merge with no services or volumes for the new


### PR DESCRIPTION
## Purpose

We need to run Celery workers to handle asynchronous tasks.

## Proposal

- [x] add Redis as a separate app (to avoid redeploying it each time we redeploy edxapp) and without blue/green (because Redis does not support several instances on the same volume...) 
- [x] add Celery workers to edxapp (one for each queue in both LMS and CMS)
- [x] remove the "selector" item in dc templates as it seems useless and is generating errors with multiple deployments per service.
- [x] add vars for celery queues and use them in DCs + settings