### PR TITLE
Add theme support for edxapp's LMS

### DIFF
--- a/apps/edxapp/templates/lms/bc.yml.j2
+++ b/apps/edxapp/templates/lms/bc.yml.j2
@@ -27,9 +27,19 @@ spec:
   strategy:
     type: Docker
   source:
+    {% if edxapp_theme_url is defined and edxapp_theme_url -%}
+    git:
+      uri: "{{ edxapp_theme_url }}"
+      ref: "{{ edxapp_theme_tag | default("master") }}"
+    {% endif -%}
     dockerfile: |-
       FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
-      # Add new statements here
+      USER 0
+      {% if edxapp_theme_url is defined and edxapp_theme_url -%}
+      COPY . /edx/app/edxapp/edx-platform/themes/custom-theme
+      RUN NO_PREREQ_INSTALL=1 paver update_assets --settings={{ edxapp_build_settings }} --skip-collect
+      {% endif -%}
+      USER 10000
   triggers:
     - type: "ConfigChange"
   output:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -8,6 +8,14 @@ edxapp_lms_host: "lms.{{ project_name}}.{{ domain_name }}"
 edxapp_image_name: "fundocker/edxapp"
 edxapp_image_tag: "hawthorn.1-1.0.0"
 edxapp_django_port: 8000
+# Customize edxapp's LMS theme: the url is supposed to point to the git
+# repository and the tag to either a tag or a branch, e.g.:
+#
+#   edxapp_theme_url: "https://github.com/raccoongang/themes_for_themex.io)"
+#   edxapp_theme_tag: "marvel-theme-ginkgo"
+edxapp_theme_url: ""
+edxapp_theme_tag: ""
+edxapp_build_settings: "fun.docker_build_production"
 
 # -- memcached
 edxapp_memcached_image_name: memcached

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -8,7 +8,6 @@ edxapp_lms_host: "lms.{{ project_name}}.{{ domain_name }}"
 edxapp_image_name: "fundocker/edxapp"
 edxapp_image_tag: "hawthorn.1-1.0.0"
 edxapp_django_port: 8000
-edxapp_sql_dump_url: "https://gist.github.com/jmaupetit/1f9d270d7d2106774fd94ba89a51ab78/raw/b0004f2825623d03de58710bf936db175e96bc90/edx-database-ginko.sql"
 
 # -- memcached
 edxapp_memcached_image_name: memcached

--- a/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
@@ -22,3 +22,6 @@ HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}"
 DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}"
 LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}"
 HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}"
+
+# Use a custom theme
+DEFAULT_SITE_THEME: "custom-theme"

--- a/group_vars/customer/patient0/development/main.yml
+++ b/group_vars/customer/patient0/development/main.yml
@@ -18,3 +18,7 @@ apps:
           - group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
   - name: redis
   - name: hello
+
+# Install a custom theme for edxapp-lms
+edxapp_theme_url: "https://github.com/raccoongang/themes_for_themex.io"
+edxapp_theme_tag: "marvel-theme-ginkgo"


### PR DESCRIPTION
## Purpose

**disclaimer** this PR is a replacement for #105 

> Adding a custom theme to an Open edX site must be done upon deployment and not in the common 
> Docker image because it is specific to each customer.

## Proposal

- [x] add edxapp new settings for theme url/tag
- [x] make the LMS BuildConfig more versatile to checkout and build custom theme
- [x] add custom theme example for `patient0-development`

Closes #105 