### PR TITLE
Add support for ImageSteam and BuildConfig objects

### DIFF
--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -57,7 +57,9 @@ spec:
           value: {{ service_variant }}
         - name: DJANGO_SETTINGS_MODULE
           value: {{ service_variant }}.envs.fun.docker_run
-        image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+        # We point to a local registry image build for this "live" image (see
+        # ImageStream and BuildConfig templates)
+        image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-{{ service_variant }}:{{ edxapp_image_tag }}-live"
         imagePullPolicy: IfNotPresent
         volumeMounts:
         - mountPath: /config

--- a/apps/edxapp/templates/cms/bc.yml.j2
+++ b/apps/edxapp/templates/cms/bc.yml.j2
@@ -1,0 +1,38 @@
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  # FIXME
+  #
+  # As mentionned in the official documentation [1]:
+  #
+  #   Configuration change triggers currently only work when creating a new
+  #   BuildConfig. In a future release, configuration change triggers will also
+  #   be able to launch a build whenever a BuildConfig is updated.
+  #
+  # Hence, we must force BuildConfig to always get created with a unique name.
+  # This is a temporary solution that needs to be improved as soon as OKD
+  # triggers a new build upon BC object update.
+  #
+  # References:
+  #
+  # 1. https://docs.okd.io/latest/dev_guide/builds/triggering_builds.html#config-change-triggers
+  name: "edxapp-cms-{{ deployment_stamp }}"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "cms"
+    version: "{{ edxapp_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  strategy:
+    type: Docker
+  source:
+    dockerfile: |-
+      FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
+      # Add new statements here
+  triggers:
+    - type: "ConfigChange"
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "edxapp-cms:{{ edxapp_image_tag }}-live"

--- a/apps/edxapp/templates/cms/is.yml.j2
+++ b/apps/edxapp/templates/cms/is.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "edxapp-cms"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "cms"

--- a/apps/edxapp/templates/cms/job_01_collectstatic.yml.j2
+++ b/apps/edxapp/templates/cms/job_01_collectstatic.yml.j2
@@ -22,7 +22,9 @@ spec:
     spec:
       containers:
         - name: edxapp-cms-collectstatic-{{ job_stamp }}
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/cms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/cms/job_04_db_migrate.yml.j2
@@ -22,7 +22,9 @@ spec:
     spec:
       containers:
       - name: edxapp-cms-dbmigrate-{{ job_stamp }}
-        image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+        # We point to a local registry image build for this "live" image (see
+        # ImageStream and BuildConfig templates)
+        image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/cms/job_05_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/cms/job_05_load_fixtures.yml.j2
@@ -22,7 +22,9 @@ spec:
     spec:
       containers:
         - name: edxapp-cms-load-fixtures-{{ job_stamp }}
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/lms/bc.yml.j2
+++ b/apps/edxapp/templates/lms/bc.yml.j2
@@ -1,0 +1,38 @@
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  # FIXME
+  #
+  # As mentionned in the official documentation [1]:
+  #
+  #   Configuration change triggers currently only work when creating a new
+  #   BuildConfig. In a future release, configuration change triggers will also
+  #   be able to launch a build whenever a BuildConfig is updated.
+  #
+  # Hence, we must force BuildConfig to always get created with a unique name.
+  # This is a temporary solution that needs to be improved as soon as OKD
+  # triggers a new build upon BC object update.
+  #
+  # References:
+  #
+  # 1. https://docs.okd.io/latest/dev_guide/builds/triggering_builds.html#config-change-triggers
+  name: "edxapp-lms-{{ deployment_stamp }}"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "lms"
+    version: "{{ edxapp_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  strategy:
+    type: Docker
+  source:
+    dockerfile: |-
+      FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
+      # Add new statements here
+  triggers:
+    - type: "ConfigChange"
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "edxapp-lms:{{ edxapp_image_tag }}-live"

--- a/apps/edxapp/templates/lms/is.yml.j2
+++ b/apps/edxapp/templates/lms/is.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "edxapp-lms"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "lms"

--- a/apps/edxapp/templates/lms/job_02_collectstatic.yml.j2
+++ b/apps/edxapp/templates/lms/job_02_collectstatic.yml.j2
@@ -22,7 +22,9 @@ spec:
     spec:
       containers:
         - name: edxapp-lms-collectstatic-{{ job_stamp }}
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-lms:{{ edxapp_image_tag }}-live"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run

--- a/apps/edxapp/templates/lms/job_03_db_migrate.yml.j2
+++ b/apps/edxapp/templates/lms/job_03_db_migrate.yml.j2
@@ -22,7 +22,9 @@ spec:
     spec:
       containers:
       - name: edxapp-lms-dbmigrate-{{ job_stamp }}
-        image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+        # We point to a local registry image build for this "live" image (see
+        # ImageStream and BuildConfig templates)
+        image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-lms:{{ edxapp_image_tag }}-live"
         env:
           - name: DJANGO_SETTINGS_MODULE
             value: lms.envs.fun.docker_run

--- a/apps/richie/templates/app/bc.yml.j2
+++ b/apps/richie/templates/app/bc.yml.j2
@@ -1,0 +1,38 @@
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  # FIXME
+  #
+  # As mentionned in the official documentation [1]:
+  #
+  #   Configuration change triggers currently only work when creating a new
+  #   BuildConfig. In a future release, configuration change triggers will also
+  #   be able to launch a build whenever a BuildConfig is updated.
+  #
+  # Hence, we must force BuildConfig to always get created with a unique name.
+  # This is a temporary solution that needs to be improved as soon as OKD
+  # triggers a new build upon BC object update.
+  #
+  # References:
+  #
+  # 1. https://docs.okd.io/latest/dev_guide/builds/triggering_builds.html#config-change-triggers
+  name: "richie-{{ deployment_stamp }}"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "richie"
+    service: "richie"
+    version: "{{ richie_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  strategy:
+    type: Docker
+  source:
+    dockerfile: |-
+      FROM {{ richie_image_name }}:{{ richie_image_tag }}
+      # Add new statements here
+  triggers:
+    - type: "ConfigChange"
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "richie:{{ richie_image_tag }}-live"

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "richie-app-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1  # number of pods we want
+  replicas: 1 # number of pods we want
   template:
     metadata:
       labels:
@@ -21,7 +21,9 @@ spec:
     spec:
       containers:
         - name: richie
-          image: "{{ richie_image_name }}:{{ richie_image_tag }}"
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
           imagePullPolicy: IfNotPresent
           env:
             - name: DJANGO_SETTINGS_MODULE

--- a/apps/richie/templates/app/is.yml.j2
+++ b/apps/richie/templates/app/is.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "richie"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "richie"
+    service: "richie"

--- a/apps/richie/templates/app/job_collectstatic.yml.j2
+++ b/apps/richie/templates/app/job_collectstatic.yml.j2
@@ -38,7 +38,9 @@ spec:
         envFrom:
           - secretRef:
               name: richie-{{ secret_id }}
-        image: "{{ richie_image_name }}:{{ richie_image_tag }}"
+        # We point to a local registry image build for this "live" image (see
+        # ImageStream and BuildConfig templates)
+        image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
         command: ["python", "manage.py", "collectstatic", "--noinput"]
         volumeMounts:
         - mountPath: /data/static

--- a/apps/richie/templates/app/job_db_migrate.yml.j2
+++ b/apps/richie/templates/app/job_db_migrate.yml.j2
@@ -38,6 +38,8 @@ spec:
         envFrom:
           - secretRef:
               name: richie-{{ secret_id }}
-        image: "{{ richie_image_name }}:{{ richie_image_tag }}"
+        # We point to a local registry image build for this "live" image (see
+        # ImageStream and BuildConfig templates)
+        image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
         command: ["python", "manage.py", "migrate"]
       restartPolicy: Never

--- a/apps/richie/templates/app/job_regenerate_indexes.yml.j2
+++ b/apps/richie/templates/app/job_regenerate_indexes.yml.j2
@@ -40,6 +40,8 @@ spec:
         envFrom:
           - secretRef:
               name: richie-{{ secret_id }}
-        image: "{{ richie_image_name }}:{{ richie_image_tag }}"
+        # We point to a local registry image build for this "live" image (see
+        # ImageStream and BuildConfig templates)
+        image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
         command: ["python", "manage.py", "regenerate_indexes"]
       restartPolicy: Never

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -62,6 +62,9 @@ job_stamp: null
 # docs/developer_guide/secrets.md
 secret_id: "1.0.0"
 
+# OpenShift's internal docker registry server
+internal_docker_registry: "docker-registry.default.svc:5000"
+
 # TODO: move the following settings to the redirect app
 # Ports
 aliases_port: 8999

--- a/group_vars/env_type/ci.yml
+++ b/group_vars/env_type/ci.yml
@@ -2,6 +2,12 @@
 project_description: "A minimal project to test apps bootstrapping ({{ env_type }})"
 domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 
+# OpenShift's internal docker registry server
+#
+# FIXME: use docker registry server IP address instead of the service name (i.e.
+# docker-registry.default.svc) to prevent oc cluster DNS issues
+internal_docker_registry: "172.30.1.1:5000"
+
 apps:
   - name: hello
   - name: richie

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -1,6 +1,12 @@
 # Variables specific to development environments
 domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 
+# OpenShift's internal docker registry server
+#
+# FIXME: use docker registry server IP address instead of the service name (i.e.
+# docker-registry.default.svc) to prevent oc cluster DNS issues
+internal_docker_registry: "172.30.1.1:5000"
+
 # Use development images in the development environment
 edxapp_image_tag: "hawthorn.1-1.0.0-dev"
 richie_image_tag: "0.1.0-alpha.3-alpine-dev"

--- a/init_project.yml
+++ b/init_project.yml
@@ -24,7 +24,9 @@
           - create_app_volumes
           - create_app_endpoints
           - create_static_services_routes
+          - create_app_image_streams
       tags:
         - volume
         - endpoint
         - route
+        - stream

--- a/tasks/create_app_image_streams.yml
+++ b/tasks/create_app_image_streams.yml
@@ -1,0 +1,14 @@
+---
+# Create volumes for an app
+
+- name: Print app name
+  debug: msg="App name {{ app.name }}"
+  tags: stream
+
+- name: Make sure image streams exist
+  openshift_raw:
+    definition: "{{ lookup('template', item) | from_yaml }}"
+    state: present
+  with_items: "{{ streams }}"
+  when: streams is defined
+  tags: stream

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -1,4 +1,3 @@
----
 # Get objects for an application
 
 - name: Set templates list for this app
@@ -8,16 +7,28 @@
 
 - name: Set OpenShift objects to manage
   set_fact:
+    builds: "{{ templates | map('regex_search', '.*/bc.*\\.yml\\.j2$') | select('string') | list }}"
     deployments: "{{ templates | map('regex_search', '.*/dc.*\\.yml\\.j2$') | select('string') | list }}"
     services: "{{ templates | map('regex_search', '.*/svc\\.yml\\.j2$') | select('string') | list }}"
+    streams: "{{ templates | map('regex_search', '.*/is.*\\.yml\\.j2$') | select('string') | list }}"
     jobs: "{{ templates | map('regex_search', '.*/job_.*\\.yml\\.j2$') | select('string') | list }}"
     routes: "{{ templates | map('regex_search', '.*/route.*\\.yml\\.j2$') | select('string') | list }}"
   tags:
     - deploy
+    - build
     - deployment
     - service
+    - stream
     - job
     - route
+
+- name: Display OpenShift's builds for this app
+  debug:
+    msg: "{{ builds | to_nice_yaml}}"
+  when: builds
+  tags:
+    - deploy
+    - build
 
 - name: Display OpenShift's deployments for this app
   debug:
@@ -34,6 +45,14 @@
   tags:
     - deploy
     - service
+
+- name: Display OpenShift's image streams for this app
+  debug:
+    msg: "{{ streams | to_nice_yaml }}"
+  when: streams
+  tags:
+    - deploy
+    - stream
 
 - name: Display OpenShift's jobs for this app
   debug:

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -1,4 +1,3 @@
----
 # Task set to manage apps
 #
 # Args:
@@ -12,10 +11,12 @@
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: "{{ deployment_state | default('present') }}"
   with_items:
+    - "{{ builds }}"
     - "{{ deployments }}"
     - "{{ services }}"
   tags:
     - deploy
+    - build
     - deployment
     - service
 


### PR DESCRIPTION
## Purpose

Until now, BuildConfiguration and ImageStream objects were not required. Now that we need to add APM and customize images on a per-client basis, using the aforementioned objects seems the more relevant solution.

_nota bene_: 

* this PR is closely related to #101 and #105 as they both require support for those objects.
* this PR also address #106 

## Proposal

- [x] add basic/generic support for `ImageStream` and `BuildConfig` objects
- [x] add templates to use an IS/BC for `edxapp` (lms + cms)
- [x] add templates to use an IS/BC for `richie` (app)