### PR TITLE
✨(jobs) add support for pre/post deployment jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Implement support for pre and post-deployment jobs
+
 ### Fixed
 
 - Edxapp Celery workers DC names are now more explicit (worker vs wsgi)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Fixed
 
 - Edxapp Celery workers DC names are now more explicit (worker vs wsgi)
+- Edxapp internationalization-related objects are now properly created
 
 ### Added
 

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -79,6 +79,10 @@ spec:
           name: edxapp-v-static
         - mountPath: /edx/app/edxapp/data
           name: edxapp-v-data
+{% if EDXAPP_VAULT.TX_TOKEN is defined %}
+        - mountPath: /edx/app/edxapp/edx-platform/conf/locale
+          name: edxapp-v-locale
+{% endif %}
       initContainers:
         # This initContainer has nothing mounted on its "/config" directory. We
         # copy the content of its "/config" directory (fun-platform default
@@ -107,10 +111,6 @@ spec:
               name: edxapp-configmap-{{ service_variant }}
             - mountPath: /tmp/secret
               name: edxapp-secret
-{% if TX_TOKEN is defined %}
-            - mountPath: /edx/app/edxapp/edx-platform/conf/locale
-              name: edxapp-v-locale
-{% endif %}
       volumes:
         - name: edxapp-configmap-{{ service_variant }}
           configMap:
@@ -130,7 +130,7 @@ spec:
         - name: edxapp-v-data
           persistentVolumeClaim:
             claimName: edxapp-pvc-data
-{% if TX_TOKEN is defined %}
+{% if EDXAPP_VAULT.TX_TOKEN is defined %}
         - name: edxapp-v-locale
           persistentVolumeClaim:
             claimName: edxapp-pvc-locale

--- a/apps/edxapp/templates/cms/job_01_internationalization.yml.j2
+++ b/apps/edxapp/templates/cms/job_01_internationalization.yml.j2
@@ -1,4 +1,4 @@
-{% if TX_TOKEN is defined %}
+{% if EDXAPP_VAULT.TX_TOKEN is defined %}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -40,10 +40,10 @@ spec:
             - pip install -I --prefix /tmp transifex-client &&
               cp -R .tx /tmp &&
 {% for lang in edxapp_i18n_languages %}
-              HOME="/tmp" PYTHONPATH=/tmp/lib/python2.7/site-packages/ /tmp/bin/tx --root /tmp pull -l {{ lang }} &&
-              cp -Rf /tmp/conf/locale/{{ lang }} conf/locale/
+              HOME="/tmp" PYTHONPATH=/tmp/lib/python2.7/site-packages/ /tmp/bin/tx --root /tmp pull --mode=reviewed -l {{ lang }} &&
+              cp -Rf /tmp/conf/locale/{{ lang }} conf/locale/ &&
+              python manage.py cms compilemessages -l {{ lang }} &&
 {% endfor %}
-              python manage.py cms compilemessages {{ edxapp_i18n_languages | join(" -l ") }}
               python manage.py cms compilejsi18n
           volumeMounts:
             - mountPath: /edx/app/edxapp/edx-platform/conf/locale

--- a/apps/edxapp/templates/cms/job_01_internationalization.yml.j2
+++ b/apps/edxapp/templates/cms/job_01_internationalization.yml.j2
@@ -9,6 +9,8 @@ metadata:
     service: cms
     version: "{{ edxapp_image_tag }}"
     job_stamp: "{{ job_stamp }}"
+    # Jobs with the "pre" job type will be executed prior to deployments
+    job_type: "pre"
     deployment_stamp: "{{ deployment_stamp }}"
 spec:
   template:

--- a/apps/edxapp/templates/cms/secret_transifex.yml.j2
+++ b/apps/edxapp/templates/cms/secret_transifex.yml.j2
@@ -1,4 +1,4 @@
-{% if TX_TOKEN is defined %}
+{% if EDXAPP_VAULT.TX_TOKEN is defined %}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -8,5 +8,5 @@ metadata:
   name: "{{ edxapp_tx_secret_name }}"
   namespace: "{{ project_name }}"
 data:
-  TX_TOKEN: "{{ TX_TOKEN | default('') | b64encode }}"
+  TX_TOKEN: "{{ EDXAPP_VAULT.TX_TOKEN | default('') | b64encode }}"
 {% endif %}

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -7,7 +7,7 @@ edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "hawthorn.1-2.0.1"
+edxapp_image_tag: "hawthorn.1-2.3.0"
 edxapp_django_port: 8000
 edxapp_sql_dump_url: "https://gist.githubusercontent.com/jmaupetit/76fe7db4a8314fe1fa10895edf14248e/raw/1fd2aab7d57273bbe4cf40603c119a1c8026cbc1/edx-database-hawthorn.sql"
 edxapp_secret_name: "edxapp-{{ edxapp_vault_checksum | default('undefined_edxapp_vault_checksum') }}"

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -12,13 +12,47 @@
     state: "{{ deployment_state | default('present') }}"
   with_items:
     - "{{ endpoints }}"
-    - "{{ deployments }}"
     - "{{ services }}"
   tags:
     - deploy
     - endpoint
-    - deployment
     - service
+
+- name: Prepare jobs ordering & filtering
+  set_fact:
+    template: "{{ item }}"
+    basename: "{{ item | basename }}"
+    job_type: "{{ lookup('template', item) | from_yaml | json_query('metadata.labels.job_type') | default('post', true) }}"
+  register: jobs_basename
+  with_items: "{{ jobs | flatten }}"
+  tags:
+    - deploy
+    - job
+
+- name: Sort jobs alphabetically according to their basename
+  set_fact:
+    jobs: "{{ jobs_basename.results | sort(attribute='ansible_facts.basename') | map(attribute='ansible_facts') | list }}"
+  tags:
+    - deploy
+    - job
+
+- name: Run pre-deployment jobs
+  include_tasks: tasks/run_job.yml
+  loop: "{{ jobs | selectattr('job_type', 'eq', 'pre') | map(attribute='template') | list }}"
+  loop_control:
+    loop_var: job_template
+  tags:
+    - deploy
+    - job
+
+- name: OpenShift deployments with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
+  openshift_raw:
+    definition: "{{ lookup('template', item) | from_yaml }}"
+    state: "{{ deployment_state | default('present') }}"
+  with_items: "{{ deployments }}"
+  tags:
+    - deploy
+    - deployment
 
 - name: Define pod label selector
   set_fact:
@@ -72,26 +106,9 @@
   retries: 120
   delay: 5
 
-- name: Prepare jobs ordering
-  set_fact:
-    template: "{{ item }}"
-    basename: "{{ item | basename }}"
-  register: jobs_basename
-  with_items: "{{ jobs | flatten }}"
-  tags:
-    - deploy
-    - job
-
-- name: Sort jobs alphabetically according to their basename
-  set_fact:
-    jobs: "{{ jobs_basename.results | sort(attribute='ansible_facts.basename') | map(attribute='ansible_facts.template') | list }}"
-  tags:
-    - deploy
-    - job
-
-- name: Run jobs
+- name: Run post-deployment jobs
   include_tasks: tasks/run_job.yml
-  loop: "{{ jobs }}"
+  loop: "{{ jobs | selectattr('job_type', 'eq', 'post') | map(attribute='template') | list }}"
   loop_control:
     loop_var: job_template
   tags:


### PR DESCRIPTION
## Purpose

Some jobs require to be run before deploying an application, hence we need a way to filter jobs and execute them before or after creating deployments.

## Proposal

Filtering is based on the `job_type` label, pre-deployment jobs must be labelled with `job_type: "pre"` and post-deployment jobs must be labelled with `job_type: "post"`. Jobs without `job_type` label will be considered as post-deployment jobs.

For now the only pre-deployment job is edxapp's internationalization job.

