### PR TITLE
⬇️(cli) downgrade oc client to 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,7 +36,7 @@ aliases:
     run:
       name: Install the OC client
       command: |
-        wget https://github.com/openshift/origin/releases/download/v3.10.0/openshift-origin-client-tools-v3.10.0-dd10d17-linux-64bit.tar.gz -P /tmp/openshift/
+        wget https://github.com/openshift/origin/releases/download/v3.9.0/openshift-origin-client-tools-v3.9.0-191fece-linux-64bit.tar.gz -P /tmp/openshift/
         tar xzf /tmp/openshift/openshift*.tar.gz --strip-components=1 -C /tmp/openshift/
         cp /tmp/openshift/oc $HOME/bin/
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ changes to your OpenShift instance that orchestrates your services.
 - [OpenShift's client](https://docs.openshift.org/latest/welcome/index.html)
   (_aka_ `oc`): this CLI is used to communicate with the running OpenShift
   instance you will use. Plus, it offers the possibility to run a minimal
-  cluster for development purpose (using a set of docker containers).
+  cluster for development purpose (using a set of docker containers). For now
+  please stick to the [`3.9` release of
+  `oc`](https://github.com/openshift/origin/releases/tag/v3.9.0), we've
+  experienced too much DNS issues with the `3.10` newer release.
 
 > Even if we recommend to only use `oc` and docker to work locally with Arnold,
 > you might also consider using


### PR DESCRIPTION
# Purpose

We are struggling like hell with oc 3.10 DNS issues. I think it's time to give up and downgrade to 3.9 that provided a better stability/experience.

## Proposal

- [x] downgrade oc release used in the CI
- [x] update docs (README)
