### PR TITLE
WIP: Add a custom theme to edxapp LMS

### DIFF
--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -57,7 +57,7 @@ spec:
           value: {{ service_variant }}
         - name: DJANGO_SETTINGS_MODULE
           value: {{ service_variant }}.envs.fun.docker_run
-        image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+        image: ""
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /config
@@ -115,3 +115,12 @@ spec:
         - name: edxapp-v-data
           persistentVolumeClaim:
             claimName: edxapp-pvc-data
+  triggers:
+    - type: ImageChange
+      imageChangeParams:
+        automatic: true
+        containerNames:
+        - "{{ service_variant }}"
+        from:
+          kind: ImageStreamTag
+          name: "augmented-{{ edxapp_image_name }}:{{ edxapp_image_tag }}"

--- a/apps/edxapp/templates/lms/bc.yml.j2
+++ b/apps/edxapp/templates/lms/bc.yml.j2
@@ -1,0 +1,30 @@
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  name: "edxapp-lms"
+  labels:
+    app: "edxapp"
+    service: "lms"
+spec:
+  strategy:
+    dockerStrategy:
+  source:
+    {% if edxapp_theme_url is defined and edxapp_theme_url %}
+    git:
+      uri: "{{ edxapp_theme_url }}"
+      ref: "{{ edxapp_theme_tag | default("master") }}"
+    sourceSecret:
+      name: "edxapp_theme_ssh_key"
+    {% endif %}
+    dockerfile: |-
+      FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
+      USER 0
+      {% if edxapp_theme_url is defined and edxapp_theme_url %}
+      COPY . /edx/app/edxapp/edx-platform/themes/custom-theme
+      NO_PREREQ_INSTALL=1 DEFAULT_SITE_THEME="custom-theme" paver update_assets --settings={{ edxapp_build_settings }} --skip-collect 
+      {% endif %}
+      USER 10000
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "augmented-{{ edxapp_image_name }}:{{ edxapp_image_tag }}"

--- a/apps/edxapp/templates/lms/is.yml.j2
+++ b/apps/edxapp/templates/lms/is.yml.j2
@@ -1,0 +1,7 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "augmented-{{ edxapp_image_name }}"
+  labels:
+    app: "edxapp"
+    service: "lms"

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -9,6 +9,9 @@ edxapp_image_name: "fundocker/edxapp"
 edxapp_image_tag: "ginkgo.1-1.0.6"
 edxapp_django_port: 8000
 edxapp_sql_dump_url: "https://gist.github.com/jmaupetit/1f9d270d7d2106774fd94ba89a51ab78/raw/b0004f2825623d03de58710bf936db175e96bc90/edx-database-ginko.sql"
+edxapp_theme_url: "git@git.alt.openfun.fr:openfun/cnfpt.git"
+edxapp_theme_tag: "master"
+edxapp_build_settings: "fun.docker_build_production"
 
 # -- memcached
 edxapp_memcached_image_name: memcached


### PR DESCRIPTION
## Purpose

Adding a custom theme to an Open edX site must be done upon deployment and not in the common Docker image because it is specific to each customer.

**edit**: this PR is depends on #111 

## Proposal

We propose to use OpenShift's buildconfig objects to automate such builds. The same mechanism can be used to add monitoring or other build steps that are specific either to our way to deploy things to OpenShift or to a customer (like the theme).

It is a good idea to use a common image stream for the CMS and the LMS even if no customization is made because it allows keeping a copy of the image in our local registry and avoid downloading it
from DockerHub upon each deployment.

- [x] Add a build config step and an image stream
- [ ] Upgrade edxapp docker image version to gingko.1-1.0.7
- [ ] Remove the DEFAULT_SITE_THEME env var (see https://github.com/openfun/arnold/pull/105#discussion_r213377200)
- [ ] Add a private SSH key as a sshauth secret to connect to the theme as a private repository in Gitlab