### PR TITLE
Fix nginx configurations to work behind the TLS termination proxy

### DIFF
--- a/apps/edxapp/templates/nginx/_configs/cms.conf.j2
+++ b/apps/edxapp/templates/nginx/_configs/cms.conf.j2
@@ -17,10 +17,6 @@ server {
   server_tokens off;
 
   location @proxy_to_cms_app {
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Port $server_port;
-    proxy_set_header X-Forwarded-For $remote_addr;
-
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/apps/edxapp/templates/nginx/_configs/lms.conf.j2
+++ b/apps/edxapp/templates/nginx/_configs/lms.conf.j2
@@ -17,10 +17,6 @@ server {
   server_tokens off;
 
   location @proxy_to_lms_app {
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Port $server_port;
-    proxy_set_header X-Forwarded-For $remote_addr;
-
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/apps/marsha/templates/nginx/_configs/marsha.conf.j2
+++ b/apps/marsha/templates/nginx/_configs/marsha.conf.j2
@@ -14,10 +14,6 @@ server {
   server_tokens off;
 
   location @proxy_to_marsha_app {
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Port $server_port;
-    proxy_set_header X-Forwarded-For $remote_addr;
-
     proxy_set_header Host $http_host;
 
     proxy_redirect off;

--- a/apps/richie/templates/nginx/_configs/richie.conf.j2
+++ b/apps/richie/templates/nginx/_configs/richie.conf.j2
@@ -14,10 +14,6 @@ server {
   server_tokens off;
 
   location @proxy_to_richie_app {
-    proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_set_header X-Forwarded-Port $server_port;
-    proxy_set_header X-Forwarded-For $remote_addr;
-
     proxy_set_header Host $http_host;
 
     proxy_redirect off;


### PR DESCRIPTION
## Purpose

`Nginx` acts as a proxy and was overriding the value of the `X-Forwarded-` headers. The problem is that our applications are running in `OpenShift` behind a `HAProxy` that handles the TLS termination. This proxy has already set the `X-Forwarded-` headers with the values received from the client, so we should respect them and not override them with the values in the request hitting `Ǹginx` because they come from the `HAProxy`, not the client.

## Proposal

Stop overriding the `X-Forwarded-` headers in `Nginx`.