### PR TITLE
Inject the edxapp image tag as a RELEASE environment variable

### DIFF
--- a/apps/edxapp/templates/cms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/cms/_configs/settings.yml.j2
@@ -5,6 +5,8 @@ PLATFORM_NAME: "{{ customer }}"
 LMS_BASE: "{{ edxapp_lms_host }}"
 CMS_BASE: "{{ edxapp_cms_host }}"
 
+RELEASE: {{ edxapp_image_tag }}
+
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis
 CELERY_BROKER_HOST: redis

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -5,6 +5,8 @@ PLATFORM_NAME: "{{ customer }}"
 LMS_BASE: "{{ edxapp_lms_host }}"
 CMS_BASE: "{{ edxapp_cms_host }}"
 
+RELEASE: {{ edxapp_image_tag }}
+
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis
 CELERY_BROKER_HOST: redis


### PR DESCRIPTION
## Purpose

Injecting the edxapp image tag as environment variable allow us to access it in edxapp settings. For example, the new version of [openedx-docker](https://github.com/openfun/openedx-docker) hawthorn.1-oee-2.0.3 is using it to improve Sentry logs.

## Proposal

Add a RELEASE entry in the settings.yml file of the LMS and CMS and set it to the `edxapp_image_tag` variable.