### PR TITLE
🐛(richie,marsha) fix ALLOWED_HOST setting

### DIFF
--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -37,7 +37,7 @@ spec:
             - name: POSTGRES_PORT
               value: "{{ marsha_postgresql_port }}"
             - name: DJANGO_ALLOWED_HOSTS
-              value: "{{ marsha_host | blue_green_host(prefix) }}"
+              value: "{{ marsha_host | blue_green_hosts }}"
             - name: DJANGO_CLOUDFRONT_PRIVATE_KEY_PATH
               value: "{{ marsha_cloudfront_private_key_path }}"
           envFrom:

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -29,15 +29,15 @@ spec:
             - name: DJANGO_SETTINGS_MODULE
               value: richie.settings
             - name: DJANGO_CONFIGURATION
-              value: {{ richie_django_configuration }}
+              value: "{{ richie_django_configuration }}"
             - name: POSTGRES_DB
-              value: {{ richie_postgresql_database }}
+              value: "{{ richie_postgresql_database }}"
             - name: POSTGRES_HOST
               value: "richie-{{ richie_postgresql_host }}-{{ deployment_stamp }}"
             - name: POSTGRES_PORT
               value: "{{ richie_postgresql_port }}"
             - name: DJANGO_ALLOWED_HOSTS
-              value: "{{ richie_host | blue_green_host(prefix) }}"
+              value: "{{ richie_host | blue_green_hosts }}"
             - name: ES_CLIENT
               value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
           envFrom:

--- a/plugins/filter/deploy.py
+++ b/plugins/filter/deploy.py
@@ -36,6 +36,26 @@ def blue_green_host(host, prefix=None):
     return "{}.{}".format(prefix, host) if prefix != "current" else host
 
 
+def blue_green_hosts(host):
+    """
+        Add next/current/previous prefix to the base host, and return that list
+        of possible hosts.
+
+        Example usage:
+
+            {{ "foo.bar.com" | blue_green_hosts }}
+            # Should return: previous.foo.bar.com, foo.bar.com, next.foo.bar.com
+    """
+
+    if not host:
+        raise AnsibleFilterError("host cannot be empty")
+
+    return [
+        "{}.{}".format(prefix, host) if prefix != "current" else host
+        for prefix in BLUE_GREEN_PREFIXES
+    ]
+
+
 # pylint: disable=no-self-use,too-few-public-methods
 class FilterModule(object):
     """Filters used for deployments"""
@@ -43,4 +63,7 @@ class FilterModule(object):
     def filters(self):
         """List plugin filters"""
 
-        return {"blue_green_host": blue_green_host}
+        return {
+            "blue_green_host": blue_green_host,
+            "blue_green_hosts": blue_green_hosts,
+        }

--- a/tests/units/plugins/filter/test_deploy.py
+++ b/tests/units/plugins/filter/test_deploy.py
@@ -5,7 +5,7 @@ Tests for the "deploy" plugin filter
 from ansible.compat.tests import unittest
 from ansible.errors import AnsibleFilterError
 
-from plugins.filter.deploy import blue_green_host
+from plugins.filter.deploy import blue_green_host, blue_green_hosts
 
 
 class TestBlueGreenHostFilter(unittest.TestCase):
@@ -45,3 +45,27 @@ class TestBlueGreenHostFilter(unittest.TestCase):
 
         self.assertEqual(blue_green_host(host, "previous"), "previous.{}".format(host))
         self.assertEqual(blue_green_host(host, "next"), "next.{}".format(host))
+
+
+class TestBlueGreenHostsFilter(unittest.TestCase):
+    """Tests for the ``blue_green_hosts`` filter"""
+
+    def test_with_empty_host(self):
+        """When the host is empty, the filter should raise an error"""
+
+        with self.assertRaises(AnsibleFilterError) as context_manager:
+            blue_green_hosts(None)
+        self.assertEqual(context_manager.exception.message, "host cannot be empty")
+
+        with self.assertRaises(AnsibleFilterError) as context_manager:
+            blue_green_hosts("")
+        self.assertEqual(context_manager.exception.message, "host cannot be empty")
+
+    def test_with_valid_base_host(self):
+        """Test the filter with a valid host"""
+
+        host = "foo.com"
+
+        self.assertEqual(
+            blue_green_hosts(host), ["previous.foo.com", "foo.com", "next.foo.com"]
+        )


### PR DESCRIPTION
## Purpose

A standard Django application that will be deployed with blue-green enabled will change its domain name upon each URL switch (next > current > previous). Hence, as once deployed the application pod will not be deployed again after the switch, we need to make sure the deployed Django app will allow requests for all blue-green hosts.

## Proposal

We've implemented a new `blue_green_hosts` filter that returns a list of all possible hosts given a base host and use it for `marsha` & `richie` core application's deployment configurations.