### PR TITLE
🐛(forum) add missing tls-acme annotation in route

### DIFF
--- a/apps/forum/templates/app/route.yml.j2
+++ b/apps/forum/templates/app/route.yml.j2
@@ -12,6 +12,8 @@ metadata:
     deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
+  annotations:
+    kubernetes.io/tls-acme: "true"
 spec:
   host: "{{ forum_host | blue_green_host(prefix) }}"
   tls:


### PR DESCRIPTION
## Purpose

The forum application's route is never patched with an associated SSL certificate.

## Proposal

- [x] add the `kubernetes.io/tls-acme: "true"` annotation so that OpenShift ACME's Service Account knows that it must generate an SSL certificate for this route.