### PR TITLE
Fix default domain and ssl redirection

### DIFF
--- a/apps/edxapp/templates/nginx/route_cms.yml.j2
+++ b/apps/edxapp/templates/nginx/route_cms.yml.j2
@@ -18,6 +18,7 @@ spec:
   host: "{{ edxapp_cms_host | blue_green_host(prefix) }}"
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   port:
     targetPort: "{{ edxapp_nginx_cms_port }}-tcp"
   to:

--- a/apps/edxapp/templates/nginx/route_lms.yml.j2
+++ b/apps/edxapp/templates/nginx/route_lms.yml.j2
@@ -18,6 +18,7 @@ spec:
   host: "{{ edxapp_lms_host | blue_green_host(prefix) }}"
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   port:
     targetPort: "{{ edxapp_nginx_lms_port }}-tcp"
   to:

--- a/apps/hello/templates/app/route.yml.j2
+++ b/apps/hello/templates/app/route.yml.j2
@@ -17,6 +17,7 @@ spec:
   host: "{{ hello_host | blue_green_host(prefix) }}"
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   port:
     targetPort: "{{ hello_app_port }}-tcp"
   to:

--- a/apps/mailcatcher/templates/app/route.yml.j2
+++ b/apps/mailcatcher/templates/app/route.yml.j2
@@ -16,6 +16,7 @@ spec:
   host: "{{ mailcatcher_host | blue_green_host(prefix) }}"
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   port:
     targetPort: "{{ mailcatcher_reader_port }}-tcp"
   to:

--- a/apps/redirect/templates/nginx/route.yml.j2
+++ b/apps/redirect/templates/nginx/route.yml.j2
@@ -18,3 +18,4 @@ spec:
     weight: 100
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect

--- a/apps/richie/templates/nginx/route.yml.j2
+++ b/apps/richie/templates/nginx/route.yml.j2
@@ -18,6 +18,7 @@ spec:
   host: "{{ richie_host | blue_green_host(prefix) }}"
   tls:
     termination: edge
+    insecureEdgeTerminationPolicy: Redirect
   port:
     targetPort: "{{ richie_nginx_port }}-tcp"
   to:

--- a/group_vars/all/openshift_routes.yml
+++ b/group_vars/all/openshift_routes.yml
@@ -1,6 +1,5 @@
----
 # URL
-domain_name: dev.openfun.fr
+domain_name: oc.openfun.fr
 
 # OpenShift routes_aliases exemple
 # openshift_routes_aliases:       # routes to be redirected
@@ -13,4 +12,4 @@ domain_name: dev.openfun.fr
 #       - alias_1
 #       - alias_2
 openshift_routes_aliases:
-    # No route aliases
+  # No route aliases


### PR DESCRIPTION
## Purpose

We've updated our frontal reverse proxies / load balancers to handle SSL pass-through. This requires a small update in our configuration. 

## Proposal

- [x] update default `domain_name` to `oc.openfun.fr`
- [x] redirect http to https for every route
