### PR TITLE
🐛(marsha) manage case where cloudfront private key is not defined

### DIFF
--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -48,8 +48,10 @@ spec:
               mountPath: /data/media
             - name: marsha-v-static
               mountPath: /data/static
+{% if DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
             - mountPath: "{{ marsha_cloudfront_private_key_path | dirname }}"
               name: marsha-cloudfront-private-key-secret
+{% endif %}
       volumes:
         - name: marsha-v-media
           persistentVolumeClaim:
@@ -57,6 +59,8 @@ spec:
         - name: marsha-v-static
           persistentVolumeClaim:
             claimName: marsha-pvc-static
+{% if DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
         - name: marsha-cloudfront-private-key-secret
           secret:
             secretName: "{{ marsha_cloudfront_private_key_secret_name }}"
+{% endif %}

--- a/apps/marsha/templates/app/secret_cloudfront_private_key.yml.j2
+++ b/apps/marsha/templates/app/secret_cloudfront_private_key.yml.j2
@@ -1,3 +1,4 @@
+{% if DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -9,3 +10,4 @@ metadata:
 data:
   ssh-privatekey: "{{ DJANGO_CLOUDFRONT_PRIVATE_KEY | default('') | b64encode }}"
 type: kubernetes.io/ssh-auth
+{% endif %}

--- a/bin/ansible-playbook
+++ b/bin/ansible-playbook
@@ -8,4 +8,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 _set_openshift_env
 
 # Run ansible-playbook
-_docker_run ansible-playbook "$@"
+_docker_run ansible-playbook "$@" --ask-vault-pass

--- a/bin/deploy
+++ b/bin/deploy
@@ -8,4 +8,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 _set_openshift_env
 
 # Run ansible-playbook
-_docker_run ansible-playbook deploy.yml "$@"
+_docker_run ansible-playbook deploy.yml --ask-vault-pass "$@"

--- a/bin/job
+++ b/bin/job
@@ -53,7 +53,7 @@ function main() {
     echo "deployment stamp: $deployment_stamp"
     echo "job             : $job_template"
 
-    _docker_run ansible-playbook create_object.yml \
+    _docker_run ansible-playbook create_object.yml --ask-vault-pass \
         -e "customer=$customer" \
         -e "env_type=$env_type" \
         -e "object_template=$job_template" \

--- a/bin/switch
+++ b/bin/switch
@@ -8,4 +8,4 @@ source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 _set_openshift_env
 
 # Run ansible-playbook
-_docker_run ansible-playbook switch.yml "$@"
+_docker_run ansible-playbook switch.yml --ask-vault-pass "$@"

--- a/tasks/create_app_secrets.yml
+++ b/tasks/create_app_secrets.yml
@@ -4,28 +4,6 @@
   debug: msg="App name {{ app.name }}"
   tags: secret
 
-- name: Get vault variable for this app
-  set_fact:
-    app_vault: "{{ lookup('vars', app.name + '_vault', default='') }}"
-
-# Decrypt vaulted credentials and load new variable from those definitions.
-# Credentials are expected to be found in:
-#
-# group_vars/customer/{{ customer }}/{{ env_type }}/secrets/{{ app.name }}.vault.yml
-#
-# Valid examples for the foo app:
-#
-#   - group_vars/customer/eugene/development/secrets/foo.vault.yml
-#   - group_vars/customer/eugene/staging/secrets/foo.vault.yml
-#
-# Nota bene:
-#    - you will need to set the vaut password while using this playbook to
-#      ensure we can decrypt vaulted credentials
-- name: Decrypt vaulted credentials for the given customer and environment
-  include_vars:
-    file: "{{ app_vault.stat.path }}"
-  when: app_vault.stat is defined and app_vault.stat.exists and app_vault.stat.isreg
-
 # Create all secrets for the current application
 - name: Actually create the secrets in OpenShift
   openshift_raw:

--- a/tasks/get_vault_for_app.yml
+++ b/tasks/get_vault_for_app.yml
@@ -19,7 +19,12 @@
     "{{ app.name }}_vault": "{{ app_vault }}"
     "{{ app.name }}_vault_checksum": "{{ app_vault_checksum }}"
   # Only set those variables when the vault file exists and is a regular file
-  when: app_vault.stat.exists and app_vault.stat.isreg
+  when: app_vault.stat is defined and app_vault.stat.exists and app_vault.stat.isreg
+
+- name: Decrypt vaulted credentials for the given customer and environment
+  include_vars:
+    file: "{{ app_vault.stat.path }}"
+  when: app_vault.stat is defined and app_vault.stat.exists and app_vault.stat.isreg
 
 - include_tasks: tasks/set_htpasswd_path_for_app.yml
 


### PR DESCRIPTION
cloudfront private key is not required and can be not defined when you
deploy marsha. We have to manage this case and remove resources related
to this private key

## Purpose

Marsha is not installable anymore without defining cloudfront private key but this is not a requirement in marsha apps.

Fixes #180 

## Proposal

Manage case where the private key is not defined and not create resources linked to this secret key if not present.