### PR TITLE
🐛(edxapp) fix edxapp image used in development

### DIFF
--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -2,7 +2,7 @@
 domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 
 # Use development images in the development environment
-edxapp_image_tag: "ginkgo.1-1.0.3-dev"
+edxapp_image_tag: "ginkgo.1-1.0.6-dev"
 richie_image_tag: "0.1.0-alpha.3-alpine-dev"
 
 apps:


### PR DESCRIPTION
## Purpose

Celery workers have permission issues in development.

## Proposal

`ginkgo.1-1.0.3-dev` docker image has permission issues to run Celery workers. This issue has been fixed since, so we must upgrade to the latest release to make Celery workers fully functional in `development` env_type.