### PR TITLE
⚡️(dc) move imagePullPolicy to Always

### DIFF
--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -60,7 +60,7 @@ spec:
         # We point to a local registry image build for this "live" image (see
         # ImageStream and BuildConfig templates)
         image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-{{ service_variant }}:{{ edxapp_image_tag }}-live"
-        imagePullPolicy: IfNotPresent
+        imagePullPolicy: Always
         volumeMounts:
         - mountPath: /config
           name: edxapp-config
@@ -84,7 +84,7 @@ spec:
         # settings generation mecanism.
         - name: init-create-config
           image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - "/bin/bash"
             - "-c"

--- a/apps/edxapp/templates/cms/job_01_collectstatic.yml.j2
+++ b/apps/edxapp/templates/cms/job_01_collectstatic.yml.j2
@@ -56,7 +56,7 @@ spec:
         # https://openedx.atlassian.net/browse/OPEN-2411
         - name: init-create-config
           image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - "/bin/bash"
             - "-c"

--- a/apps/edxapp/templates/cms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/cms/job_04_db_migrate.yml.j2
@@ -21,22 +21,22 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:
-      - name: edxapp-cms-dbmigrate-{{ job_stamp }}
-        # We point to a local registry image build for this "live" image (see
-        # ImageStream and BuildConfig templates)
-        image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
-        env:
-          - name: DJANGO_SETTINGS_MODULE
-            value: cms.envs.fun.docker_run
-        command:
-          - "/bin/bash"
-          - "-c"
-          - DJANGO_SETTINGS_MODULE=cms.envs.fun.docker_run python manage.py cms migrate
-        volumeMounts:
-        - mountPath: /config
-          name: edxapp-config
-        - mountPath: /edx/var/edxapp/media
-          name: edxapp-v-media
+        - name: edxapp-cms-dbmigrate-{{ job_stamp }}
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: cms.envs.fun.docker_run
+          command:
+            - "/bin/bash"
+            - "-c"
+            - DJANGO_SETTINGS_MODULE=cms.envs.fun.docker_run python manage.py cms migrate
+          volumeMounts:
+            - mountPath: /config
+              name: edxapp-config
+            - mountPath: /edx/var/edxapp/media
+              name: edxapp-v-media
       initContainers:
         # This initContainer has nothing mounted on its "/config" directory. We
         # copy the content of its "/config" directory (fun-platform default
@@ -51,7 +51,7 @@ spec:
         # settings generation mecanism.
         - name: init-create-config
           image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - "/bin/bash"
             - "-c"
@@ -66,16 +66,16 @@ spec:
             - mountPath: /tmp/secret
               name: edxapp-secret
       volumes:
-      - name: edxapp-configmap-cms
-        configMap:
-          defaultMode: 420
-          name: edxapp-cms-{{ deployment_stamp }}
-      - name: edxapp-config
-        emptyDir: {}  # volume that lives as long as the pod lives
-      - name: edxapp-secret
-        secret:
-          secretName: "{{ edxapp_secret_name }}"
-      - name: edxapp-v-media
-        persistentVolumeClaim:
-          claimName: edxapp-pvc-media
+        - name: edxapp-configmap-cms
+          configMap:
+            defaultMode: 420
+            name: edxapp-cms-{{ deployment_stamp }}
+        - name: edxapp-config
+          emptyDir: {} # volume that lives as long as the pod lives
+        - name: edxapp-secret
+          secret:
+            secretName: "{{ edxapp_secret_name }}"
+        - name: edxapp-v-media
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-media
       restartPolicy: Never

--- a/apps/edxapp/templates/cms/job_05_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/cms/job_05_load_fixtures.yml.j2
@@ -63,7 +63,7 @@ spec:
         # settings generation mecanism.
         - name: init-create-config
           image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - "/bin/bash"
             - "-c"

--- a/apps/edxapp/templates/lms/job_02_collectstatic.yml.j2
+++ b/apps/edxapp/templates/lms/job_02_collectstatic.yml.j2
@@ -56,7 +56,7 @@ spec:
         # https://openedx.atlassian.net/browse/OPEN-2411
         - name: init-create-config
           image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - "/bin/bash"
             - "-c"

--- a/apps/edxapp/templates/lms/job_03_db_migrate.yml.j2
+++ b/apps/edxapp/templates/lms/job_03_db_migrate.yml.j2
@@ -21,22 +21,22 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:
-      - name: edxapp-lms-dbmigrate-{{ job_stamp }}
-        # We point to a local registry image build for this "live" image (see
-        # ImageStream and BuildConfig templates)
-        image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-lms:{{ edxapp_image_tag }}-live"
-        env:
-          - name: DJANGO_SETTINGS_MODULE
-            value: lms.envs.fun.docker_run
-        command:
-          - "/bin/bash"
-          - "-c"
-          - DJANGO_SETTINGS_MODULE=lms.envs.fun.docker_run python manage.py lms migrate
-        volumeMounts:
-        - mountPath: /config
-          name: edxapp-config
-        - mountPath: /edx/var/edxapp/media
-          name: edxapp-v-media
+        - name: edxapp-lms-dbmigrate-{{ job_stamp }}
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-lms:{{ edxapp_image_tag }}-live"
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: lms.envs.fun.docker_run
+          command:
+            - "/bin/bash"
+            - "-c"
+            - DJANGO_SETTINGS_MODULE=lms.envs.fun.docker_run python manage.py lms migrate
+          volumeMounts:
+            - mountPath: /config
+              name: edxapp-config
+            - mountPath: /edx/var/edxapp/media
+              name: edxapp-v-media
       initContainers:
         # This initContainer has nothing mounted on its "/config" directory. We
         # copy the content of its "/config" directory (fun-platform default
@@ -51,7 +51,7 @@ spec:
         # settings generation mecanism.
         - name: init-create-config
           image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           command:
             - "/bin/bash"
             - "-c"
@@ -66,16 +66,16 @@ spec:
             - mountPath: /tmp/secret
               name: edxapp-secret
       volumes:
-      - name: edxapp-configmap-lms
-        configMap:
-          defaultMode: 420
-          name: edxapp-lms-{{ deployment_stamp }}
-      - name: edxapp-config
-        emptyDir: {}  # volume that lives as long as the pod lives
-      - name: edxapp-secret
-        secret:
-          secretName: "{{ edxapp_secret_name }}"
-      - name: edxapp-v-media
-        persistentVolumeClaim:
-          claimName: edxapp-pvc-media
+        - name: edxapp-configmap-lms
+          configMap:
+            defaultMode: 420
+            name: edxapp-lms-{{ deployment_stamp }}
+        - name: edxapp-config
+          emptyDir: {} # volume that lives as long as the pod lives
+        - name: edxapp-secret
+          secret:
+            secretName: "{{ edxapp_secret_name }}"
+        - name: edxapp-v-media
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-media
       restartPolicy: Never

--- a/apps/forum/templates/app/dc.yml.j2
+++ b/apps/forum/templates/app/dc.yml.j2
@@ -24,7 +24,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/forum:{{ forum_image_tag }}-live"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           ports:
             - containerPort: "{{ forum_port }}"
               protocol: TCP

--- a/apps/hello/templates/app/dc.yml.j2
+++ b/apps/hello/templates/app/dc.yml.j2
@@ -7,7 +7,7 @@ metadata:
   name: "hello-app-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1  # number of pods we want
+  replicas: 1 # number of pods we want
   template:
     metadata:
       labels:
@@ -16,26 +16,26 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:
-      - name: hello-openshift
-        image: openshift/hello-openshift
-        ports:
-        - containerPort: 8080
-          protocol: TCP
-        env:
-          - name: RESPONSE
-            value: "{{ hello_app_msg }} - {{ deployment_stamp }}"
-        resources: {}
-        volumeMounts:
-        - name: tmp
-          mountPath: "/tmp"
-        terminationMessagePath: "/dev/termination-log"
-        imagePullPolicy: IfNotPresent
-        capabilities: {}
-        securityContext:
+        - name: hello-openshift
+          image: openshift/hello-openshift
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+          env:
+            - name: RESPONSE
+              value: "{{ hello_app_msg }} - {{ deployment_stamp }}"
+          resources: {}
+          volumeMounts:
+            - name: tmp
+              mountPath: "/tmp"
+          terminationMessagePath: "/dev/termination-log"
+          imagePullPolicy: Always
           capabilities: {}
-          privileged: false
+          securityContext:
+            capabilities: {}
+            privileged: false
       volumes:
-      - name: tmp
-        emptyDir: {}
+        - name: tmp
+          emptyDir: {}
       restartPolicy: Always
       dnsPolicy: ClusterFirst

--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -24,7 +24,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/marsha:{{ marsha_image_tag }}-live"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: marsha.settings

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -24,7 +24,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: richie.settings


### PR DESCRIPTION
## Purpose

By relying on the `ifNotPresent` image pull policy, we aren't sure which image version will be deployed if we've just built and pushed target image (with the same name and tag).

## Proposal

- [x] Switch to the `Always` image pull policy to ensure local image is up-to-date

Note: We've also fixed indentation for some deployment configurations.
