### PR TITLE
🔥(oc) remove oc client in arnold's image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,12 +143,6 @@ jobs:
       - *docker_load
       - *ci_env
       - run:
-          name: Test oc client installation
-          command: |
-            docker run --rm \
-              "${ARNOLD_IMAGE}" \
-              oc version
-      - run:
           name: Test ansible installation
           command: |
             docker run --rm \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,6 @@ RUN apt-get update && \
     unzip && \
     rm -rf /var/lib/apt/lists/*
 
-# Install OpenShift client
-ENV OC_VERSION=v3.9.0 \
-    OC_TAG_SHA=191fece
-
-RUN curl -sLo /tmp/oc.tar.gz "https://github.com/openshift/origin/releases/download/${OC_VERSION}/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG_SHA}-linux-64bit.tar.gz" && \
-    tar xzvf /tmp/oc.tar.gz -C /tmp/ && \
-    mv "/tmp/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG_SHA}-linux-64bit/oc" /usr/local/bin/ && \
-    rm -rf /tmp/oc.tar.gz "/tmp/openshift-origin-client-tools-${OC_VERSION}-${OC_TAG_SHA}-linux-64bit"
-
 COPY ./requirements/pip-requirements.txt /app/requirements/
 RUN pip install -r /app/requirements/pip-requirements.txt
 

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -86,6 +86,7 @@ function _docker_run() {
         --env K8S_AUTH_HOST \
         --env OPENSHIFT_DOMAIN \
         -v "$PWD:/app" \
+        -v "$HOME/.kube:/home/arnold/.kube" \
         "arnold:$(tr -d '\n' < VERSION)" \
         "${args[@]}"
 }

--- a/bin/ci-bootstrap
+++ b/bin/ci-bootstrap
@@ -9,9 +9,11 @@ app="${1:-hello}"
 # Run the bootstrap.yml playbook with the ansible vault password
 # passed to stdin
 echo "arnold" | docker run --rm -i \
+  -u "$(id -u)" \
   --env-file env.d/ci \
   --env K8S_AUTH_API_KEY \
   --env K8S_AUTH_HOST \
   --env OPENSHIFT_DOMAIN \
+  -v "$HOME/.kube:/home/arnold/.kube" \
   "arnold:$(tr -d '\n' < VERSION)" \
     ansible-playbook bootstrap.yml --ask-vault-pass -e "env_type=ci" -e "apps_filter=${app}"

--- a/bin/entrypoint
+++ b/bin/entrypoint
@@ -6,31 +6,12 @@
 # container to create an entry for this user in the /etc/passwd file.
 export HOME=/home/arnold
 
-oc_login() {
-  # Login to OpenShift to create configuration files in the container itself
-  echo "******************************************************************"
-  echo "Using OpenShift server: ${K8S_AUTH_HOST}"
-
-  login_options=""
-  if [[ ${INSECURE_SKIP_TLS_VERIFY} -eq 1 ]]; then
-      login_options="--insecure-skip-tls-verify=true"
-  fi
-
-  oc login "${K8S_AUTH_HOST}" --token="${K8S_AUTH_API_KEY}" ${login_options}
-  echo "******************************************************************"
-}
-
 # Create docker user as defined in the Dockerfile (see USER statement) or
 # overriden by the `--user` option of `docker run`
 if ! whoami &> /dev/null; then
   if [[ -w /etc/passwd ]]; then
     echo "app:x:$(id -u):0:Arnold's App:${HOME}:/sbin/nologin" >> /etc/passwd
   fi
-fi
-
-# Login to OpenShift only if $K8S_AUTH_HOST is defined
-if [[ ! -z ${K8S_AUTH_HOST} ]]; then
-  oc_login
 fi
 
 exec "${@}"


### PR DESCRIPTION
## Purpose

Installing oc in arnold's docker image seemed a pretty good idea, as docker would have been the only requirement for Arnold. Unfortunately, oc stores a lot of data in the user space, and, thus we never used it.

Fixes #107 

## Proposal

Remove the oc client installation in Dockerfile and its usage in `entrypoint`. We also need to share the `$HOME/.kube` folder in the container to share context and config.

