### PR TITLE
enforce database env prefix

### DIFF
--- a/apps/edxapp/vars/vault/main.yml.j2
+++ b/apps/edxapp/vars/vault/main.yml.j2
@@ -12,7 +12,7 @@ MYSQL_PASSWORD: {{ mysql_credentials.password }}
 
 # MongoDB
 {% set mongodb_credentials = databases.mongodb | json_query("[?release=='" ~ edxapp_mongodb_version ~ "'].databases | [0][?application=='edxapp'].{user: user, password: password, name: name} | [0]") %}
-MONGODB_ADMIN_PASSWORD: password
+MONGODB_ADMIN_PASSWORD: "{{ lookup('password', '/dev/null length=24') }}"
 MONGODB_USER: {{ mongodb_credentials.user }}
 MONGODB_PASSWORD: {{ mongodb_credentials.password }}
 MONGODB_DATABASE: {{ mongodb_credentials.name }}

--- a/apps/forum/vars/vault/main.yml.j2
+++ b/apps/forum/vars/vault/main.yml.j2
@@ -4,7 +4,7 @@
 
 # MongoDB
 {% set mongodb_credentials = databases.mongodb | json_query("[?release=='" ~ forum_mongodb_version ~ "'].databases | [0][?application=='forum'].{user: user, password: password, name: name} | [0]") %}
-MONGODB_ADMIN_PASSWORD: password
+MONGODB_ADMIN_PASSWORD: "{{ lookup('password', '/dev/null length=24') }}"
 MONGODB_USER: {{ mongodb_credentials.user }}
 MONGODB_PASSWORD: {{ mongodb_credentials.password }}
 MONGODB_DATABASE: {{ mongodb_credentials.name }}

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -3,6 +3,35 @@ env_type: development  # default to be overriden on command line
 customer: eugene  # default to be overriden on command line
 project_name: "{{ env_type }}-{{ customer }}"
 
+# Environments
+#
+# Each environment is defined by a name and a code. These environments can be
+# extended given your needs, but they should respect the following conventions:
+#
+# 1. the current env_type should match one of those environments name,
+# 2. an environment code should be unique among all environments.
+#
+# You should note that the environment code will be used to generate database
+# credentials with the following pattern: 
+#
+# {{ environment.code }}_{{ customer }}_{{ app.name }}
+#
+# For example, the database name for the marsha application deployed in
+# development environment for the eugene customer will be "d_eugene_marsha".
+environments:
+  - name: "ci"
+    code: "c"
+  - name: "development"
+    code: "d"
+  - name: "feature"
+    code: "f"
+  - name: "production"
+    code: "p"
+  - name: "staging"
+    code: "s"
+  - name: "preprod"
+    code: "t"
+
 # Openshift applications list for the project
 # Example :
 # apps:

--- a/plugins/filter/merge.py
+++ b/plugins/filter/merge.py
@@ -80,15 +80,24 @@ def merge_with_database(base, database, app_name, customer, environment):
     if not isinstance(base, dict) or not isinstance(database, dict):
         raise AnsibleFilterError("input database is empty")
 
+    if not isinstance(environment, dict):
+        raise AnsibleFilterError("input environment must be a dictionnary")
+
     if "engine" not in database:
         raise AnsibleFilterError("input database should define an 'engine' key")
 
     if "release" not in database:
         raise AnsibleFilterError("input database should define a 'release' key")
 
+    if "code" not in environment:
+        raise AnsibleFilterError("environment dict should define a 'code' key")
+
+    if "name" not in environment:
+        raise AnsibleFilterError("environment dict should define a 'name' key")
+
     result = deepcopy(base)
 
-    database_name = "_".join([environment[0], customer, app_name])
+    database_name = "_".join([environment.get("code"), customer, app_name])
     new_database = {
         "application": app_name,
         "password": random_password(),

--- a/tasks/create_app_database_vault.yml
+++ b/tasks/create_app_database_vault.yml
@@ -12,8 +12,9 @@
     name: "{{app.name}}_databases"
   when: database_conf.stat.exists == True
 
+# Select the environment matching the current env_type: environments | json_query(\"[?name=='\" ~ env_type ~ \"'] | [0]\")
 - name: Append database to databases vault
   set_fact:
-    databases: "{{ databases | default({}) | merge_with_database(item, app.name, customer, env_type) }}"
+    databases: "{{ databases | default({}) | merge_with_database(item, app.name, customer, environments | json_query(\"[?name=='\" ~ env_type ~ \"'] | [0]\")) }}"
   loop: "{{ lookup('vars', app.name + '_databases').databases }}"
   when: database_conf.stat.exists == True

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -391,7 +391,9 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
         }
 
         self.assertEquals(
-            merge_with_database(base, database, "edxapp", "eugene", "development"),
+            merge_with_database(
+                base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
+            ),
             expected,
         )
 
@@ -448,7 +450,9 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
         }
 
         self.assertEquals(
-            merge_with_database(base, database, "edxapp", "eugene", "development"),
+            merge_with_database(
+                base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
+            ),
             expected,
         )
 
@@ -487,7 +491,9 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
         }
 
         self.assertEquals(
-            merge_with_database(base, database, "edxapp", "eugene", "development"),
+            merge_with_database(
+                base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
+            ),
             expected,
         )
 
@@ -542,7 +548,9 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
         }
 
         self.assertEquals(
-            merge_with_database(base, database, "edxapp", "eugene", "development"),
+            merge_with_database(
+                base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
+            ),
             expected,
         )
 
@@ -556,8 +564,10 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
             ("production", "p"),
             ("staging", "s"),
             ("development", "d"),
-            ("testing", "t"),
-            ("foo", "f"),
+            ("preprod", "t"),
+            ("ci", "c"),
+            ("feature", "f"),
+            ("random", "a"),
         )
 
         for environment, env_code in environments:
@@ -580,6 +590,12 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
             }
 
             self.assertEquals(
-                merge_with_database(base, database, "edxapp", "eugene", environment),
+                merge_with_database(
+                    base,
+                    database,
+                    "edxapp",
+                    "eugene",
+                    {"name": environment, "code": env_code},
+                ),
                 expected,
             )


### PR DESCRIPTION
## Purpose

To prevent having the same prefix between different environments, we have created a mapping where all environment are defined with a corresponding prefix.

## Proposal

Create a mapping between and their prefixes and use them to generate database credentials.
Also added in this PR mongodb admin password generation.
