### PR TITLE
🙈(openshift) ignore local cluster tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ env.d/*
 # Tests temporary files
 .coverage
 .pytest_cache
+
+# OpenShift
+openshift.local.clusterup


### PR DESCRIPTION
## Purpose

Since OpenShift 3.10 release, cluster temporary files are created in the current directory by default.

## Proposal

- [x] git-ignore the `./openshift.local.clusterup` directory