### PR TITLE
Restore configmaps overriding mecanism

### DIFF
--- a/group_vars/customer/patient0/development/configs/edxapp/cms/docker_run.py.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/cms/docker_run.py.j2
@@ -1,0 +1,1 @@
+from .docker_run_{{ env_type }} import *

--- a/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
@@ -1,0 +1,23 @@
+# Settings for edxapp cms
+
+PLATFORM_NAME: "{{ project_display_name }}"
+
+SITE_NAME: "{{ project_display_name }}"
+
+LMS_BASE: "{{ edxapp_lms_host }}"
+CMS_BASE: "{{ edxapp_cms_host }}"
+
+# Celery Broker
+CELERY_BROKER_TRANSPORT: redis
+CELERY_BROKER_HOST: "{{ redis_app_host }}"
+CELERY_BROKER_VHOST: 0
+CELERY_BROKER_PORT: "{{ redis_app_port }}"
+# FIXME: for now, we haven't set a user/password to connect to redis. Once those
+# are set, you'll need to move the two following settings in edxapp secret
+CELERY_BROKER_USER: ""
+CELERY_BROKER_PASSWORD: ""
+
+# Celery queues
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}"

--- a/group_vars/customer/patient0/development/configs/edxapp/lms/docker_run.py.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/lms/docker_run.py.j2
@@ -1,0 +1,1 @@
+from .docker_run_{{ env_type }} import *

--- a/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
@@ -1,0 +1,24 @@
+# Settings for edxapp lms
+
+PLATFORM_NAME: "{{ project_display_name }}"
+
+SITE_NAME: "{{ project_display_name }}"
+
+LMS_BASE: "{{ edxapp_lms_host }}"
+CMS_BASE: "{{ edxapp_cms_host }}"
+
+# Celery Broker
+CELERY_BROKER_TRANSPORT: redis
+CELERY_BROKER_HOST: "{{ redis_app_host }}"
+CELERY_BROKER_VHOST: 0
+CELERY_BROKER_PORT: "{{ redis_app_port }}"
+# FIXME: for now, we haven't set a user/password to connect to redis. Once those
+# are set, you'll need to move the two following settings in edxapp secret
+CELERY_BROKER_USER: ""
+CELERY_BROKER_PASSWORD: ""
+
+# Celery queues
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}"
+HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}"

--- a/group_vars/customer/patient0/development/main.yml
+++ b/group_vars/customer/patient0/development/main.yml
@@ -1,0 +1,20 @@
+# Variables specific to the patient0 customer in development env_type
+
+apps:
+  - name: richie
+  - name: edxapp
+    services:
+      - name: cms
+        # We override default ConfigMaps for this customer/env_type
+        #
+        # Nota bene: file paths are not enforced, but the override mecanism
+        # implies that the file names are identical, e.g. docker_run.py.j2
+        configs:
+          - group_vars/customer/patient0/development/configs/edxapp/cms/docker_run.py.j2
+          - group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
+      - name: lms
+        configs:
+          - group_vars/customer/patient0/development/configs/edxapp/lms/docker_run.py.j2
+          - group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
+  - name: redis
+  - name: hello

--- a/tasks/create_app_config.yml
+++ b/tasks/create_app_config.yml
@@ -1,34 +1,19 @@
 ---
 # Create ConfigMaps for an app
 
-# Make a raw list of configmap templates for an app
-- name: Select configMap templates
+# Select services with ConfigMaps
+- name: Set ConfigMaps for application {{ app.name }}
   set_fact:
-    service: "{{ item | regex_replace('apps/(.*)/templates/(.*)/_configs/(.*).j2', '\\2') }}"
-    filename: "{{ item | basename | regex_replace('.j2') }}"
-    content: "{{ lookup('template', item) }}"
-  register: raw_configmaps
-  with_items: "{{ app | json_query('services[*].configs[]') }}"
+    app_configmaps: "{{ app | json_query('services[?configs].{name: name, configs: configs}') }}"
 
-# ConfigMap data are first grouped by service:
+# Create the configmaps dictionnary:
 #
-# [
-#     "nginx", // the service name
-#     [        // a list of configmaps for this service
-#         {
-#             "content": "...",
-#             "filename": "cms.conf",
-#             "service": "nginx"
-#         },
-#         {
-#             "content": "...",
-#             "filename": "lms.conf",
-#             "service": "nginx"
-#         }
-#     ]
-# ]
+# - each key of this dictionnary is a service name
+# - the corresponding value is the ConfigMap for this service (a dictionnary):
+#     - each key of this dictionnary is a file name
+#     - the corresponding value is the file content (rendered template)
 #
-# And then updated as a dictionnary of files per services:
+# An example follows:
 #
 # {
 #   "nginx": {
@@ -39,13 +24,15 @@
 - name: Format configMaps
   set_fact:
     configmaps: |
-      {% set configmaps = {} %}
-      {% for service in raw_configmaps.results | map(attribute='ansible_facts') | groupby('service') %}
-      {% set _ = configmaps.update({service.0: {}}) %}
-      {% for cm in service.1 %}
-      {% set _ = configmaps.get(service.0).update({cm.filename: cm.content}) %}
-      {% endfor %}
-      {% endfor %}
+      {%- set configmaps = {} -%}
+      {%- for service in app_configmaps -%}
+        {%- set _ = configmaps.update({service.name: {}}) -%}
+        {%- for cm_path in service.configs -%}
+          {%- set content = lookup('template', cm_path) -%}
+          {%- set filename = cm_path | basename | regex_replace('.j2') -%}
+          {%- set _ = configmaps.get(service.name).update({filename: content}) -%}
+        {%- endfor -%}
+      {%- endfor -%}
       {{ configmaps }}
 
 - name: Display config maps

--- a/tasks/load_app_defaults.yml
+++ b/tasks/load_app_defaults.yml
@@ -1,0 +1,18 @@
+# Load application default variables if not already defined
+
+- name: Load default variables from {{ file }}
+  include_vars:
+    file: "{{ file }}"
+    name: defaults
+
+- name: Print loaded variables from {{ file }}
+  debug:
+    msg: "{{ defaults | to_nice_yaml }}"
+    verbosity: 3
+
+- name: Define missing variables with defaults
+  set_fact:
+    "{{ app_var.key }}": "{{ lookup('vars', app_var.key, default=app_var.value) }}"
+  loop: "{{ lookup('dict', defaults) }}"
+  loop_control:
+    loop_var: "app_var"

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -125,7 +125,8 @@
     verbosity: 1
 
 - name: Include "all" type vars for applications
-  include_vars:
+  include_tasks: tasks/load_app_defaults.yml
+  vars:
     file: "{{ item.path }}"
   with_items: "{{ apps | json_query(\"[*].vars[?type=='all']\") | flatten }}"
 

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -8,6 +8,12 @@
     - "group_vars/customer/{{ customer }}/main.yml"
     - "group_vars/env_type/{{ env_type }}.yml"
 
+- name: Override specific vars given a customer and its env_type
+  include_vars:
+    file: "{{ item }}"
+  with_fileglob:
+    - "group_vars/customer/{{ customer }}/{{ env_type }}/*.yml"
+
 # The following tasks goal is to define the `apps` var that describes
 # applications to work on.
 #
@@ -122,12 +128,6 @@
   include_vars:
     file: "{{ item.path }}"
   with_items: "{{ apps | json_query(\"[*].vars[?type=='all']\") | flatten }}"
-
-- name: Override specific vars given a customer and its env_type
-  include_vars:
-    file: "{{ item }}"
-  with_fileglob:
-    - "group_vars/customer/{{ customer }}/{{ env_type }}/*.yml"
 
 - name: Print project details
   debug:


### PR DESCRIPTION
## Purpose

We need to be able to override ConfigMaps for a particular customer in a more particular environment.

## Proposal

- [x] fix ConfigMap generation to be file-path-agnostic
- [x] add a POC for ConfigMaps override for `patient0-development`
- [x] restore application defaults overriding mecanism #100 

Fix #100 