### PR TITLE
✨(security) add http basic auth for app services

### DIFF
--- a/apps/edxapp/templates/nginx/_configs/cms.conf.j2
+++ b/apps/edxapp/templates/nginx/_configs/cms.conf.j2
@@ -6,6 +6,11 @@ server {
   listen {{ edxapp_nginx_cms_port }};
   server_name localhost;
 
+  {% if activate_http_basic_auth -%}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+  {% endif %}
+
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P 'CP="Open edX does not have a P3P policy."';
 

--- a/apps/edxapp/templates/nginx/_configs/lms.conf.j2
+++ b/apps/edxapp/templates/nginx/_configs/lms.conf.j2
@@ -6,6 +6,11 @@ server {
   listen {{ edxapp_nginx_lms_port }};
   server_name localhost;
 
+  {% if activate_http_basic_auth -%}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+  {% endif %}
+
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P 'CP="Open edX does not have a P3P policy."';
 

--- a/apps/edxapp/templates/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/nginx/dc.yml.j2
@@ -20,28 +20,38 @@ spec:
         deploymentconfig: "edxapp-nginx-{{ deployment_stamp }}"
     spec:
       containers:
-      - image: "{{ edxapp_nginx_image_name }}:{{ edxapp_nginx_image_tag }}"
-        name: nginx
-        ports:
-        - containerPort: 80
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /etc/nginx/conf.d
-          name: edxapp-v-nginx
-          readOnly: true
-        - mountPath: /data/media
-          name: edxapp-v-media
-          readOnly: true
-        - mountPath: /data/static
-          name: edxapp-v-static
-          readOnly: true
+        - image: "{{ edxapp_nginx_image_name }}:{{ edxapp_nginx_image_tag }}"
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: edxapp-v-nginx
+              readOnly: true
+            - mountPath: /data/media
+              name: edxapp-v-media
+              readOnly: true
+            - mountPath: /data/static
+              name: edxapp-v-static
+              readOnly: true
+            {% if activate_http_basic_auth -%}
+            - mountPath: "{{ http_basic_auth_user_file | dirname }}"
+              name: edxapp-htpasswd
+            {% endif %}
+
       volumes:
-      - name: edxapp-v-nginx
-        configMap:
-          name: "edxapp-nginx-{{ deployment_stamp }}"
-      - name: edxapp-v-static
-        persistentVolumeClaim:
-          claimName: edxapp-pvc-static
-      - name: edxapp-v-media
-        persistentVolumeClaim:
-          claimName: edxapp-pvc-media
+        - name: edxapp-v-nginx
+          configMap:
+            name: "edxapp-nginx-{{ deployment_stamp }}"
+        - name: edxapp-v-static
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-static
+        - name: edxapp-v-media
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-media
+        {% if activate_http_basic_auth -%}
+        - name: edxapp-htpasswd
+          secret:
+            secretName: "{{ edxapp_nginx_htpasswd_secret_name }}"
+        {% endif %}

--- a/apps/edxapp/templates/nginx/secret.yml.j2
+++ b/apps/edxapp/templates/nginx/secret.yml.j2
@@ -1,0 +1,14 @@
+{% if activate_http_basic_auth %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: edxapp
+    service: "nginx"
+  name: "{{ edxapp_nginx_htpasswd_secret_name }}"
+  namespace: "{{ project_name }}"
+data:
+  # nota bene: the {{ app.name }}_htpasswd variable is set in
+  # tasks/get_vault_for_app.yml tasks list only if the pointed file exists
+  "{{ http_basic_auth_user_file | basename }}": "{{ lookup('file', edxapp_htpasswd) | b64encode }}"
+{% endif %}

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -57,6 +57,7 @@ edxapp_nginx_image_name: "fundocker/openshift-nginx"
 edxapp_nginx_image_tag: "1.13"
 edxapp_nginx_cms_port: 8081
 edxapp_nginx_lms_port: 8071
+edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
 
 # -- celery/redis
 edxapp_celery_lms_high_priority_queue: "edx.lms.core.high"

--- a/apps/marsha/templates/nginx/_configs/marsha.conf.j2
+++ b/apps/marsha/templates/nginx/_configs/marsha.conf.j2
@@ -6,6 +6,11 @@ server {
   listen {{ marsha_nginx_port }};
   server_name localhost;
 
+  {% if activate_http_basic_auth -%}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+  {% endif %}
+
   client_max_body_size 100M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;

--- a/apps/marsha/templates/nginx/dc.yml.j2
+++ b/apps/marsha/templates/nginx/dc.yml.j2
@@ -20,28 +20,38 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:
-      - image: "{{ marsha_nginx_image_name }}:{{ marsha_nginx_image_tag }}"
-        name: nginx
-        ports:
-        - containerPort: 80
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /etc/nginx/conf.d
-          name: marsha-v-nginx
-          readOnly: true
-        - mountPath: /data/media/marsha
-          name: marsha-v-media
-          readOnly: true
-        - mountPath: /data/static/marsha
-          name: marsha-v-static
-          readOnly: true
+        - image: "{{ marsha_nginx_image_name }}:{{ marsha_nginx_image_tag }}"
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: marsha-v-nginx
+              readOnly: true
+            - mountPath: /data/media/marsha
+              name: marsha-v-media
+              readOnly: true
+            - mountPath: /data/static/marsha
+              name: marsha-v-static
+              readOnly: true
+            {% if activate_http_basic_auth -%}
+            - mountPath: "{{ http_basic_auth_user_file | dirname }}"
+              name: marsha-htpasswd
+            {% endif %}
+
       volumes:
-      - name: marsha-v-nginx
-        configMap:
-          name: marsha-nginx-{{ deployment_stamp }}
-      - name: marsha-v-media
-        persistentVolumeClaim:
-          claimName: marsha-pvc-media
-      - name: marsha-v-static
-        persistentVolumeClaim:
-          claimName: marsha-pvc-static
+        - name: marsha-v-nginx
+          configMap:
+            name: marsha-nginx-{{ deployment_stamp }}
+        - name: marsha-v-media
+          persistentVolumeClaim:
+            claimName: marsha-pvc-media
+        - name: marsha-v-static
+          persistentVolumeClaim:
+            claimName: marsha-pvc-static
+        {% if activate_http_basic_auth -%}
+        - name: marsha-htpasswd
+          secret:
+            secretName: "{{ marsha_nginx_htpasswd_secret_name }}"
+        {% endif %}

--- a/apps/marsha/templates/nginx/secret.yml.j2
+++ b/apps/marsha/templates/nginx/secret.yml.j2
@@ -1,0 +1,14 @@
+{% if activate_http_basic_auth %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: marsha
+    service: "nginx"
+  name: "{{ marsha_nginx_htpasswd_secret_name }}"
+  namespace: "{{ project_name }}"
+data:
+  # nota bene: the {{ app.name }}_htpasswd variable is set in
+  # tasks/get_vault_for_app.yml tasks list only if the pointed file exists
+  "{{ http_basic_auth_user_file | basename }}": "{{ lookup('file', marsha_htpasswd) | b64encode }}"
+{% endif %}

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -7,6 +7,7 @@ marsha_host: "marsha.{{ project_name}}.{{ domain_name }}"
 marsha_nginx_image_name: "fundocker/openshift-nginx"
 marsha_nginx_image_tag: "1.13"
 marsha_nginx_port: 8061
+marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 
 # -- postgresql
 marsha_postgresql_image_name: "centos/postgresql-96-centos7"

--- a/apps/richie/templates/nginx/_configs/richie.conf.j2
+++ b/apps/richie/templates/nginx/_configs/richie.conf.j2
@@ -6,6 +6,11 @@ server {
   listen {{ richie_nginx_port }};
   server_name localhost;
 
+  {% if activate_http_basic_auth -%}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+  {% endif %}
+
   client_max_body_size 100M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;

--- a/apps/richie/templates/nginx/dc.yml.j2
+++ b/apps/richie/templates/nginx/dc.yml.j2
@@ -20,28 +20,38 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:
-      - image: "{{ richie_nginx_image_name }}:{{ richie_nginx_image_tag }}"
-        name: nginx
-        ports:
-        - containerPort: 80
-          protocol: TCP
-        volumeMounts:
-        - mountPath: /etc/nginx/conf.d
-          name: richie-v-nginx
-          readOnly: true
-        - mountPath: /data/media/richie
-          name: richie-v-media
-          readOnly: true
-        - mountPath: /data/static/richie
-          name: richie-v-static
-          readOnly: true
+        - image: "{{ richie_nginx_image_name }}:{{ richie_nginx_image_tag }}"
+          name: nginx
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /etc/nginx/conf.d
+              name: richie-v-nginx
+              readOnly: true
+            - mountPath: /data/media/richie
+              name: richie-v-media
+              readOnly: true
+            - mountPath: /data/static/richie
+              name: richie-v-static
+              readOnly: true
+            {% if activate_http_basic_auth -%}
+            - mountPath: "{{ http_basic_auth_user_file | dirname }}"
+              name: richie-htpasswd
+            {% endif %}
+
       volumes:
-      - name: richie-v-nginx
-        configMap:
-          name: richie-nginx-{{ deployment_stamp }}
-      - name: richie-v-media
-        persistentVolumeClaim:
-          claimName: richie-pvc-media
-      - name: richie-v-static
-        persistentVolumeClaim:
-          claimName: richie-pvc-static
+        - name: richie-v-nginx
+          configMap:
+            name: richie-nginx-{{ deployment_stamp }}
+        - name: richie-v-media
+          persistentVolumeClaim:
+            claimName: richie-pvc-media
+        - name: richie-v-static
+          persistentVolumeClaim:
+            claimName: richie-pvc-static
+        {% if activate_http_basic_auth -%}
+        - name: richie-htpasswd
+          secret:
+            secretName: "{{ richie_nginx_htpasswd_secret_name }}"
+        {% endif %}

--- a/apps/richie/templates/nginx/secret.yml.j2
+++ b/apps/richie/templates/nginx/secret.yml.j2
@@ -1,0 +1,14 @@
+{% if activate_http_basic_auth %}
+apiVersion: v1
+kind: Secret
+metadata:
+  labels:
+    app: richie
+    service: "nginx"
+  name: "{{ richie_nginx_htpasswd_secret_name }}"
+  namespace: "{{ project_name }}"
+data:
+  # nota bene: the {{ app.name }}_htpasswd variable is set in
+  # tasks/get_vault_for_app.yml tasks list only if the pointed file exists
+  "{{ http_basic_auth_user_file | basename }}": "{{ lookup('file', richie_htpasswd) | b64encode }}"
+{% endif %}

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -7,6 +7,7 @@ richie_host: "richie.{{ project_name}}.{{ domain_name }}"
 richie_nginx_image_name: "fundocker/openshift-nginx"
 richie_nginx_image_tag: "1.13"
 richie_nginx_port: 8061
+richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 
 # -- elasticsearch
 richie_elasticsearch_image_name: "fundocker/openshift-elasticsearch"

--- a/create_htpasswds.yml
+++ b/create_htpasswds.yml
@@ -1,0 +1,16 @@
+- hosts: local
+  gather_facts: False
+
+  tasks:
+    - name: Display playbook name
+      debug: msg="==== Starting create_htpasswds playbook ===="
+      tags: deploy
+
+    - import_tasks: tasks/set_vars.yml
+
+    - include_tasks: tasks/run_tasks_for_apps.yml
+      vars:
+        tasks:
+          - tasks/create_app_htpasswd
+      tags:
+        - secret

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -67,6 +67,19 @@ acme_env: staging
 # "true"
 has_acme_cluster_role: false
 
+# Expected vault path
+vault_path: "group_vars/customer/{{ customer }}/{{ env_type }}/secrets"
+
+# Protect public services behind HTTP basic authentication
+activate_http_basic_auth: false
+# The message that will be displayed by the client browser
+http_basic_auth_message: "Restricted Area"
+# htpasswd absolute or relative path (relative to nginx configuration)
+http_basic_auth_user_file: "/etc/nginx/conf/htpasswd"
+http_basic_auth_users:
+  - "admin"
+  - "{{ customer }}-admin"
+
 # TODO: move the following settings to the redirect app
 # Ports
 aliases_port: 8999

--- a/init_project.yml
+++ b/init_project.yml
@@ -1,6 +1,6 @@
----
-
 - import_playbook: create_project.yml
+- import_playbook: create_htpasswds.yml
+  when: activate_http_basic_auth
 - import_playbook: create_secrets.yml
 - import_playbook: create_acme.yml
 
@@ -13,7 +13,6 @@
       tags: deploy
 
     - import_tasks: tasks/set_vars.yml
-
 
     - import_tasks: tasks/create_route_aliases.yml
 

--- a/requirements/pip-requirements.txt
+++ b/requirements/pip-requirements.txt
@@ -4,6 +4,7 @@ ansible-lint==3.4.22
 deepmerge==0.0.4
 jmespath==0.9.3
 openshift==0.4.4
+passlib==1.7.1
 
 # Quality
 flake8

--- a/tasks/create_app_htpasswd.yml
+++ b/tasks/create_app_htpasswd.yml
@@ -1,0 +1,58 @@
+- name: Print "create_app_htpasswd" tasks header
+  debug:
+    msg: "Will create htpasswd for app {{ app.name }}"
+  tags:
+    - secret
+    - htpasswd
+
+- name: Set basic auth user password files
+  set_fact:
+    user: "{{ item }}"
+    path: "{{ app_htpasswd_file_path | dirname + '/' + item }}"
+  with_items: "{{ http_basic_auth_users }}"
+  register: http_basic_auth_user_passwords
+  tags:
+    - secret
+    - htpasswd
+
+- name: Display http_basic_auth_user_passwords
+  debug:
+    msg: "{{ http_basic_auth_user_passwords | json_query('results[*].ansible_facts') | list | to_nice_yaml }}"
+    verbosity: 3
+  tags:
+    - secret
+    - htpasswd
+
+# Create a htpasswd encrypted file with random passwords for users. Password
+# files are generated plain text by default. They will be encrypted in the next
+# step. If the htpasswd file (or user password files) already exists it won't be
+# updated but left as is.
+- name: Create htpasswd file
+  htpasswd:
+    path: "{{ app_htpasswd_file_path }}"
+    name: "{{ item.user }}"
+    password: "{{ lookup('password', item.path) }}"
+  with_items: "{{ http_basic_auth_user_passwords | json_query('results[*].ansible_facts') }}"
+  tags:
+    - secret
+    - htpasswd
+
+# Look for the $ANSIBLE_VAULT header in ansible vaults. If it cannot be found,
+# then the password file needs to be encrypted. We ignore errors as the `grep`
+# command exit code may not be zero if the pattern has been found (already
+# encrypted file case).
+- name: Check htpasswd users password file encryption
+  shell: "head -n 1 {{ item }} | grep -q -v '$ANSIBLE_VAULT'"
+  ignore_errors: True
+  no_log: True
+  with_items: "{{ http_basic_auth_user_passwords | json_query('results[*].ansible_facts.path') | list }}"
+  register: http_basic_auth_user_passwords_encryption_check
+
+# Only encrypt plain text password files, e.g. files with no $ANSIBLE_VAULT
+# header (the exit code of the previous grep command should be 0).
+- name: Encrypt basic auth users password file
+  command: ansible-vault encrypt {{ item }}
+  with_items: "{{ http_basic_auth_user_passwords_encryption_check | json_query('results[?rc == `0`].item') | list }}"
+  tags:
+    - secret
+    - htpasswd

--- a/tasks/get_vault_for_app.yml
+++ b/tasks/get_vault_for_app.yml
@@ -3,7 +3,7 @@
 # group_vars for an environent and a customer.
 - name: Get expected vault file for application
   stat:
-    path: "group_vars/customer/{{ customer }}/{{ env_type }}/secrets/{{ app.name }}.vault.yml"
+    path: "{{ vault_path }}/{{ app.name }}.vault.yml"
   register: app_vault
 
 # If the vault exists for this app, store its checksum (sha1).
@@ -18,4 +18,23 @@
   set_fact:
     "{{ app.name }}_vault": "{{ app_vault }}"
     "{{ app.name }}_vault_checksum": "{{ app_vault_checksum }}"
+  # Only set those variables when the vault file exists and is a regular file
   when: app_vault.stat.exists and app_vault.stat.isreg
+
+- name: Set htpasswd target file name for app
+  set_fact:
+    app_htpasswd_file_path: "{{ vault_path }}/htpasswd/{{ app.name }}/{{ http_basic_auth_user_file | basename }}"
+  tags: htpasswd
+
+- name: Test htpasswd target file for app
+  stat:
+    path: "{{ app_htpasswd_file_path }}"
+  register: app_htpasswd_file
+  tags: htpasswd
+
+- name: Set application htpasswd variable
+  set_fact:
+    "{{ app.name }}_htpasswd": "{{ app_htpasswd_file.stat.path }}"
+  # Only set this variable when the htpasswd file exists and is a regular file
+  when: activate_http_basic_auth and app_htpasswd_file.stat.exists and app_htpasswd_file.stat.isreg
+  tags: htpasswd


### PR DESCRIPTION
## Purpose

In some cases, we must be able to protect a publicly deployed service behind an HTTP Basic Auth, _e.g._ to prevent search engines bots crawling or restrict access to a confidential application instance.

## Proposal

- [x] automate htpasswd file generation for apps
- [x] integrate HTTP Basic Auth for `richie`
- [x] integrate HTTP Basic Auth for `marsha`
- [x] integrate HTTP Basic Auth for `edxapp`