### PR TITLE
Configure replicas on all apps

### DIFF
--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -57,6 +57,19 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
         deploymentconfig: "{{ dc_name }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "{{ dc_name }}"
+              topologyKey: kubernetes.io/hostname
       containers:
       - name: {{ service_variant }}
 {{ command(service_variant, celery_worker) }}

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -14,7 +14,7 @@
 #}
 {%- if celery_worker is defined -%}
   {%- set queues = celery_worker.queues | map('regex_replace', '$', '-%s' | format(deployment_stamp)) -%}
-  {%- set dc_name = "edxapp-worker-%s-%s" | format(celery_worker.name, deployment_stamp) -%}
+  {%- set dc_name = "edxapp-%s-worker-%s" | format(celery_worker.name, deployment_stamp) -%}
   {%- set replicas = celery_worker.replicas -%}
 {%- endif -%}
 

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -6,7 +6,6 @@
 
 {# The dc_name should be unique #}
 {%- set dc_name = "edxapp-%s-%s-%s" | format(service_variant, worker_type, deployment_stamp) -%}
-{%- set replicas = 1 -%}
 
 {#
   In case of a worker, we need to:
@@ -47,7 +46,7 @@ metadata:
 spec:
   # We want to deploy every target DC even if replicas has been set to zero to
   # be able to scale up/down worker for a deployed stack.
-  replicas: {{ replicas }} # number of pods we want
+  replicas: {{ replicas | default(1) }} # number of pods we want
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/cms/dc.yml.j2
+++ b/apps/edxapp/templates/cms/dc.yml.j2
@@ -1,4 +1,5 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "wsgi" %}
+{% set replicas = edxapp_cms_replicas %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/lms/dc.yml.j2
+++ b/apps/edxapp/templates/lms/dc.yml.j2
@@ -1,4 +1,5 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "wsgi" %}
+{% set replicas = edxapp_lms_replicas %}
 
 {% include "apps/edxapp/templates/cms/_dc_base.yml.j2" with context %}

--- a/apps/edxapp/templates/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/nginx/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "edxapp-nginx-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1
+  replicas: {{ edxapp_nginx_replicas }}
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/nginx/dc.yml.j2
@@ -19,6 +19,19 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
         deploymentconfig: "edxapp-nginx-{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "edxapp-nginx-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: "{{ edxapp_nginx_image_name }}:{{ edxapp_nginx_image_tag }}"
           name: nginx

--- a/apps/edxapp/templates/nginx/route_cms.yml.j2
+++ b/apps/edxapp/templates/nginx/route_cms.yml.j2
@@ -13,6 +13,8 @@ metadata:
     route_target_service: "cms"
   annotations:
     kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   host: "{{ edxapp_cms_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/edxapp/templates/nginx/route_lms.yml.j2
+++ b/apps/edxapp/templates/nginx/route_lms.yml.j2
@@ -13,6 +13,8 @@ metadata:
     route_target_service: "lms"
   annotations:
     kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   host: "{{ edxapp_lms_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/edxapp/templates/nginx/route_preview.yml.j2
+++ b/apps/edxapp/templates/nginx/route_preview.yml.j2
@@ -13,6 +13,8 @@ metadata:
     route_target_service: "lms"
   annotations:
     kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   host: "{{ edxapp_preview_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -9,6 +9,8 @@ edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 edxapp_image_name: "fundocker/edxapp"
 edxapp_image_tag: "hawthorn.1-2.3.0"
 edxapp_django_port: 8000
+edxapp_lms_replicas: 1
+edxapp_cms_replicas: 1
 edxapp_sql_dump_url: "https://gist.githubusercontent.com/jmaupetit/76fe7db4a8314fe1fa10895edf14248e/raw/1fd2aab7d57273bbe4cf40603c119a1c8026cbc1/edx-database-hawthorn.sql"
 edxapp_secret_name: "edxapp-{{ edxapp_vault_checksum | default('undefined_edxapp_vault_checksum') }}"
 
@@ -72,6 +74,7 @@ edxapp_nginx_image_name: "fundocker/openshift-nginx"
 edxapp_nginx_image_tag: "1.13"
 edxapp_nginx_cms_port: 8081
 edxapp_nginx_lms_port: 8071
+edxapp_nginx_replicas: 1
 edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
 
 # -- celery/redis

--- a/apps/forum/templates/app/dc.yml.j2
+++ b/apps/forum/templates/app/dc.yml.j2
@@ -19,6 +19,19 @@ spec:
         deploymentconfig: "forum-app-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "forum-app-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: forum
           # We point to a local registry image build for this "live" image (see

--- a/apps/forum/templates/app/dc.yml.j2
+++ b/apps/forum/templates/app/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "forum-app-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1 # number of pods we want
+  replicas: {{ forum_app_replicas }}
   template:
     metadata:
       labels:

--- a/apps/forum/templates/app/route.yml.j2
+++ b/apps/forum/templates/app/route.yml.j2
@@ -13,6 +13,8 @@ metadata:
     route_target_service: "app"
   annotations:
     kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   host: "{{ forum_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/forum/vars/all/main.yml
+++ b/apps/forum/vars/all/main.yml
@@ -7,6 +7,7 @@ forum_host: "forum.{{ project_name}}.{{ domain_name }}"
 forum_image_name: "fundocker/forum"
 forum_image_tag: "1.0.0-beta.1"
 forum_port: 9292
+forum_app_replicas: 1
 forum_secret_name: "forum-{{ forum_vault_checksum | default('undefined_forum_vault_checksum') }}"
 
 # -- elasticsearch

--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "marsha-app-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1 # number of pods we want
+  replicas: {{ marsha_app_replicas }}
   template:
     metadata:
       labels:

--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -19,6 +19,19 @@ spec:
         deploymentconfig: "marsha-app-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "marsha-app-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: marsha
           # We point to a local registry image build for this "live" image (see

--- a/apps/marsha/templates/nginx/dc.yml.j2
+++ b/apps/marsha/templates/nginx/dc.yml.j2
@@ -19,6 +19,19 @@ spec:
         deploymentconfig: "marsha-nginx-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "marsha-nginx-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: "{{ marsha_nginx_image_name }}:{{ marsha_nginx_image_tag }}"
           name: nginx

--- a/apps/marsha/templates/nginx/dc.yml.j2
+++ b/apps/marsha/templates/nginx/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "marsha-nginx-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1
+  replicas: {{ marsha_nginx_replicas }}
   template:
     metadata:
       labels:

--- a/apps/marsha/templates/nginx/route.yml.j2
+++ b/apps/marsha/templates/nginx/route.yml.j2
@@ -13,6 +13,8 @@ metadata:
     route_target_service: "app"
   annotations:
     kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   host: "{{ marsha_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -7,6 +7,7 @@ marsha_host: "marsha.{{ project_name}}.{{ domain_name }}"
 marsha_nginx_image_name: "fundocker/openshift-nginx"
 marsha_nginx_image_tag: "1.13"
 marsha_nginx_port: 8061
+marsha_nginx_replicas: 1
 marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 
 # -- postgresql
@@ -22,6 +23,7 @@ marsha_postgresql_secret_name: "marsha-postgresql-{{ marsha_vault_checksum | def
 marsha_image_name: "fundocker/marsha"
 marsha_image_tag: "1.0.0-alpha.3-alpine"
 marsha_django_port: 8000
+marsha_app_replicas: 1
 marsha_django_configuration: "Development"
 marsha_secret_name: "marsha-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"
 marsha_cloudfront_private_key_secret_name: "marsha-sshkey-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"

--- a/apps/redirect/templates/nginx/dc.yml.j2
+++ b/apps/redirect/templates/nginx/dc.yml.j2
@@ -7,7 +7,7 @@ metadata:
   name: redirect-nginx-{{ deployment_stamp }}
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1
+  replicas: {{ redirect_nginx_replicas }}
   template:
     metadata:
       labels:
@@ -16,7 +16,7 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:
-        - image: "{{ nginx_image }}:{{ nginx_tag }}"
+        - image: "{{ redirect_nginx_image_name }}:{{ redirect_nginx_image_tag }}"
           name: nginx
           ports:
             - containerPort: 80

--- a/apps/redirect/templates/nginx/dc.yml.j2
+++ b/apps/redirect/templates/nginx/dc.yml.j2
@@ -15,6 +15,19 @@ spec:
         deploymentconfig: redirect-nginx-{{ deployment_stamp }}
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "redirect-nginx-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: "{{ redirect_nginx_image_name }}:{{ redirect_nginx_image_tag }}"
           name: nginx

--- a/apps/redirect/vars/all/main.yml
+++ b/apps/redirect/vars/all/main.yml
@@ -1,0 +1,6 @@
+# Application default configuration
+
+# -- nginx
+redirect_nginx_image_name: "fundocker/openshift-nginx"
+redirect_nginx_image_tag: "1.13"
+redirect_nginx_replicas: 1

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -19,6 +19,19 @@ spec:
         deploymentconfig: "richie-app-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "richie-app-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: richie
           # We point to a local registry image build for this "live" image (see

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "richie-app-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1 # number of pods we want
+  replicas: {{ richie_app_replicas }}
   template:
     metadata:
       labels:

--- a/apps/richie/templates/nginx/dc.yml.j2
+++ b/apps/richie/templates/nginx/dc.yml.j2
@@ -19,6 +19,19 @@ spec:
         deploymentconfig: "richie-nginx-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: deploymentconfig
+                  operator: In
+                  values:
+                  - "richie-nginx-{{ deployment_stamp }}"
+              topologyKey: kubernetes.io/hostname
       containers:
         - image: "{{ richie_nginx_image_name }}:{{ richie_nginx_image_tag }}"
           name: nginx

--- a/apps/richie/templates/nginx/dc.yml.j2
+++ b/apps/richie/templates/nginx/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: "richie-nginx-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1
+  replicas: {{ richie_nginx_replicas }}
   template:
     metadata:
       labels:

--- a/apps/richie/templates/nginx/route.yml.j2
+++ b/apps/richie/templates/nginx/route.yml.j2
@@ -13,6 +13,8 @@ metadata:
     route_target_service: "app"
   annotations:
     kubernetes.io/tls-acme: "true"
+    haproxy.router.openshift.io/disable_cookies: "true"
+    haproxy.router.openshift.io/balance: "roundrobin"
 spec:
   host: "{{ richie_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -7,6 +7,7 @@ richie_host: "richie.{{ project_name}}.{{ domain_name }}"
 richie_nginx_image_name: "fundocker/openshift-nginx"
 richie_nginx_image_tag: "1.13"
 richie_nginx_port: 8061
+richie_nginx_replicas: 1
 richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 
 # -- elasticsearch
@@ -28,6 +29,7 @@ richie_postgresql_secret_name: "richie-postgresql-{{ richie_vault_checksum | def
 richie_image_name: "fundocker/richie"
 richie_image_tag: "0.1.0-alpha.3-alpine"
 richie_django_port: 8000
+richie_app_replicas: 1
 richie_django_configuration: "Development"
 richie_secret_name: "richie-{{ richie_vault_checksum | default('undefined_richie_vault_checksum') }}"
 

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -390,7 +390,7 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
             ]
         }
 
-        self.assertEquals(
+        self.assertEqual(
             merge_with_database(
                 base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
             ),
@@ -449,7 +449,7 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
             ],
         }
 
-        self.assertEquals(
+        self.assertEqual(
             merge_with_database(
                 base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
             ),
@@ -490,7 +490,7 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
             ]
         }
 
-        self.assertEquals(
+        self.assertEqual(
             merge_with_database(
                 base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
             ),
@@ -547,7 +547,7 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
             ]
         }
 
-        self.assertEquals(
+        self.assertEqual(
             merge_with_database(
                 base, database, "edxapp", "eugene", {"name": "development", "code": "d"}
             ),
@@ -589,7 +589,7 @@ class TestMergeWithDatabaseFilter(unittest.TestCase):
                 ]
             }
 
-            self.assertEquals(
+            self.assertEqual(
                 merge_with_database(
                     base,
                     database,


### PR DESCRIPTION
## Purpose

We need to run several replicas of our application and nginx pods for redundancy and/or scaling.

## Proposal

- [x] make the number of replicas configurable in all apps for stateless application and nginx pods,
- [x] add a rule to make sure each replica of a given pod is started on a differnt OpenShift node for redundancy,
- [x] modify routes to get a real round-robin because by default OpenShift uses a cookie to always send a given user to the same pod which is not optimal for stateless applications.

Side chores:
- [x] rename edxapp's Celery worker pods for coherence with the wsgi pods,
- [x] replace deprecated use of `assertEquals` by `assertEqual`.
