### PR TITLE
🐛(edxapp) ignore fixture-jobs for non-trashable envs

### DIFF
--- a/apps/edxapp/templates/cms/job_05_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/cms/job_05_load_fixtures.yml.j2
@@ -1,3 +1,4 @@
+{% if env_type in trashable_env_types %}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -98,3 +99,4 @@ spec:
           persistentVolumeClaim:
             claimName: edxapp-pvc-data
       restartPolicy: Never
+{% endif %}

--- a/apps/edxapp/templates/mysql/job_00_load_sql_dump.yml.j2
+++ b/apps/edxapp/templates/mysql/job_00_load_sql_dump.yml.j2
@@ -1,3 +1,4 @@
+{% if env_type in trashable_env_types %}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -37,3 +38,4 @@ spec:
               --password=${MYSQL_PASSWORD}
               ${MYSQL_DATABASE} < edx-database.sql
       restartPolicy: Never
+{% endif %}


### PR DESCRIPTION
## Purpose

When deploying `edxapp` to environments that require data persistency, we certainly don't want to reset databases or load test fixtures.

## Proposal

Hence, we ignore edxapp MySQL dump and load fixtures jobs in staging, pre-production and production.
