### PR TITLE
Add new route for preview url

### DIFF
--- a/apps/edxapp/templates/nginx/route_preview.yml.j2
+++ b/apps/edxapp/templates/nginx/route_preview.yml.j2
@@ -1,0 +1,25 @@
+apiVersion: v1
+kind: Route
+metadata:
+  namespace: "{{ project_name }}"
+  name: "edxapp-nginx-preview-{{ prefix }}"
+  labels:
+    env_type: "{{ env_type }}"
+    customer: "{{ customer }}"
+    app: "edxapp"
+    service: "nginx"
+    version: "{{ edxapp_nginx_image_tag }}"
+    route_prefix: "{{ prefix }}"
+    route_target_service: "lms"
+  annotations:
+    kubernetes.io/tls-acme: "true"
+spec:
+  host: "{{ edxapp_preview_host | blue_green_host(prefix) }}"
+  tls:
+    termination: edge
+    insecureEdgeTerminationPolicy: Redirect
+  port:
+    targetPort: "{{ edxapp_nginx_lms_port }}-tcp"
+  to:
+    kind: Service
+    name: "edxapp-nginx-{{ deployment_stamp }}"

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -3,6 +3,7 @@
 # -- routes
 edxapp_cms_host: "cms.{{ project_name}}.{{ domain_name }}"
 edxapp_lms_host: "lms.{{ project_name}}.{{ domain_name }}"
+edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"

--- a/group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
@@ -9,6 +9,9 @@ ALLOWED_HOSTS:
   - "previous.{{ edxapp_lms_host }}"
   - "{{ edxapp_lms_host }}"
   - "next.{{ edxapp_lms_host }}"
+  - "previous.{{ edxapp_preview_host }}"
+  - "{{ edxapp_preview_host }}"
+  - "next.{{ edxapp_preview_host }}"
 
 # Celery Broker
 CELERY_BROKER_TRANSPORT: redis


### PR DESCRIPTION
## Purpose

The preview url is used to allow instructors to review a course that is now published on the LMS. It is an accessible by intructors of the course and unlock displaying of the draft items in the course.

Since this is using a specific domain, we must create a specific route and add it to allowed hosts.

## Proposal

- [x] add a route for the preview url
- [x] add the preview host to ALLOWED_HOST in the demo project.
