### PR TITLE
🔒(python) upgrade ansible to 2.5.10

### DIFF
--- a/requirements/pip-requirements.txt
+++ b/requirements/pip-requirements.txt
@@ -1,5 +1,5 @@
 # Core
-ansible==2.5.0
+ansible==2.5.10
 ansible-lint==3.4.22
 deepmerge==0.0.4
 jmespath==0.9.3


### PR DESCRIPTION
## Purpose

A recent security issue raised for ansible 2.5 < 2.5.5 [1]

[1] https://nvd.nist.gov/vuln/detail/CVE-2018-10855

## Proposal

- [x] upgrade to Ansible `2.5.10`