### PR TITLE
Add a mail catcher app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -178,6 +178,29 @@ jobs:
             bin/ci-bootstrap "hello"
             bin/ci-test-service "hello" "Hello OpenShift! by Arnold"
 
+  # Test the bootstrap playbook on the "mailcatcher" application
+  # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
+  test-bootstrap-mailcatcher:
+    machine:
+      docker_layer_caching: true
+
+    working_directory: ~/fun
+
+    steps:
+      - checkout
+      - *attach_workspace
+      - *docker_load
+      - *ci_env
+      - *install_openshift_cluster
+      - *configure_openshift_cluster
+      - *run_openshift_cluster
+
+      - run:
+          name: Test the "mailcatcher" application bootstrapping
+          command: |
+            bin/ci-bootstrap "mailcatcher"
+            bin/ci-test-service "mailcatcher" "MailCatcher"
+
   # Test the bootstrap playbook on the "richie" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-richie:
@@ -282,6 +305,12 @@ workflows:
             - lint-ansible
             - lint-plugins
       - test-bootstrap-edxapp:
+          requires:
+            - lint-bash
+            - lint-docker
+            - lint-ansible
+            - lint-plugins
+      - test-bootstrap-mailcatcher:
           requires:
             - lint-bash
             - lint-docker

--- a/apps/edxapp/templates/cms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/cms/_configs/settings.yml.j2
@@ -9,7 +9,7 @@ CMS_BASE: "{{ edxapp_cms_host }}"
 
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis
-CELERY_BROKER_HOST: "{{ redis_app_host }}"
+CELERY_BROKER_HOST: redis
 CELERY_BROKER_VHOST: 0
 CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # FIXME: for now, we haven't set a user/password to connect to redis. Once those

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -9,7 +9,7 @@ CMS_BASE: "{{ edxapp_cms_host }}"
 
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis
-CELERY_BROKER_HOST: "{{ redis_app_host }}"
+CELERY_BROKER_HOST: redis
 CELERY_BROKER_VHOST: 0
 CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # FIXME: for now, we haven't set a user/password to connect to redis. Once those

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -6,7 +6,7 @@ edxapp_lms_host: "lms.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "hawthorn.1-1.0.0"
+edxapp_image_tag: "hawthorn.1-1.0.4"
 edxapp_django_port: 8000
 edxapp_sql_dump_url: "https://gist.githubusercontent.com/jmaupetit/76fe7db4a8314fe1fa10895edf14248e/raw/1fd2aab7d57273bbe4cf40603c119a1c8026cbc1/edx-database-hawthorn.sql"
 
@@ -54,7 +54,9 @@ edxapp_celery_cms_high_priority_queue: "edx.cms.core.high"
 edxapp_celery_cms_default_priority_queue: "edx.cms.core.default"
 edxapp_celery_cms_low_priority_queue: "edx.cms.core.low"
 
-# FIXME: when deploying only edxapp (and not edxapp + redis), these variables
-# are required
+# FIXME: when deploying only edxapp (and not edxapp + redis and/or mailcatcher),
+# these variables are required
 redis_app_host: "redis"
 redis_app_port: 6379
+
+mailcatcher_sender_port: 1025

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -56,7 +56,5 @@ edxapp_celery_cms_low_priority_queue: "edx.cms.core.low"
 
 # FIXME: when deploying only edxapp (and not edxapp + redis and/or mailcatcher),
 # these variables are required
-redis_app_host: "redis"
 redis_app_port: 6379
-
 mailcatcher_sender_port: 1025

--- a/apps/mailcatcher/templates/app/dc.yml.j2
+++ b/apps/mailcatcher/templates/app/dc.yml.j2
@@ -1,0 +1,29 @@
+apiVersion: v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: mailcatcher
+    service: app
+    version: "{{ mailcatcher_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "mailcatcher-app"
+  namespace: "{{ project_name }}"
+spec:
+  replicas: 1  # number of pods we want
+  template:
+    metadata:
+      labels:
+        app: mailcatcher
+        service: app
+        version: "{{ mailcatcher_image_tag }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+        deploymentconfig: "mailcatcher-app"
+    spec:
+      containers:
+      - name: mailcatcher
+        image: "{{ mailcatcher_image_name }}:{{ mailcatcher_image_tag }}"
+        ports:
+        - containerPort: 1025
+          protocol: TCP
+        - containerPort: 1080
+          protocol: TCP

--- a/apps/mailcatcher/templates/app/route.yml.j2
+++ b/apps/mailcatcher/templates/app/route.yml.j2
@@ -20,4 +20,4 @@ spec:
     targetPort: "{{ mailcatcher_reader_port }}-tcp"
   to:
     kind: Service
-    name: "{{ mailcatcher_app_host }}"
+    name: "mailcatcher"

--- a/apps/mailcatcher/templates/app/route.yml.j2
+++ b/apps/mailcatcher/templates/app/route.yml.j2
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Route
+metadata:
+  namespace: "{{ project_name }}"
+  name: "mailcatcher-{{ prefix }}"
+  labels:
+    env_type: "{{ env_type }}"
+    customer: "{{ customer }}"
+    app: "mailcatcher"
+    service: "app"
+    version: "{{ mailcatcher_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+    route_prefix: "{{ prefix }}"
+    route_target_service: "app"
+spec:
+  host: "{{ mailcatcher_host | blue_green_host(prefix) }}"
+  tls:
+    termination: edge
+  port:
+    targetPort: "{{ mailcatcher_reader_port }}-tcp"
+  to:
+    kind: Service
+    name: "{{ mailcatcher_app_host }}"

--- a/apps/mailcatcher/templates/app/svc.yml.j2
+++ b/apps/mailcatcher/templates/app/svc.yml.j2
@@ -6,7 +6,7 @@ metadata:
     service: app
     version: "{{ mailcatcher_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
-  name: "{{ mailcatcher_app_host }}"
+  name: "mailcatcher"
   namespace: "{{ project_name }}"
 spec:
   ports:

--- a/apps/mailcatcher/templates/app/svc.yml.j2
+++ b/apps/mailcatcher/templates/app/svc.yml.j2
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: mailcatcher
+    service: app
+    version: "{{ mailcatcher_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+  name: "{{ mailcatcher_app_host }}"
+  namespace: "{{ project_name }}"
+spec:
+  ports:
+  - name: {{ mailcatcher_sender_port }}-tcp
+    port: {{ mailcatcher_sender_port }}
+    protocol: TCP
+    targetPort: 1025
+  - name: {{ mailcatcher_reader_port }}-tcp
+    port: {{ mailcatcher_reader_port }}
+    protocol: TCP
+    targetPort: 1080
+  selector:
+    deploymentconfig: "mailcatcher-app"
+  type: ClusterIP

--- a/apps/mailcatcher/vars/all/main.yml
+++ b/apps/mailcatcher/vars/all/main.yml
@@ -6,6 +6,5 @@ mailcatcher_host: "mailcatcher.{{ project_name}}.{{ domain_name }}"
 # -- mailcatcher
 mailcatcher_image_name: "sj26/mailcatcher"
 mailcatcher_image_tag: "latest"
-mailcatcher_app_host: "mailcatcher"
 mailcatcher_sender_port: 1025
 mailcatcher_reader_port: 1080

--- a/apps/mailcatcher/vars/all/main.yml
+++ b/apps/mailcatcher/vars/all/main.yml
@@ -1,0 +1,11 @@
+# Application default configuration
+
+# -- route
+mailcatcher_host: "mailcatcher.{{ project_name}}.{{ domain_name }}"
+
+# -- mailcatcher
+mailcatcher_image_name: "sj26/mailcatcher"
+mailcatcher_image_tag: "latest"
+mailcatcher_app_host: "mailcatcher"
+mailcatcher_sender_port: 1025
+mailcatcher_reader_port: 1080

--- a/apps/redis/templates/app/svc.yml.j2
+++ b/apps/redis/templates/app/svc.yml.j2
@@ -7,7 +7,7 @@ metadata:
     version: "{{ redis_app_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the service should be host name in edxapp configuration
-  name: "{{ redis_app_host }}"
+  name: redis
   namespace: "{{ project_name }}"
 spec:
   ports:

--- a/apps/redis/vars/all/main.yml
+++ b/apps/redis/vars/all/main.yml
@@ -2,5 +2,4 @@
 
 redis_app_image_name: redis
 redis_app_image_tag: 4
-redis_app_host: redis
 redis_app_port: 6379

--- a/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
@@ -7,7 +7,7 @@ CMS_BASE: "{{ edxapp_cms_host }}"
 
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis
-CELERY_BROKER_HOST: "{{ redis_app_host }}"
+CELERY_BROKER_HOST: redis
 CELERY_BROKER_VHOST: 0
 CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # FIXME: for now, we haven't set a user/password to connect to redis. Once those

--- a/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
@@ -21,3 +21,8 @@ CELERY_BROKER_PASSWORD: ""
 HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}"
 DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}"
 LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}"
+
+# Email
+EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST: "mailcatcher"
+EMAIL_PORT: "{{ mailcatcher_sender_port }}"

--- a/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/cms/settings.yml.j2
@@ -2,8 +2,6 @@
 
 PLATFORM_NAME: "{{ project_display_name }}"
 
-SITE_NAME: "{{ project_display_name }}"
-
 LMS_BASE: "{{ edxapp_lms_host }}"
 CMS_BASE: "{{ edxapp_cms_host }}"
 

--- a/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
@@ -25,3 +25,8 @@ HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}"
 
 # Use a custom theme
 DEFAULT_SITE_THEME: "custom-theme"
+
+# Email
+EMAIL_BACKEND: "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_HOST: "mailcatcher"
+EMAIL_PORT: "{{ mailcatcher_sender_port }}"

--- a/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
@@ -7,7 +7,7 @@ CMS_BASE: "{{ edxapp_cms_host }}"
 
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis
-CELERY_BROKER_HOST: "{{ redis_app_host }}"
+CELERY_BROKER_HOST: redis
 CELERY_BROKER_VHOST: 0
 CELERY_BROKER_PORT: "{{ redis_app_port }}"
 # FIXME: for now, we haven't set a user/password to connect to redis. Once those

--- a/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/patient0/development/configs/edxapp/lms/settings.yml.j2
@@ -2,8 +2,6 @@
 
 PLATFORM_NAME: "{{ project_display_name }}"
 
-SITE_NAME: "{{ project_display_name }}"
-
 LMS_BASE: "{{ edxapp_lms_host }}"
 CMS_BASE: "{{ edxapp_cms_host }}"
 

--- a/group_vars/customer/patient0/development/main.yml
+++ b/group_vars/customer/patient0/development/main.yml
@@ -1,6 +1,7 @@
 # Variables specific to the patient0 customer in development env_type
 
 apps:
+  - name: mailcatcher
   - name: richie
   - name: edxapp
     services:

--- a/group_vars/env_type/ci.yml
+++ b/group_vars/env_type/ci.yml
@@ -9,6 +9,7 @@ domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 internal_docker_registry: "172.30.1.1:5000"
 
 apps:
+  - name: mailcatcher
   - name: hello
   - name: richie
   - name: edxapp

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -8,10 +8,11 @@ domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 internal_docker_registry: "172.30.1.1:5000"
 
 # Use development images in the development environment
-edxapp_image_tag: "hawthorn.1-1.0.0-dev"
+edxapp_image_tag: "hawthorn.1-1.0.4-dev"
 richie_image_tag: "0.1.0-alpha.3-alpine-dev"
 
 apps:
+  - name: mailcatcher
   - name: richie
   - name: edxapp
   - name: redis


### PR DESCRIPTION
## Purpose

In non-production environments, we don't want  to send real emails but we want to easily consult the emails sent to anyone.

## Proposal

The solution for this is to use a mail catcher. There are several solutions available and we chose https://github.com/sj26/mailcatcher because it is easy, good enough and distributed as a Docker image.

- [x] Add a separate mailcatcher app not subject to blue/green deployments
- [x] Configure edxapp to send its emails to mailcatcher

