### PR TITLE
WIP: Add datadog APM support

### DIFF
--- a/apps/richie/templates/app/bc.yml.j2
+++ b/apps/richie/templates/app/bc.yml.j2
@@ -29,7 +29,12 @@ spec:
   source:
     dockerfile: |-
       FROM {{ richie_image_name }}:{{ richie_image_tag }}
-      # Add new statements here
+      USER 0
+      {% if is_apm_enabled -%}
+      RUN pip install ddtrace
+      CMD ddtrace-run gunicorn -c /usr/local/etc/gunicorn/richie.py richie.wsgi:application
+      {% endif -%}
+      USER 10000
   triggers:
     - type: "ConfigChange"
   output:

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -40,6 +40,18 @@ spec:
               value: "{{ richie_host }}"
             - name: ES_CLIENT
               value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
+            {% if is_apm_enabled -%}
+            - name: DATADOG_TRACE_AGENT_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_AGENT_SERVICE_HOST
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+            - name: DD_AGENT_SERVICE_PORT
+              value: "{{ apm_agent_port }}"
+            {% endif -%}
           envFrom:
             - secretRef:
                 name: richie-{{ secret_id }}

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -40,6 +40,7 @@ spec:
               value: "{{ richie_host }}"
             - name: ES_CLIENT
               value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
+
             {% if is_apm_enabled -%}
             - name: DATADOG_TRACE_AGENT_HOSTNAME
               valueFrom:
@@ -51,7 +52,8 @@ spec:
                   fieldPath: status.hostIP
             - name: DD_AGENT_SERVICE_PORT
               value: "{{ apm_agent_port }}"
-            {% endif -%}
+            {%- endif %}
+
           envFrom:
             - secretRef:
                 name: richie-{{ secret_id }}

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -65,6 +65,12 @@ secret_id: "1.0.0"
 # OpenShift's internal docker registry server
 internal_docker_registry: "docker-registry.default.svc:5000"
 
+# Set is_apm_enabled to "true" to enable APM in all apps where defined templates
+# include this feature (default: "false")
+is_apm_enabled: false
+# APM agent port defaults to Datadog agent service port
+apm_agent_port: 8126
+
 # TODO: move the following settings to the redirect app
 # Ports
 aliases_port: 8999

--- a/group_vars/env_type/preproduction.yml
+++ b/group_vars/env_type/preproduction.yml
@@ -1,2 +1,5 @@
 # Variables specific to the pre-production environment
 richie_django_configuration: PreProduction
+
+# Enable APM in all apps where defined templates include this feature
+is_apm_enabled: true

--- a/group_vars/env_type/production.yml
+++ b/group_vars/env_type/production.yml
@@ -1,3 +1,6 @@
 # Variables specific to the production environment
 richie_django_configuration: Production
 acme_env: live
+
+# Enable APM in all apps where defined templates include this feature
+is_apm_enabled: true

--- a/group_vars/env_type/staging.yml
+++ b/group_vars/env_type/staging.yml
@@ -1,2 +1,5 @@
 # Variables specific to the staging environment
 richie_django_configuration: Staging
+
+# Enable APM in all apps where defined templates include this feature
+is_apm_enabled: true

--- a/tasks/delete_app.yml
+++ b/tasks/delete_app.yml
@@ -13,6 +13,7 @@
     obj: "{{ lookup('openshift', api_version='v1', namespace=project_name, kind=item, label_selector='app=' + app.name + ',deployment_stamp=' + targeted_deployment_stamp) | zip_longest([{'kind': item}], fillvalue={'kind': item}) | list }}"
   register: raw_selected_objects
   loop:
+    - BuildConfig
     - ConfigMap
     - DeploymentConfig
     - Job


### PR DESCRIPTION
## Purpose

This is a follow up of #101 considering recent changes concerning BuildConfig and ImageStream. We've decided to add APM to our apps by adding new layers to base images (_via_ service BuildConfig).

## Proposal

- [x] add APM related variables to make them configurable (env_type, customers)
- [ ] integrate APM for `richie`
- [ ] integrate APM for `edxapp`

Closes #101