### PR TITLE
♻️ (ip) remove default cluster ip configuration

### DIFF
--- a/apps/edxapp/templates/mongodb/ep.yml.j2
+++ b/apps/edxapp/templates/mongodb/ep.yml.j2
@@ -1,3 +1,4 @@
+{% if endpoint_mongodb_ip | ipaddr != false %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -14,3 +15,4 @@ subsets:
     ports:
     - port: "{{ edxapp_mongodb_port }}"
       name: "{{ edxapp_mongodb_port}}-tcp"
+{% endif %}

--- a/apps/edxapp/templates/mysql/ep.yml.j2
+++ b/apps/edxapp/templates/mysql/ep.yml.j2
@@ -1,3 +1,4 @@
+{% if endpoint_mysql_ip | ipaddr != false %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -14,3 +15,4 @@ subsets:
     ports:
     - port: "{{ edxapp_mysql_port }}"
       name: "{{ edxapp_mysql_port }}-tcp"
+{% endif %}

--- a/apps/forum/templates/mongodb/ep.yml.j2
+++ b/apps/forum/templates/mongodb/ep.yml.j2
@@ -1,3 +1,4 @@
+{% if endpoint_mongodb_ip | ipaddr != false %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -14,3 +15,4 @@ subsets:
     ports:
     - port: "{{ forum_mongodb_port }}"
       name: "{{ forum_mongodb_port}}-tcp"
+{% endif %}

--- a/apps/marsha/templates/postgresql/ep.yml.j2
+++ b/apps/marsha/templates/postgresql/ep.yml.j2
@@ -1,3 +1,4 @@
+{% if endpoint_postgresql_ip | ipaddr != false %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -14,3 +15,4 @@ subsets:
     ports:
     - port: 5432
       name: 5432-tcp
+{% endif %}

--- a/apps/richie/templates/postgresql/ep.yml.j2
+++ b/apps/richie/templates/postgresql/ep.yml.j2
@@ -1,3 +1,4 @@
+{% if endpoint_postgresql_ip | ipaddr != false %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -14,3 +15,4 @@ subsets:
     ports:
     - port: 5432
       name: 5432-tcp
+{% endif %}

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -58,11 +58,6 @@ trashable_env_types:
   - "development"
   - "feature"
 
-# Endpoints IP
-endpoint_mongodb_ip:     192.168.10.11
-endpoint_mysql_ip:       192.168.10.254
-endpoint_postgresql_ip:  192.168.10.21
-
 # Blue/Green deployment route prefixes
 blue_green_route_prefixes:
   - "previous"
@@ -114,3 +109,14 @@ http_basic_auth_users:
 aliases_port: 8999
 nginx_ports:
   - "{{ aliases_port }}"
+
+# Endpoints IP
+# These endpoints are used when you don't run your databases inside an OpenShift cluster
+# but you have dedicated external resource to manage your databases.
+# In trashable environments these endpoints will not be used because everything will
+# run inside OpenShift pods. in Production and Pre-production environments you should consider using a dedicated cluster
+# for your databases.
+# Endpoint IPs are initialized at "null" by default and you SHOULD overwrite them in the corresponding environment where you will use them.
+endpoint_mongodb_ip:     null
+endpoint_mysql_ip:       null
+endpoint_postgresql_ip:  null

--- a/group_vars/env_type/preprod.yml
+++ b/group_vars/env_type/preprod.yml
@@ -1,3 +1,9 @@
 # Variables specific to the pre-production environment
 richie_django_configuration: PreProduction
 acme_env: live
+
+# Endpoints IP
+# In preproduction these variables must be set.
+# endpoint_mongodb_ip:     null
+# endpoint_mysql_ip:       null
+# endpoint_postgresql_ip:  null

--- a/group_vars/env_type/production.yml
+++ b/group_vars/env_type/production.yml
@@ -1,3 +1,9 @@
 # Variables specific to the production environment
 richie_django_configuration: Production
 acme_env: live
+
+# Endpoints IP
+# In production these variables must be set.
+# endpoint_mongodb_ip:     null
+# endpoint_mysql_ip:       null
+# endpoint_postgresql_ip:  null

--- a/requirements/pip-requirements.txt
+++ b/requirements/pip-requirements.txt
@@ -5,6 +5,7 @@ deepmerge==0.0.4
 jmespath==0.9.3
 openshift==0.4.4
 passlib==1.7.1
+netaddr==0.7.19
 
 # Quality
 flake8


### PR DESCRIPTION
## Purpose

Default cluster ip configuration is not relevant because this is a configuration by customer.

Fixes #181 

## Proposal

- [x] remove default ip configuration
- [x] manage endpoint creation
