### PR TITLE
⏪(job) restore edxapp mysql dump loading

### DIFF
--- a/apps/edxapp/templates/mysql/job_00_load_sql_dump.yml.j2
+++ b/apps/edxapp/templates/mysql/job_00_load_sql_dump.yml.j2
@@ -1,0 +1,42 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: edxapp-mysql-load-sql-dump-{{ job_stamp }}
+  namespace: "{{ project_name }}"
+  labels:
+    app: edxapp
+    service: mysql
+    version: "{{ edxapp_image_tag }}"
+    job_stamp: "{{ job_stamp }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  template:
+    metadata:
+      name: mysql-load-sql-dump-{{ job_stamp }}
+      labels:
+        app: edxapp
+        service: mysql
+        version: "{{ edxapp_image_tag }}"
+        job_stamp: "{{ job_stamp }}"
+        deployment_stamp: "{{ deployment_stamp }}"
+    spec:
+      containers:
+        - name: mysql-load-sql-dump-{{ job_stamp }}
+          image: "{{ edxapp_mysql_image_name }}:{{ edxapp_mysql_image_tag }}"
+          env:
+            - name: MYSQL_DATABASE
+              value: {{ edxapp_mysql_database }}
+          envFrom:
+            - secretRef:
+                name: edxapp-{{ secret_id }}
+          command:
+            - "bash"
+            - "-c"
+            - cd /tmp &&
+                curl -sL -o edx-database.sql "{{ edxapp_sql_dump_url }}" &&
+                mysql
+                  -u ${MYSQL_USER}
+                  -h ${MYSQL_SERVICE_HOST}
+                  --password=${MYSQL_PASSWORD}
+                  ${MYSQL_DATABASE} < edx-database.sql
+      restartPolicy: Never

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -8,6 +8,8 @@ edxapp_lms_host: "lms.{{ project_name}}.{{ domain_name }}"
 edxapp_image_name: "fundocker/edxapp"
 edxapp_image_tag: "hawthorn.1-1.0.0"
 edxapp_django_port: 8000
+edxapp_sql_dump_url: "https://gist.githubusercontent.com/jmaupetit/76fe7db4a8314fe1fa10895edf14248e/raw/1fd2aab7d57273bbe4cf40603c119a1c8026cbc1/edx-database-hawthorn.sql"
+
 # Customize edxapp's LMS theme: the url is supposed to point to the git
 # repository and the tag to either a tag or a branch, e.g.:
 #


### PR DESCRIPTION
## Purpose

When switching to hawthorn, as MySQL database migrations were quite quick to run, I decided to remove the SQL dump loading job. Unfortunately database migration time (~5 min) can still get improved.

## Proposal

I've cooked a SQL dump after having run hawthorn migrations and restored the SQL dump loading job.