### PR TITLE
🐛(plugin) fix blue_green_hosts filter output

### DIFF
--- a/plugins/filter/deploy.py
+++ b/plugins/filter/deploy.py
@@ -50,10 +50,12 @@ def blue_green_hosts(host):
     if not host:
         raise AnsibleFilterError("host cannot be empty")
 
-    return [
-        "{}.{}".format(prefix, host) if prefix != "current" else host
-        for prefix in BLUE_GREEN_PREFIXES
-    ]
+    return ",".join(
+        [
+            "{}.{}".format(prefix, host) if prefix != "current" else host
+            for prefix in BLUE_GREEN_PREFIXES
+        ]
+    )
 
 
 # pylint: disable=no-self-use,too-few-public-methods

--- a/tests/units/plugins/filter/test_deploy.py
+++ b/tests/units/plugins/filter/test_deploy.py
@@ -67,5 +67,5 @@ class TestBlueGreenHostsFilter(unittest.TestCase):
         host = "foo.com"
 
         self.assertEqual(
-            blue_green_hosts(host), ["previous.foo.com", "foo.com", "next.foo.com"]
+            blue_green_hosts(host), "previous.foo.com,foo.com,next.foo.com"
         )


### PR DESCRIPTION
## Purpose

Current implementation of the `blue_green_hosts` filter returns a list (_e.g._ `["previous.foo.com", "foo.com", "next.foo.com"]`) that will be converted to a string once injected as a template variable (_e.g._ `'["previous.foo.com", "foo.com", "next.foo.com"]'`). This list cannot be easily parsed by applications loading this setting as an environment variable for example.

## Proposal

Make the `blue_green_hosts` filter return a string with comma-separated items (_e.g._ `"previous.foo.com,foo.com,next.foo.com"`). By doing so, if an environment variable is set with the returned value, most application will be able to extract host names easily.

This fixes Django's `ALLOWED_HOSTS` setting loaded _via_ an environment variable thanks to `django-configurations` (used in `marsha` and `richie` apps).
