### PR TITLE
🐛(acme) restore live/staging certificates switch

### DIFF
--- a/core_apps/acme/templates/app/dpl.yml.j2
+++ b/core_apps/acme/templates/app/dpl.yml.j2
@@ -29,7 +29,7 @@ spec:
             fieldRef:
               fieldPath: status.podIP
         - name: OPENSHIFT_ACME_ACMEURL
-          value: "https://acme-staging.api.letsencrypt.org/directory"
+          value: "https://acme-{% if acme_env == 'live' %}v01{% else %}staging{% endif %}.api.letsencrypt.org/directory"
         - name: OPENSHIFT_ACME_LOGLEVEL
           value: "4"
         - name: OPENSHIFT_ACME_NAMESPACE


### PR DESCRIPTION
## Purpose

During recent acme (let's encrypt) SSL certificate generation refactoring, the live/staging certificates switch broke, and we are always generating staging certificates. 

## Proposal

- [x] Switch acme API URL depending on the `acme_env` value (live or staging).