### PR TITLE
Improve BuildConfig triggering

### DIFF
--- a/apps/edxapp/templates/cms/bc.yml.j2
+++ b/apps/edxapp/templates/cms/bc.yml.j2
@@ -16,13 +16,12 @@ metadata:
   # References:
   #
   # 1. https://docs.okd.io/latest/dev_guide/builds/triggering_builds.html#config-change-triggers
-  name: "edxapp-cms-{{ deployment_stamp }}"
+  name: "edxapp-cms-{{ edxapp_image_tag }}"
   namespace: "{{ project_name }}"
   labels:
     app: "edxapp"
     service: "cms"
     version: "{{ edxapp_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
 spec:
   strategy:
     type: Docker

--- a/apps/edxapp/templates/lms/bc.yml.j2
+++ b/apps/edxapp/templates/lms/bc.yml.j2
@@ -16,13 +16,12 @@ metadata:
   # References:
   #
   # 1. https://docs.okd.io/latest/dev_guide/builds/triggering_builds.html#config-change-triggers
-  name: "edxapp-lms-{{ deployment_stamp }}"
+  name: "edxapp-lms-{{ edxapp_image_tag }}"
   namespace: "{{ project_name }}"
   labels:
     app: "edxapp"
     service: "lms"
     version: "{{ edxapp_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
 spec:
   strategy:
     type: Docker

--- a/apps/richie/templates/app/bc.yml.j2
+++ b/apps/richie/templates/app/bc.yml.j2
@@ -16,13 +16,12 @@ metadata:
   # References:
   #
   # 1. https://docs.okd.io/latest/dev_guide/builds/triggering_builds.html#config-change-triggers
-  name: "richie-{{ deployment_stamp }}"
+  name: "richie-{{ richie_image_tag }}"
   namespace: "{{ project_name }}"
   labels:
     app: "richie"
     service: "richie"
     version: "{{ richie_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
 spec:
   strategy:
     type: Docker

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -2,4 +2,5 @@
 
 - import_playbook: delete_project.yml
 - import_playbook: init_project.yml
+- import_playbook: build_images.yml
 - import_playbook: deploy.yml

--- a/build_images.yml
+++ b/build_images.yml
@@ -1,0 +1,25 @@
+---
+# This playbook creates an OpenShift project for a particular
+# customer/environment
+
+- hosts: local
+  gather_facts: False
+
+  tasks:
+    - name: Display playbook name
+      debug: msg="==== Starting build_images playbook ===="
+      tags: deploy
+
+    - import_tasks: tasks/set_vars.yml
+
+    - name: Display BuildConfigs to create
+      debug: msg="{{ apps | to_nice_yaml }}"
+      tags: deploy
+
+    - include_tasks: tasks/run_tasks_for_apps.yml
+      vars:
+        tasks:
+          - tasks/get_objects_for_app
+          - tasks/create_app_builds
+      tags:
+        - build

--- a/tasks/create_app_builds.yml
+++ b/tasks/create_app_builds.yml
@@ -1,0 +1,15 @@
+---
+# Create BuildConfigs for an app
+
+- name: Print app name
+  debug: msg="App name {{ app.name }}"
+  tags: build
+
+- name: Make sure build configs exist
+  openshift_raw:
+    definition: "{{ lookup('template', item) | from_yaml }}"
+    state: present
+    force: true
+  with_items: "{{ builds }}"
+  when: builds is defined
+  tags: build

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -11,12 +11,10 @@
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: "{{ deployment_state | default('present') }}"
   with_items:
-    - "{{ builds }}"
     - "{{ deployments }}"
     - "{{ services }}"
   tags:
     - deploy
-    - build
     - deployment
     - service
 


### PR DESCRIPTION
## Purpose

Instead of building images at every deployment, we need to make it a separated process to avoid using resources when it's not necessary and potentially harmful as it slows down deployments.

## Proposal

- [x] remove builds from deployment
- [x] add a `build_images.yml` playbook
- [x] ~add docker hub webhooks to trigger a new build when a new image has been published~ \*

\* After thought: this might be a bad idea as it would require that we create one webhook per image per project (_i.e._ a `customer` in an `env_type`), and each new image publication would trigger a lot of builds that we are not sure to be able to support.