### PR TITLE
✨(bin) secure bootstrap by asking confirmation before deletion

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,5 +1,15 @@
 ---
 
+- hosts: local
+  gather_facts: False
+  tasks:
+    - import_tasks: tasks/set_vars.yml
+
+    - name: Ask confirmation before running bootstrap playbook to prevent deleting project accidentally
+      pause:
+        prompt: "This playbook will delete project {{ project_name }} using domain {{ domain_name }}. Press enter to continue, Ctrl+C to interrupt"
+      when: skip_verification is not defined
+
 - import_playbook: delete_project.yml
 - import_playbook: init_project.yml
 - import_playbook: build_images.yml


### PR DESCRIPTION
## Purpose

The bin/bootstrap command starts by deleting any existing project. It does not ask for confirmation so there is a risk of someone unintentionally losing information.

Fixes #94

## Proposal

- [x] Add a confirmation message before deleting the project,
- [x] Allow skipping this confirmation
