### PR TITLE
Add missing secret update state shared secrets to marsha

### DIFF
--- a/apps/marsha/templates/app/secret.yml.j2
+++ b/apps/marsha/templates/app/secret.yml.j2
@@ -11,6 +11,7 @@ data:
   POSTGRES_PASSWORD: "{{ POSTGRESQL_PASSWORD | default('password') | b64encode }}"
   DJANGO_AWS_ACCESS_KEY_ID: "{{ DJANGO_AWS_ACCESS_KEY_ID | default('secret') | b64encode }}"
   DJANGO_AWS_SECRET_ACCESS_KEY: "{{ DJANGO_AWS_SECRET_ACCESS_KEY | default('secret') | b64encode }}"
+  DJANGO_UPDATE_STATE_SHARED_SECRETS: "{{ DJANGO_UPDATE_STATE_SHARED_SECRETS | default('secret') | b64encode }}"
   DJANGO_CLOUDFRONT_ACCESS_KEY_ID: "{{ DJANGO_CLOUDFRONT_ACCESS_KEY_ID | default('secret') | b64encode }}"
   DJANGO_CLOUDFRONT_URL: "{{ DJANGO_CLOUDFRONT_URL | default('https://foo.com') | b64encode }}"
   DJANGO_JWT_SIGNING_KEY: "{{ DJANGO_JWT_SIGNING_KEY | default('secret') | b64encode }}"

--- a/requirements/pip-requirements.txt
+++ b/requirements/pip-requirements.txt
@@ -12,5 +12,5 @@ isort
 pylint
 
 # Tests
-pytest
+pytest<4
 pytest-coverage


### PR DESCRIPTION
## Purpose

This secret is necessary for the AWS lambda `lambda-update-state` to call Django and update the status of the video. It was forgotten because it was not [properly documented in `Marsha`](https://github.com/openfun/marsha/blob/master/docs/env.md#django_update_state_shared_secrets) until recently.

We need to add this secret in `Arnold` before we can set its value in our vaults in `Matsuo`.

## Proposal

Add it the `DJANGO_UPDATE_STATE_SHARED_SECRETS` key to secrets in `Marsha`.


