### PR TITLE
Route deployment stamp removal

### DIFF
--- a/apps/edxapp/templates/nginx/route_cms.yml.j2
+++ b/apps/edxapp/templates/nginx/route_cms.yml.j2
@@ -9,7 +9,6 @@ metadata:
     app: "edxapp"
     service: "nginx"
     version: "{{ edxapp_nginx_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "cms"
   annotations:

--- a/apps/edxapp/templates/nginx/route_lms.yml.j2
+++ b/apps/edxapp/templates/nginx/route_lms.yml.j2
@@ -9,7 +9,6 @@ metadata:
     app: "edxapp"
     service: "nginx"
     version: "{{ edxapp_nginx_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "lms"
   annotations:

--- a/apps/forum/templates/app/route.yml.j2
+++ b/apps/forum/templates/app/route.yml.j2
@@ -9,7 +9,6 @@ metadata:
     app: "forum"
     service: "app"
     version: "{{ forum_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:

--- a/apps/hello/templates/app/route.yml.j2
+++ b/apps/hello/templates/app/route.yml.j2
@@ -8,7 +8,6 @@ metadata:
     customer: "{{ customer }}"
     app: "hello"
     service: "app"
-    deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:

--- a/apps/marsha/templates/nginx/route.yml.j2
+++ b/apps/marsha/templates/nginx/route.yml.j2
@@ -9,7 +9,6 @@ metadata:
     app: "marsha"
     service: "nginx"
     version: "{{ marsha_nginx_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:

--- a/apps/redirect/templates/nginx/route.yml.j2
+++ b/apps/redirect/templates/nginx/route.yml.j2
@@ -3,7 +3,6 @@ apiVersion: v1
 metadata:
   labels:
     app: alias-{{ item }}
-    deployment_stamp: "{{ deployment_stamp }}"
   name: alias-{{ item }}
   namespace: "{{ project_name }}"
   annotations:

--- a/apps/richie/templates/nginx/route.yml.j2
+++ b/apps/richie/templates/nginx/route.yml.j2
@@ -9,7 +9,6 @@ metadata:
     app: "richie"
     service: "nginx"
     version: "{{ richie_nginx_image_tag }}"
-    deployment_stamp: "{{ deployment_stamp }}"
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:

--- a/tasks/delete_app.yml
+++ b/tasks/delete_app.yml
@@ -2,7 +2,7 @@
 # Delete objects for the targeted deployment_stamp
 - name: Set targetted deployment stamp
   set_fact:
-    targeted_deployment_stamp: "{{ app_route_deployment_stamp | default(none) }}"
+    targeted_deployment_stamp: "{{ app_deployment_stamp | default(none) }}"
 
 # Set the deployment stamp value for this deployment
 #

--- a/tasks/deploy_get_stamp_from_route.yml
+++ b/tasks/deploy_get_stamp_from_route.yml
@@ -3,10 +3,10 @@
 
 # An application can define several routes (e.g. two services with two
 # different routes). Our goal here is to get the deployment_stamp of a
-# deployed stack by getting a route object. As the deployment_stamp is
-# commonly shared among objects of a stack, there is no need to get more than
-# one route to achieve this.
-- name: Get deployment_stamp from {{ app.name }} application routes with prefix {{ prefix }}
+# deployed stack by getting a route object. We first retrieve a route and
+# then the service targeted by this route. TThis service will be labelled with the
+# deploy_stamp we are looking for.
+- name: Get route for application {{ app.name }} with prefix {{ prefix }}
   set_fact:
     route: |
       {{
@@ -29,10 +29,36 @@
     verbosity: 3
   when: app_route is defined
 
-- name: set_fact app_route_deployment_stamp
+- name: Get targeted service
   set_fact:
-    app_route_deployment_stamp: "{{ app_route.ansible_facts.route.metadata.labels.deployment_stamp | default(none) }}"
+    targeted_service: |
+      {{
+        lookup(
+          'openshift',
+          api_version='v1',
+          namespace=project_name,
+          kind='Service',
+          resource_name=app_route.ansible_facts.route.spec.to.name
+        )
+      }}
   when: app_route.ansible_facts is defined
+
+- name: Display targeted service
+  debug:
+    msg: "{{ targeted_service | to_nice_yaml }}"
+    verbosity: 3
+  when: targeted_service is defined
+
+# app_deployment_stamp must be defined otherwise all script dependending on this one will fail
+- name: Initialize app_deployment_stamp
+  set_fact:
+    app_deployment_stamp: ""
+
+- name: set_fact app_deployment_stamp
+  set_fact:
+    app_route_deployment_stamp: "{{ targeted_service.metadata.labels.deployment_stamp | default(none) }}"
+  with:
+  when: targeted_service is defined and targeted_service | length >  0
 
 - name: Print app_route_deployment_stamp
   debug:

--- a/tasks/deploy_get_stamp_from_route.yml
+++ b/tasks/deploy_get_stamp_from_route.yml
@@ -56,11 +56,11 @@
 
 - name: set_fact app_deployment_stamp
   set_fact:
-    app_route_deployment_stamp: "{{ targeted_service.metadata.labels.deployment_stamp | default(none) }}"
+    app_deployment_stamp: "{{ targeted_service.metadata.labels.deployment_stamp | default(none) }}"
   with:
   when: targeted_service is defined and targeted_service | length >  0
 
-- name: Print app_route_deployment_stamp
+- name: Print app_deployment_stamp
   debug:
-    msg: "[{{ app.name }}] route[{{ app.name }}-{{ prefix }}] app_route_deployment_stamp[{{ app_route_deployment_stamp }}]"
-  when: app_route_deployment_stamp is defined
+    msg: "[{{ app.name }}] app_deployment_stamp[{{ app_deployment_stamp }}]"
+  when: app_deployment_stamp is defined

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -5,6 +5,13 @@
     raw_templates: "{{ app | json_query('services[*].templates[]') | list }}"
   tags: deploy
 
+# force prefix initialization. If prefix is not set, in the next step the first template
+# rendered will fail if it uses the prefix variable in it.
+- name: set Prefix
+  set_fact:
+    prefix: "next"
+  when: prefix is not defined
+
 # Remove empty rendered templates (e.g. inactivated for an env_type)
 - name: Ignore empty rendered templates
   set_fact:

--- a/tasks/switch_route.yml
+++ b/tasks/switch_route.yml
@@ -13,7 +13,7 @@
 - include_tasks: deploy_patch_route.yml
   vars:
     prefix: "{{ prefix_route_dest }}"
-    deployment_stamp: "{{ app_route_deployment_stamp }}"
+    deployment_stamp: "{{ app_deployment_stamp }}"
   tags: switch
 
 - include_tasks: deploy_patch_route.yml

--- a/tasks/switch_routes.yml
+++ b/tasks/switch_routes.yml
@@ -6,9 +6,9 @@
     prefix: "previous"
   tags: switch
 
-- name: Save previous_app_route_deployment_stamp
+- name: Save previous_app_deployment_stamp
   set_fact:
-    previous_app_route_deployment_stamp: "{{ app_route_deployment_stamp }}"
+    previous_app_deployment_stamp: "{{ app_deployment_stamp }}"
 
 - include_tasks: switch_route.yml
   vars:
@@ -26,4 +26,4 @@
 
 - include_tasks: delete_app.yml
   vars:
-    app_route_deployment_stamp: "{{ previous_app_route_deployment_stamp }}"
+    app_deployment_stamp: "{{ previous_app_deployment_stamp }}"


### PR DESCRIPTION
## Purpose

route objects should not have a deployment_stamp. Having a deployment_stamp avoid massively delete an entire deployment by selecting it with its deployment_stamp because you will delete the route with this deployment_stamp and future deploy will be impossible.

Fixes #183

This PR can also partially resolve issue #188 but will also have many conflicts with #168 

## Proposal


- [x] Remove the deployment_stamp on all route objects
- [x] Update the deploy.yml playbook to change how the a deployment_stamp is retrieved
- [x] Remove the task updating the route with a new deployment_stamp and check if updating the route is still needed
- [x]  test if switch is still working

