### PR TITLE
🐛(htpasswd) generate htpassword when multiple apps are active

### DIFF
--- a/tasks/create_app_htpasswd.yml
+++ b/tasks/create_app_htpasswd.yml
@@ -5,6 +5,8 @@
     - secret
     - htpasswd
 
+- include_tasks: tasks/set_htpasswd_path_for_app.yml
+
 - name: Set basic auth user password files
   set_fact:
     user: "{{ item }}"

--- a/tasks/get_vault_for_app.yml
+++ b/tasks/get_vault_for_app.yml
@@ -21,10 +21,7 @@
   # Only set those variables when the vault file exists and is a regular file
   when: app_vault.stat.exists and app_vault.stat.isreg
 
-- name: Set htpasswd target file name for app
-  set_fact:
-    app_htpasswd_file_path: "{{ vault_path }}/htpasswd/{{ app.name }}/{{ http_basic_auth_user_file | basename }}"
-  tags: htpasswd
+- include_tasks: tasks/set_htpasswd_path_for_app.yml
 
 - name: Test htpasswd target file for app
   stat:

--- a/tasks/set_htpasswd_path_for_app.yml
+++ b/tasks/set_htpasswd_path_for_app.yml
@@ -1,0 +1,4 @@
+- name: Set htpasswd target file name for app
+  set_fact:
+    app_htpasswd_file_path: "{{ vault_path }}/htpasswd/{{ app.name }}/{{ http_basic_auth_user_file | basename }}"
+  tags: htpasswd


### PR DESCRIPTION
## Purpose

When multiple apps are activated, only the last app treated in the
set_vars.yml task had htpasswd created. This is because the variable
containing the htpasswd path is itself in apps loop. 

Fixes #155 

## Proposal

extract the task computing the htpasswd path in a standalone task and import it everywhere we need it.
