### PR TITLE
✨(vault) generate forum api key in create_vaults playbook

### DIFF
--- a/apps/forum/vars/vault/main.yml.j2
+++ b/apps/forum/vars/vault/main.yml.j2
@@ -6,10 +6,10 @@
 {% set mongodb_credentials = databases.mongodb | json_query("[?release=='" ~ forum_mongodb_version ~ "'].databases | [0][?application=='forum'].{user: user, password: password, name: name} | [0]") %}
 MONGODB_ADMIN_PASSWORD: password
 MONGODB_USER: {{ mongodb_credentials.user }}
-MONGODB_PASSWORD: {{ mongodb_credentials. password }}
+MONGODB_PASSWORD: {{ mongodb_credentials.password }}
 MONGODB_DATABASE: {{ mongodb_credentials.name }}
 
 # Forum
 # Nota bene: the forum API_KEY should match the following edxapp lms settings:
 # COMMENTS_SERVICE_KEY
-API_KEY: "thisisafakeapikey"
+API_KEY: "{{ lookup('password','/dev/null length=48') }}"


### PR DESCRIPTION
## Purpose

The database API Key is not generated in the create_vaults playbook. This can be done in this playbook otherwise user must generate it afterward


## Proposal

Use lookup password to generate randomly the API Key
