### PR TITLE
🐛(routes) fix unexpected route deletion

### DIFF
--- a/tasks/delete_app.yml
+++ b/tasks/delete_app.yml
@@ -1,4 +1,3 @@
----
 # Delete objects for the targeted deployment_stamp
 - name: Set targetted deployment stamp
   set_fact:
@@ -17,7 +16,6 @@
     - DeploymentConfig
     - Endpoints
     - Job
-    - Route
     - Service
   tags: deploy
 

--- a/tasks/deploy_patch_route.yml
+++ b/tasks/deploy_patch_route.yml
@@ -1,9 +1,7 @@
----
 # Patch routes of all services from a single app to the new deployment_stamp
 
 - name: "Patching routes with prefix {{ prefix }} for the {{ app.name }} application with deployment_stamp {{ deployment_stamp }}"
   openshift_raw:
-    force: true
     definition: "{{ lookup('template', route_template) | from_yaml }}"
     state: present
   loop: "{{ routes }}"
@@ -11,7 +9,6 @@
     loop_var: route_template
   when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True) == True
   tags: route
-
 
 - name: "Patching routes for the {{ app.name }} application"
   openshift_raw:


### PR DESCRIPTION
## Purpose

As precisely described in #188:

> When an application is deployed or routes are switched, routes are not simply patched but replaced.

This has major unexpected side effects.

## Proposal

The current work fixes two major issues:

1. We do not want to delete a route bound to a stack when we delete a stack with the same deployment_stamp (this is a follow-up of #189).
2. Forcing route patching during a deployment or a switch is not required and leads to erratic behavior of the OpenShift ACME application that constantly try to renew route certificate as the object changed.

Fixes #188 