### PR TITLE
✨(volumes) add create_volumes playbook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add a new create_volumes playbook to create volumes on an existing project
+
 ### Fixed
 
 - Add app namespace in front of the DJANGO_CLOUDFRONT_PRIVATE_KEY variable where missing

--- a/create_volumes.yml
+++ b/create_volumes.yml
@@ -1,0 +1,20 @@
+---
+- hosts: local
+  gather_facts: False
+
+  pre_tasks:
+    - import_tasks: tasks/validate_configuration.yml
+
+  tasks:
+    - name: Display playbook name
+      debug: msg="==== Starting create_volumes playbook ===="
+      tags: volume
+
+    - import_tasks: tasks/set_vars.yml
+
+    - include_tasks: tasks/run_tasks_for_apps.yml
+      vars:
+        tasks:
+          - tasks/create_app_volumes
+      tags:
+        - volume

--- a/init_project.yml
+++ b/init_project.yml
@@ -1,4 +1,5 @@
 - import_playbook: create_project.yml
+- import_playbook: create_volumes.yml
 - import_playbook: create_htpasswds.yml
   when: activate_http_basic_auth
 - import_playbook: create_secrets.yml
@@ -23,7 +24,6 @@
       vars:
         tasks:
           - get_objects_for_app
-          - create_app_volumes
           - create_static_services_routes
           - create_app_image_streams
       tags:

--- a/tasks/create_app_volumes.yml
+++ b/tasks/create_app_volumes.yml
@@ -2,12 +2,12 @@
 # Create volumes for an app
 
 - name: Print app name
-  debug: msg="App name {{ app.name }}"
-  tags: route
+  debug:
+    msg: "App name {{ app.name }}"
+  tags: volume
 
 - name: Make sure application volumes exist
   openshift_raw:
-    force: true
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: present
   with_items: "{{ app.volumes }}"


### PR DESCRIPTION
## Purpose

When developing a new feature that requires a new volumes, one may need to create this new volume on a live project that already have been initialized.

## Proposal

We've added a create_volumes playbook that can be run during project's initialization and on a live project. We've removed the `force: true` flag on volumes creation which does not seem to be required.
