### PR TITLE
Improve edxapp celery workers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Edxapp Celery workers are now configurable (number of replicas and queues to
+  consume)
+
 ### Fixed
 
 - Pods deployment wait loop is now more robust by relying on the number of pod

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Pods deployment wait loop is now more robust by relying on the number of pod
+  replicas instead of the number of deployments
+
 ## [1.0.0-alpha.2] - 2018-12-14
 
 ### Added

--- a/apps/edxapp/templates/cms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/cms/_configs/settings.yml.j2
@@ -18,9 +18,9 @@ CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
 
 # Celery queues
-HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}"
-DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}"
-LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}"
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}-{{ deployment_stamp }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}-{{ deployment_stamp }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}-{{ deployment_stamp }}"
 
 # MySQL
 DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -6,10 +6,17 @@
 
 {# The dc_name should be unique #}
 {%- set dc_name = "edxapp-%s-%s-%s" | format(service_variant, worker_type, deployment_stamp) -%}
+{%- set replicas = 1 -%}
 
-{# In case of a worker, we need to add the queue name to make the dc_name unique #}
-{%- if queue -%}
-  {% set dc_name = "%s-%s" | format(dc_name, (queue | regex_replace('\\.|_', '-'))) %}
+{#
+  In case of a worker, we need to:
+    1. patch attached queue names to make them specific to this deployment
+    2. add the worker name (with the deployment_stamp) to make the dc_name unique
+#}
+{%- if celery_worker is defined -%}
+  {%- set queues = celery_worker.queues | map('regex_replace', '$', '-%s' | format(deployment_stamp)) -%}
+  {%- set dc_name = "edxapp-%s-%s" | format(celery_worker.name, deployment_stamp) -%}
+  {%- set replicas = celery_worker.replicas -%}
 {%- endif -%}
 
 {#
@@ -17,12 +24,12 @@
   case, we override this command to run celery workers instead of the CMS/LMS
   wsgi server.
 #}
-{%- macro command(service_variant, queue, concurrency=1) -%}
-  {%- if service_variant and queue %}
+{%- macro command(service_variant, celery_worker, concurrency=1) -%}
+  {%- if service_variant and celery_worker is defined %}
         command:
           - "/bin/bash"
           - "-c"
-          - python manage.py {{ service_variant }} celery worker --loglevel=info --queues={{ queue }} --hostname={{ queue }}.%%h --concurrency={{ concurrency }}
+          - python manage.py {{ service_variant }} celery worker --loglevel=info --queues={{ queues | join(',') }} --hostname={{ celery_worker.name }}.%%h --concurrency={{ concurrency }}
   {%- endif %}
 {%- endmacro -%}
 
@@ -38,7 +45,9 @@ metadata:
   name: "{{ dc_name }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1  # number of pods we want
+  # We want to deploy every target DC even if replicas has been set to zero to
+  # be able to scale up/down worker for a deployed stack.
+  replicas: {{ replicas }} # number of pods we want
   template:
     metadata:
       labels:
@@ -51,7 +60,7 @@ spec:
     spec:
       containers:
       - name: {{ service_variant }}
-{{ command(service_variant, queue) }}
+{{ command(service_variant, celery_worker) }}
         env:
         - name: SERVICE_VARIANT
           value: {{ service_variant }}

--- a/apps/edxapp/templates/cms/dc.yml.j2
+++ b/apps/edxapp/templates/cms/dc.yml.j2
@@ -1,5 +1,4 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "wsgi" %}
-{% set queue = "" %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/cms/dc_queue_default_priority.yml.j2
+++ b/apps/edxapp/templates/cms/dc_queue_default_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_cms_default_priority_queue %}
+{% set celery_worker = edxapp_celery_cms_default_priority_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/cms/dc_queue_high_priority.yml.j2
+++ b/apps/edxapp/templates/cms/dc_queue_high_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_cms_high_priority_queue %}
+{% set celery_worker = edxapp_celery_cms_high_priority_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/cms/dc_queue_low_priority.yml.j2
+++ b/apps/edxapp/templates/cms/dc_queue_low_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_cms_low_priority_queue %}
+{% set celery_worker = edxapp_celery_cms_low_priority_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -18,10 +18,10 @@ CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
 
 # Celery queues
-HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}"
-DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}"
-LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}"
-HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}"
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}-{{ deployment_stamp }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}-{{ deployment_stamp }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}-{{ deployment_stamp }}"
+HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}-{{ deployment_stamp }}"
 
 # MySQL
 DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"

--- a/apps/edxapp/templates/lms/dc.yml.j2
+++ b/apps/edxapp/templates/lms/dc.yml.j2
@@ -1,5 +1,4 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "wsgi" %}
-{% set queue = "" %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_default_priority.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_default_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_lms_default_priority_queue %}
+{% set celery_worker = edxapp_celery_lms_default_priority_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_high_mem.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_high_mem.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_lms_high_mem_queue %}
+{% set celery_worker = edxapp_celery_lms_high_mem_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_high_priority.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_high_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_lms_high_priority_queue %}
+{% set celery_worker = edxapp_celery_lms_high_priority_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc_queue_low_priority.yml.j2
+++ b/apps/edxapp/templates/lms/dc_queue_low_priority.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
-{% set queue = edxapp_celery_lms_low_priority_queue %}
+{% set celery_worker = edxapp_celery_lms_low_priority_worker %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -60,7 +60,6 @@ edxapp_mysql_image_tag: "5.7"
 edxapp_mysql_port: 3306
 edxapp_mysql_secret_name: "edxapp-mysql-{{ edxapp_vault_checksum | default('undefined_edxapp_vault_checksum') }}"
 
-
 # -- nginx
 edxapp_nginx_image_name: "fundocker/openshift-nginx"
 edxapp_nginx_image_tag: "1.13"
@@ -69,14 +68,56 @@ edxapp_nginx_lms_port: 8071
 edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
 
 # -- celery/redis
-edxapp_celery_lms_high_priority_queue: "edx.lms.core.high"
-edxapp_celery_lms_default_priority_queue: "edx.lms.core.default"
-edxapp_celery_lms_low_priority_queue: "edx.lms.core.low"
-edxapp_celery_lms_high_mem_queue: "edx.lms.core.high_mem"
 
-edxapp_celery_cms_high_priority_queue: "edx.cms.core.high"
-edxapp_celery_cms_default_priority_queue: "edx.cms.core.default"
-edxapp_celery_cms_low_priority_queue: "edx.cms.core.low"
+# LMS queues
+edxapp_celery_lms_high_priority_queue: &lms_high "edx.lms.core.high"
+edxapp_celery_lms_default_priority_queue: &lms_default "edx.lms.core.default"
+edxapp_celery_lms_low_priority_queue: &lms_low "edx.lms.core.low"
+edxapp_celery_lms_high_mem_queue: &lms_high_mem "edx.lms.core.high_mem"
+
+# CMS queues
+edxapp_celery_cms_high_priority_queue: &cms_high "edx.cms.core.high"
+edxapp_celery_cms_default_priority_queue: &cms_default "edx.cms.core.default"
+edxapp_celery_cms_low_priority_queue: &cms_low "edx.cms.core.low"
+
+# LMS workers
+edxapp_celery_lms_high_priority_worker:
+  name: "lms-high"
+  queues: [*lms_high]
+  replicas: 0
+edxapp_celery_lms_default_priority_worker:
+  name: "lms-default"
+  queues:
+    - *lms_high
+    - *lms_default
+    - *lms_low
+    - *lms_high_mem
+  replicas: 1
+edxapp_celery_lms_low_priority_worker:
+  name: "lms-low"
+  queues: [*lms_low]
+  replicas: 0
+edxapp_celery_lms_high_mem_worker:
+  name: "lms-high-mem"
+  queues: [*lms_high_mem]
+  replicas: 0
+
+# CMS workers
+edxapp_celery_cms_high_priority_worker:
+  name: "cms-high"
+  queues: [*cms_high]
+  replicas: 0
+edxapp_celery_cms_default_priority_worker:
+  name: "cms-default"
+  queues:
+    - *cms_high
+    - *cms_default
+    - *cms_low
+  replicas: 1
+edxapp_celery_cms_low_priority_worker:
+  name: "cms-low"
+  queues: [*cms_low]
+  replicas: 0
 
 # -- misc
 #

--- a/group_vars/customer/eugene/development/configs/edxapp/cms/settings.yml.j2
+++ b/group_vars/customer/eugene/development/configs/edxapp/cms/settings.yml.j2
@@ -21,9 +21,9 @@ CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
 
 # Celery queues
-HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}"
-DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}"
-LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}"
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}-{{ deployment_stamp }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}-{{ deployment_stamp }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}-{{ deployment_stamp }}"
 
 # MySQL
 DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"

--- a/group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
@@ -24,10 +24,10 @@ CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
 
 # Celery queues
-HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}"
-DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}"
-LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}"
-HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}"
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_lms_high_priority_queue }}-{{ deployment_stamp }}"
+DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}-{{ deployment_stamp }}"
+LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}-{{ deployment_stamp }}"
+HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}-{{ deployment_stamp }}"
 
 # Use a custom theme
 DEFAULT_SITE_THEME: "custom-theme"

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -29,6 +29,16 @@
     pod_label_selector: "{{ pod_label_selector }},deployment_stamp={{ deployment_stamp }}"
   when: app.settings.is_blue_green_compatible | default(True) == True
 
+- name: Render deployment templates to prepare expected running pods calculation
+  set_fact:
+    tpl: "{{ lookup('template', item) | from_yaml }}"
+  with_items: "{{ deployments }}"
+  register: rendered_deployment_templates
+
+- name: Calculate expected running pods given their replicas
+  set_fact:
+    expected_running_pods: "{{ rendered_deployment_templates.results | json_query('[*].ansible_facts.tpl.spec.replicas') | sum }}"
+
 - name: Wait for pods to be running
   debug:
     msg: |
@@ -57,7 +67,7 @@
         )
       ] | flatten | json_query('[?status.phase==`Running`].metadata.name') | length
     ) == (
-      deployments | flatten | length
+      expected_running_pods | int
     )
   retries: 120
   delay: 5


### PR DESCRIPTION
## Purpose

Celery workers deployed with `edxapp` consume too much resources by default to treat too few tasks on small instances. Moreover they are not blue-green compatible since workers still running from an old stack (previous) can treat tasks related to other stacks (current or next). This last point is a major issue.

## Proposal

- [x] deploy celery workers if their queue is different from the default queue (except for the default queue worker)
- [x] suffix celery queues with the current deployment stamp to avoid tasks collision between deployed stacks
