### PR TITLE
Add support for edxapp "private" themes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,4 @@
 .ansible/
 .git/
 .gitignore
-*.retry
+openshift.local.clusterup/

--- a/apps/edxapp/templates/lms/bc.yml.j2
+++ b/apps/edxapp/templates/lms/bc.yml.j2
@@ -30,6 +30,10 @@ spec:
     git:
       uri: "{{ edxapp_theme_url }}"
       ref: "{{ edxapp_theme_tag | default("master") }}"
+    {% if edxapp_theme_is_private -%}
+    sourceSecret:
+      name: "{{ edxapp_theme_git_private_key_secret_name }}"
+    {% endif -%}
     {% endif -%}
     dockerfile: |-
       FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}

--- a/apps/edxapp/templates/lms/secret_git_sshkey.yml.j2
+++ b/apps/edxapp/templates/lms/secret_git_sshkey.yml.j2
@@ -1,3 +1,4 @@
+{% if edxapp_theme_is_private %}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -10,3 +11,4 @@ data:
   ssh-privatekey: >-
     {{ EDXAPP_THEME_GIT_PRIVATE_KEY | default('') | b64encode }}
 type: kubernetes.io/ssh-auth
+{% endif %}

--- a/apps/edxapp/templates/lms/secret_git_sshkey.yml.j2
+++ b/apps/edxapp/templates/lms/secret_git_sshkey.yml.j2
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: edxapp
+    service: "cms"
+  name: "{{ edxapp_theme_git_private_key_secret_name }}"
+  namespace: "{{ project_name }}"
+data:
+  ssh-privatekey: >-
+    {{ EDXAPP_THEME_GIT_PRIVATE_KEY | default('') | b64encode }}
+type: kubernetes.io/ssh-auth

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -18,6 +18,21 @@ edxapp_secret_name: "edxapp-{{ edxapp_vault_checksum }}"
 #   edxapp_theme_tag: "marvel-theme-ginkgo"
 edxapp_theme_url: ""
 edxapp_theme_tag: ""
+# If your theme is versionned in a private git repository, switch this variable
+# to: "true"
+edxapp_theme_is_private: false
+# Access to private git repositories is driven by an SSH deployment key, you
+# should allow the public key in your forge (e.g. github or gitlab) and add the
+# SSH private key to your customer/environment edxapp's vault:
+#
+# # group_vars/customer/patient0/development/secrets/edxapp.vault.yml
+#
+# EDXAPP_THEME_GIT_PRIVATE_KEY: |
+#   -----BEGIN RSA PRIVATE KEY-----
+#   yourprivatekeyhere
+#   -----END RSA PRIVATE KEY-----
+edxapp_theme_git_private_key_secret_name: "edxapp-theme-git-sshkey-{{ edxapp_vault_checksum }}"
+# Settings required to build your theme
 edxapp_build_settings: "fun.docker_build_production"
 
 # -- memcached

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -8,7 +8,6 @@ domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 internal_docker_registry: "172.30.1.1:5000"
 
 # Use development images in the development environment
-edxapp_image_tag: "hawthorn.1-1.0.6-dev"
 richie_image_tag: "0.1.0-alpha.3-alpine-dev"
 marsha_image_tag: "1.0.0-alpha.2-alpine-dev"
 


### PR DESCRIPTION
## Purpose

edxapp themes may not be opensource and thus versionned in private git repositories. We need to be able to clone a theme and install it from such repository.

## Proposal

- [x] add support for SSH private key to clone a repository during the LMS image build

I've added two cosmetic fixes to ignore oc cluster files from docker's context, and, stick to edxapp production images only.
