### PR TITLE
🐛(htpasswd) prevent new generation if file already exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Edxapp Celery workers are now configurable (number of replicas and queues to
-  consume)
+  consume) (#207)
 
 ### Fixed
 
 - Pods deployment wait loop is now more robust by relying on the number of pod
-  replicas instead of the number of deployments
-- Add missing ask-vault-pass option in bin/built_images script #210
+  replicas instead of the number of deployments (#207)
+- Add missing ask-vault-pass option in bin/built_images script (#210)
+- Prevent htpasswd file overriding when running the create htpasswd playbook
+  multiple times (#211)
 
 ## [1.0.0-alpha.2] - 2018-12-14
 

--- a/tasks/create_app_htpasswd.yml
+++ b/tasks/create_app_htpasswd.yml
@@ -25,6 +25,11 @@
     - secret
     - htpasswd
 
+- name: "Check application htpasswd file status"
+  stat:
+    path: "{{ app_htpasswd_file_path }}"
+  register: app_htpasswd_file
+
 # Create a htpasswd encrypted file with random passwords for users. Password
 # files are generated plain text by default. They will be encrypted in the next
 # step. If the htpasswd file (or user password files) already exists it won't be
@@ -35,6 +40,7 @@
     name: "{{ item.user }}"
     password: "{{ lookup('password', item.path) }}"
   with_items: "{{ http_basic_auth_user_passwords | json_query('results[*].ansible_facts') }}"
+  when: not app_htpasswd_file.stat.exists
   tags:
     - secret
     - htpasswd


### PR DESCRIPTION
## Purpose

On a project for which the htpasswd secrets have already been generated and committed, deploying the project to OpenShift should not modify the htpasswd files.

## Proposal

Check if file exists and do not invoke the `htpasswd` task if it does.

Fixes #187 