### PR TITLE
🐛(forum) encode mongodb password in forum application

### DIFF
--- a/apps/forum/templates/app/dc.yml.j2
+++ b/apps/forum/templates/app/dc.yml.j2
@@ -37,4 +37,4 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-            - MONGOHQ_URL=mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@forum-mongo-{{ deployment_stamp }}:{{ forum_mongodb_port }}/${MONGODB_DATABASE} bundle exec puma
+            - MONGOHQ_URL=mongodb://${MONGODB_USER}:${MONGODB_PASSWORD_URLENCODED}@forum-mongo-{{ deployment_stamp }}:{{ forum_mongodb_port }}/${MONGODB_DATABASE} bundle exec puma

--- a/apps/forum/templates/app/job_01_init_index.yml.j2
+++ b/apps/forum/templates/app/job_01_init_index.yml.j2
@@ -32,5 +32,5 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-            - MONGOHQ_URL=mongodb://${MONGODB_USER}:${MONGODB_PASSWORD}@forum-mongo-{{ deployment_stamp }}:{{ forum_mongodb_port }}/${MONGODB_DATABASE} bin/rake search:initialize
+            - MONGOHQ_URL=mongodb://${MONGODB_USER}:${MONGODB_PASSWORD_URLENCODED}@forum-mongo-{{ deployment_stamp }}:{{ forum_mongodb_port }}/${MONGODB_DATABASE} bin/rake search:initialize
       restartPolicy: Never

--- a/apps/forum/templates/app/secret.yml.j2
+++ b/apps/forum/templates/app/secret.yml.j2
@@ -10,4 +10,5 @@ data:
   API_KEY: "{{ API_KEY | default('thereisnodefaultapikey') | b64encode }}"
   MONGODB_USER: "{{ MONGODB_USER | default('edxapp_user') | b64encode }}"
   MONGODB_PASSWORD: "{{ MONGODB_PASSWORD | default('password') | b64encode }}"
+  MONGODB_PASSWORD_URLENCODED: "{{ MONGODB_PASSWORD | default('password') | urlencode | b64encode }}"
   MONGODB_DATABASE: "{{ MONGODB_DATABASE | default('client_comments') | b64encode }}"


### PR DESCRIPTION
## Purpose

Some parts of the MONGOHQ_URL variable may break MongoDB access if they
contain special characters (e.g. `:` or `/`).

Fixes #174 

## Proposal

- [x] apply the [`urlencode` Jinja filter](http://jinja.pocoo.org/docs/2.10/templates/#urlencode) to the user password
