### PR TITLE
🔥(dc) remove deployment_stamp label for non blue-green deployments

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -193,7 +193,7 @@ jobs:
           name: Test the "mailcatcher" application bootstrapping
           command: |
             bin/ci-bootstrap "mailcatcher"
-            bin/ci-test-service "mailcatcher" "MailCatcher"
+            bin/ci-test-service "mailcatcher" "MailCatcher" "/" ""
 
   # Test the bootstrap playbook on the "richie" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.

--- a/apps/mailcatcher/templates/app/dc.yml.j2
+++ b/apps/mailcatcher/templates/app/dc.yml.j2
@@ -5,7 +5,6 @@ metadata:
     app: mailcatcher
     service: app
     version: "{{ mailcatcher_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
   name: "mailcatcher-app"
   namespace: "{{ project_name }}"
 spec:
@@ -16,7 +15,6 @@ spec:
         app: mailcatcher
         service: app
         version: "{{ mailcatcher_image_tag }}"
-        deployment_stamp: "{{ deployment_stamp }}"
         deploymentconfig: "mailcatcher-app"
     spec:
       containers:

--- a/apps/mailcatcher/templates/app/route.yml.j2
+++ b/apps/mailcatcher/templates/app/route.yml.j2
@@ -2,18 +2,16 @@ apiVersion: v1
 kind: Route
 metadata:
   namespace: "{{ project_name }}"
-  name: "mailcatcher-{{ prefix }}"
+  name: "mailcatcher"
   labels:
     env_type: "{{ env_type }}"
     customer: "{{ customer }}"
     app: "mailcatcher"
     service: "app"
     version: "{{ mailcatcher_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
-    route_prefix: "{{ prefix }}"
     route_target_service: "app"
 spec:
-  host: "{{ mailcatcher_host | blue_green_host(prefix) }}"
+  host: "{{ mailcatcher_host }}"
   tls:
     termination: edge
     insecureEdgeTerminationPolicy: Redirect

--- a/apps/mailcatcher/templates/app/svc.yml.j2
+++ b/apps/mailcatcher/templates/app/svc.yml.j2
@@ -5,7 +5,6 @@ metadata:
     app: mailcatcher
     service: app
     version: "{{ mailcatcher_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
   name: "mailcatcher"
   namespace: "{{ project_name }}"
 spec:

--- a/apps/mailcatcher/vars/settings.yml
+++ b/apps/mailcatcher/vars/settings.yml
@@ -1,0 +1,1 @@
+is_blue_green_compatible: False

--- a/apps/redis/templates/app/dc.yml.j2
+++ b/apps/redis/templates/app/dc.yml.j2
@@ -5,7 +5,6 @@ metadata:
     app: redis
     service: app
     version: "{{ redis_app_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
   name: redis-app
   namespace: "{{ project_name }}"
 spec:
@@ -21,7 +20,6 @@ spec:
         app: redis
         service: app
         version: "{{ redis_app_image_tag }}"
-        deployment_stamp: "{{ deployment_stamp }}"
         deploymentconfig: redis-app
     spec:
       containers:

--- a/apps/redis/templates/app/svc.yml.j2
+++ b/apps/redis/templates/app/svc.yml.j2
@@ -5,7 +5,6 @@ metadata:
     app: redis
     service: app
     version: "{{ redis_app_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
   # name of the service should be host name in edxapp configuration
   name: redis
   namespace: "{{ project_name }}"

--- a/apps/redis/vars/settings.yml
+++ b/apps/redis/vars/settings.yml
@@ -1,0 +1,1 @@
+is_blue_green_compatible: False

--- a/bin/ci-test-service
+++ b/bin/ci-test-service
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
 # usage: ci-test-service [SERVICE] [CONTENT] [PATH]
-
+set -x
 # First script argument is the application's service name. It defaults to
 # 'hello'
 service="${1:-hello}"
@@ -15,10 +15,24 @@ content="${2:-Hello OpenShift! by Arnold}"
 # Third script argument is the url path. It defaults to: "/"
 path="${3:-"/"}"
 
+# fourth script argument is the prefix used in the url. It defaults to "next"
+prefix="${4:-"next"}"
+
+# passing an empty string as prefix argument does not work, the default value (next) will
+# be assign to prefix. But we can detect how many arguments was used.
+# if exactly 4 arguments are used and prefix equals the default value then we consider that we want to use an empty string
+if [[ $# -eq 4 && "$prefix" == "next" ]]; then
+  prefix=""
+fi
+
+if [[ -n "$prefix" ]]; then
+  prefix="${prefix}."
+fi
+
 # Wait for the application to respond
 for try in $(seq 5); do
   echo "Testing ${service} application http response ($try)"
-  curl -vLk --header "Accept: text/html" "https://next.${service}.ci-eugene.${OPENSHIFT_DOMAIN}.nip.io${path}" 2> "/tmp/${service}.err" > "/tmp/${service}.out"
+  curl -vLk --header "Accept: text/html" "https://${prefix}${service}.ci-eugene.${OPENSHIFT_DOMAIN}.nip.io${path}" 2> "/tmp/${service}.err" > "/tmp/${service}.out"
   if grep "HTTP/1.1 200 OK" "/tmp/${service}.err" && grep "${content}" "/tmp/${service}.out"; then
     exit 0
   fi

--- a/deploy.yml
+++ b/deploy.yml
@@ -13,6 +13,11 @@
       debug: msg="==== Starting deploy playbook ===="
       tags: deploy
 
+    - name: Check if apps_filter is defined
+      fail:
+        msg: "Deploy playbook must be used with apps_filter defined"
+      when: apps_filter is not defined
+
     - import_tasks: tasks/set_vars.yml
 
     # Set the deployment stamp value for this deployment

--- a/tasks/create_static_services_routes.yml
+++ b/tasks/create_static_services_routes.yml
@@ -1,10 +1,15 @@
 ---
 # Create static routes for services of an app
 
-- name: "Make sure static route exists for the '{{ app.name }}' app"
+- name: "Make sure static route exists for the '{{ app.name }}' app with all prefixes"
   include_tasks: tasks/deploy_patch_route.yml
   loop: "{{ blue_green_route_prefixes }}"
   loop_control:
     loop_var: prefix
-  when: routes | length > 0
+  when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True) == True
+  tags: route
+
+- name: "Make sure static route exists for the '{{ app.name }}' app"
+  include_tasks: tasks/deploy_patch_route.yml
+  when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True) == False
   tags: route

--- a/tasks/deploy_get_stamp_from_route.yml
+++ b/tasks/deploy_get_stamp_from_route.yml
@@ -21,7 +21,7 @@
         ] | flatten | first
       }}
   register: app_route
-  when: routes | length > 0
+  when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True) == True
 
 - name: Display selected route
   debug:

--- a/tasks/deploy_patch_route.yml
+++ b/tasks/deploy_patch_route.yml
@@ -9,5 +9,17 @@
   loop: "{{ routes }}"
   loop_control:
     loop_var: route_template
-  when: routes | length > 0
+  when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True) == True
+  tags: route
+
+
+- name: "Patching routes for the {{ app.name }} application"
+  openshift_raw:
+    force: true
+    definition: "{{ lookup('template', route_template) | from_yaml }}"
+    state: present
+  loop: "{{ routes }}"
+  loop_control:
+    loop_var: route_template
+  when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True) == False
   tags: route

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -20,6 +20,15 @@
     - deployment
     - service
 
+- name: Define pod label selector
+  set_fact:
+    pod_label_selector: "app={{ app.name }}"
+
+- name: Add deployment_stamp to label selector
+  set_fact:
+    pod_label_selector: "{{ pod_label_selector }},deployment_stamp={{ deployment_stamp }}"
+  when: app.settings.is_blue_green_compatible | default(True) == True
+
 - name: Wait for pods to be running
   debug:
     msg: |
@@ -29,7 +38,7 @@
           api_version='v1',
           namespace=project_name,
           kind='Pod',
-          label_selector='app=' + app.name + ',deployment_stamp=' + deployment_stamp
+          label_selector=pod_label_selector
         )
       }}
     verbosity: 2
@@ -44,7 +53,7 @@
           api_version='v1',
           namespace=project_name,
           kind='Pod',
-          label_selector='app=' + app.name + ',deployment_stamp=' + deployment_stamp
+          label_selector=pod_label_selector
         )
       ] | flatten | json_query('[?status.phase==`Running`].metadata.name') | length
     ) == (


### PR DESCRIPTION
## Purpose

Deploying a "non-blue-green application" with the deployment_stamp label in its deployment configuration leads to errors as the deployment_stamp changes at every deployment (OpenShift cannot patch an object that does not exist!).

Fixes #148, #121 

## Proposal

- [x] remove the `deployment_stamp` label of the `mailcatcher` app deployment configuration
- [x] remove the `deployment_stamp` label of the `redis` app deployment configuration

## Update

Removing `label_stamp` is not as easy. Removing it is not enough. Every deploy is based on this stamp and the request made on OKD to find a resource is based on it. So if you just remove the stamp nothing can be deployed.

To resolve this problem and not be dependant on this stamp parameter, we have to know if an application is "stampable".
To do that we will introduce a new resource on each application, a `settings` file containing information describing the application. `databases.yml` should be merged in this new file.
To distinguish "stampable" and not "stampable" objects we will use `is_blue_green_compatible` boolean and depending on this setting we will adjust the request on OKD.

To add this settings we will modify the `apps lookup` and attach on the app object these settings

New things TODO:

- [x] create a `settings.yml` file in `apps/{app}/vars/`.
- [x] parse it in `apps` lookup and inject its content in the `app` variable.
- [x] change request on OKD to reflect this change
- [x] allow deploy of non `blue/green` application