### PR TITLE
Add switch playbook test in the CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -169,8 +169,18 @@ jobs:
       - run:
           name: Test the "hello" application bootstrapping
           command: |
+            # Bootstrap app
             bin/ci-bootstrap "hello"
+            # Test service deployed with the next route
             bin/ci-test-service "hello" "Hello OpenShift! by Arnold" "/" "next"
+
+      - run:
+          name: Test the "hello" application switch
+          command: |
+            # Switch next route to current
+            bin/ci-switch "hello"
+            # Test service switched to the current route
+            bin/ci-test-service "hello" "Hello OpenShift! by Arnold"
 
   # Test the bootstrap playbook on the "mailcatcher" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -193,7 +203,7 @@ jobs:
           name: Test the "mailcatcher" application bootstrapping
           command: |
             bin/ci-bootstrap "mailcatcher"
-            bin/ci-test-service "mailcatcher" "MailCatcher" "/"
+            bin/ci-test-service "mailcatcher" "MailCatcher"
 
   # Test the bootstrap playbook on the "richie" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -215,8 +225,18 @@ jobs:
       - run:
           name: Test the "richie" application bootstrapping
           command: |
+            # Bootstrap app
             bin/ci-bootstrap "richie"
+            # Test service deployed with the next route
             bin/ci-test-service "richie" "Installation successful!" "/" "next"
+
+      - run:
+          name: Test the "richie" application switch
+          command: |
+            # Switch next route to current
+            bin/ci-switch "richie"
+            # Test service switched to the current route
+            bin/ci-test-service "richie" "Installation successful!"
 
   # Test the bootstrap playbook on the "forum" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -238,8 +258,18 @@ jobs:
       - run:
           name: Test the "forum" application bootstrapping
           command: |
+            # Bootstrap app
             bin/ci-bootstrap "forum"
+            # Test service deployed with the next route
             bin/ci-test-service "forum" "collection" "/api/v1/threads?api_key=thisisafakeapikey" "next"
+
+      - run:
+          name: Test the "forum" application switch
+          command: |
+            # Switch next route to current
+            bin/ci-switch "forum"
+            # Test service switched to the current route
+            bin/ci-test-service "forum" "collection" "/api/v1/threads?api_key=thisisafakeapikey"
 
   # Test the bootstrap playbook on the "edxapp" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -261,9 +291,20 @@ jobs:
       - run:
           name: Test the "edxapp" application bootstrapping (with redis enabled)
           command: |
+            # Bootstrap app
             bin/ci-bootstrap "edxapp,redis"
+            # Test services deployed with the next route
             bin/ci-test-service "cms" "Welcome to Your Platform Studio" "/" "next"
             bin/ci-test-service "lms" "It works! This is the default homepage for this Open edX instance." "/" "next"
+
+      - run:
+          name: Test the "edxapp" application switch
+          command: |
+            # Switch next route to current
+            bin/ci-switch "edxapp"
+            # Test service switched to the current route
+            bin/ci-test-service "cms" "Welcome to Your Platform Studio"
+            bin/ci-test-service "lms" "It works! This is the default homepage for this Open edX instance."
 
   # Test the bootstrap playbook on the "marsha" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -285,8 +326,18 @@ jobs:
       - run:
           name: Test the "marsha" application bootstrapping
           command: |
+            # Bootstrap app
             bin/ci-bootstrap "marsha"
+            # Test services deployed with the next route
             bin/ci-test-service "marsha" "Api Root" "/api/" "next"
+
+      - run:
+          name: Test the "marsha" application switch
+          command: |
+            # Switch next route to current
+            bin/ci-switch "marsha"
+            # Test service switched to the current route
+            bin/ci-test-service "marsha" "Api Root" "/api/"
 
   # FIXME: we have deactivated plugins test coverage as the container user is
   # not allowed to write to /app/.coverage and CircleCI does not allow to mount

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,7 +170,7 @@ jobs:
           name: Test the "hello" application bootstrapping
           command: |
             bin/ci-bootstrap "hello"
-            bin/ci-test-service "hello" "Hello OpenShift! by Arnold"
+            bin/ci-test-service "hello" "Hello OpenShift! by Arnold" "/" "next"
 
   # Test the bootstrap playbook on the "mailcatcher" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -193,7 +193,7 @@ jobs:
           name: Test the "mailcatcher" application bootstrapping
           command: |
             bin/ci-bootstrap "mailcatcher"
-            bin/ci-test-service "mailcatcher" "MailCatcher" "/" ""
+            bin/ci-test-service "mailcatcher" "MailCatcher" "/"
 
   # Test the bootstrap playbook on the "richie" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -216,7 +216,7 @@ jobs:
           name: Test the "richie" application bootstrapping
           command: |
             bin/ci-bootstrap "richie"
-            bin/ci-test-service "richie" "Installation successful!"
+            bin/ci-test-service "richie" "Installation successful!" "/" "next"
 
   # Test the bootstrap playbook on the "forum" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -239,7 +239,7 @@ jobs:
           name: Test the "forum" application bootstrapping
           command: |
             bin/ci-bootstrap "forum"
-            bin/ci-test-service "forum" "collection" "/api/v1/threads?api_key=thisisafakeapikey"
+            bin/ci-test-service "forum" "collection" "/api/v1/threads?api_key=thisisafakeapikey" "next"
 
   # Test the bootstrap playbook on the "edxapp" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -262,8 +262,8 @@ jobs:
           name: Test the "edxapp" application bootstrapping (with redis enabled)
           command: |
             bin/ci-bootstrap "edxapp,redis"
-            bin/ci-test-service "cms" "Welcome to Your Platform Studio"
-            bin/ci-test-service "lms" "It works! This is the default homepage for this Open edX instance."
+            bin/ci-test-service "cms" "Welcome to Your Platform Studio" "/" "next"
+            bin/ci-test-service "lms" "It works! This is the default homepage for this Open edX instance." "/" "next"
 
   # Test the bootstrap playbook on the "marsha" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
@@ -286,7 +286,7 @@ jobs:
           name: Test the "marsha" application bootstrapping
           command: |
             bin/ci-bootstrap "marsha"
-            bin/ci-test-service "marsha" "Api Root" "/api/"
+            bin/ci-test-service "marsha" "Api Root" "/api/" "next"
 
   # FIXME: we have deactivated plugins test coverage as the container user is
   # not allowed to write to /app/.coverage and CircleCI does not allow to mount

--- a/bin/_config.sh
+++ b/bin/_config.sh
@@ -77,15 +77,23 @@ function _docker_run() {
         i=$(( i+1 ))
     done
 
-    [[ "$USE_TTY" == "false" ]] && TTY_OPTION="" || TTY_OPTION="-t"
+    # Use docker tty option
+    [[ "${USE_TTY}" == "false" ]] && TTY_OPTION="" || TTY_OPTION="-t"
 
+    # Mount sources as a volume
+    [[ "${MOUNT_SRC}" == "false" ]] && SRC_VOLUME_OPTION="" || SRC_VOLUME_OPTION="-v $PWD:/app"
+
+    # If we wrap the SRC_VOLUME_OPTION with double quotes, this will break the
+    # command, hence, we should ignore this rule here:
+    #
+    # shellcheck disable=SC2086
     docker run --rm -i ${TTY_OPTION} \
         -u "$(id -u)" \
         --env-file "$env_file" \
         --env K8S_AUTH_API_KEY \
         --env K8S_AUTH_HOST \
         --env OPENSHIFT_DOMAIN \
-        -v "$PWD:/app" \
+        ${SRC_VOLUME_OPTION} \
         -v "$HOME/.kube:/home/arnold/.kube" \
         "arnold:$(tr -d '\n' < VERSION)" \
         "${args[@]}"

--- a/bin/ci-switch
+++ b/bin/ci-switch
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# usage: ci-bootstrap [APP]
+# usage: ci-switch [APP]
 
 # First script argument is the application's name. It defaults to 'hello'
 app="${1:-hello}"
@@ -8,6 +8,6 @@ app="${1:-hello}"
 # shellcheck source=bin/_config.sh
 source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
 
-# Run the bootstrap.yml playbook with the ansible vault password passed to stdin
+# Run the switch.yml playbook
 echo "arnold" | USE_TTY="false" MOUNT_SRC="false" _docker_run --env-file="env.d/ci" \
-  ansible-playbook bootstrap.yml --ask-vault-pass -e "env_type=ci" -e "apps_filter=${app}"
+  ansible-playbook switch.yml --ask-vault-pass -e "env_type=ci" -e "apps_filter=${app}"

--- a/bin/ci-test-service
+++ b/bin/ci-test-service
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 #
-# usage: ci-test-service [SERVICE] [CONTENT] [PATH]
-set -x
+# usage: ci-test-service [SERVICE] [CONTENT] [PATH] [PREFIX]
+
 # First script argument is the application's service name. It defaults to
 # 'hello'
 service="${1:-hello}"
@@ -15,18 +15,16 @@ content="${2:-Hello OpenShift! by Arnold}"
 # Third script argument is the url path. It defaults to: "/"
 path="${3:-"/"}"
 
-# fourth script argument is the prefix used in the url. It defaults to "next"
-prefix="${4:-"next"}"
+# Fourth script argument is the prefix used in the url. It defaults to "current".
+prefix="${4:-"current"}"
 
-# passing an empty string as prefix argument does not work, the default value (next) will
-# be assign to prefix. But we can detect how many arguments was used.
-# if exactly 4 arguments are used and prefix equals the default value then we consider that we want to use an empty string
-if [[ $# -eq 4 && "$prefix" == "next" ]]; then
-  prefix=""
-fi
-
-if [[ -n "$prefix" ]]; then
+# Current URL has by definition no prefix, while next and previous URLs are
+# sub-domains. Hence, we add the sub-domain dot for next and previous prefixes
+# and remove the current prefix for the current URL.
+if [[ "${prefix}" != "current" ]]; then
   prefix="${prefix}."
+else
+  prefix=""
 fi
 
 # Wait for the application to respond


### PR DESCRIPTION
## Purpose

As mentioned in #190, the `switch` playbook is a crucial part of our blue-green deployment strategy. We need to automate its testing to avoid breaking it during our developments.

## Proposal

- [x] Add a `ci-switch` script
- [x] Integrate this script for each tested app in CircleCI's configuration

Fixes #190 