### PR TITLE
⬆️(arnold) upgrade curl package to 7.52.1-5+deb9u7

### DIFF
--- a/requirements/apt-packages.txt
+++ b/requirements/apt-packages.txt
@@ -1,4 +1,4 @@
-curl=7.52.1-5+deb9u6
+curl=7.52.1-5+deb9u7
 unzip=6.0-21
 shellcheck=0.4.4-4
 python-pip=9.0.1-2


### PR DESCRIPTION
## Purpose

Arnold's current build seems broken due to a wrong/missing curl package release.

## Proposal

- [x] upgrade curl to 7.52.1-5+deb9u6
