### PR TITLE
🐛(marsha) fix CloudFront variable namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add app namespace in front of the DJANGO_CLOUDFRONT_PRIVATE_KEY variable where missing
+
 ## [1.0.0-alpha.5] - 2019-01-04
 
 ### Added

--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -61,7 +61,7 @@ spec:
               mountPath: /data/media
             - name: marsha-v-static
               mountPath: /data/static
-{% if DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
+{% if MARSHA_VAULT.DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
             - mountPath: "{{ marsha_cloudfront_private_key_path | dirname }}"
               name: marsha-cloudfront-private-key-secret
 {% endif %}
@@ -72,7 +72,7 @@ spec:
         - name: marsha-v-static
           persistentVolumeClaim:
             claimName: marsha-pvc-static
-{% if DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
+{% if MARSHA_VAULT.DJANGO_CLOUDFRONT_PRIVATE_KEY is defined %}
         - name: marsha-cloudfront-private-key-secret
           secret:
             secretName: "{{ marsha_cloudfront_private_key_secret_name }}"


### PR DESCRIPTION
## Purpose

We recently added a namespace to our Ansible variables in order to avoid conflicts between 2 apps. 

We forgot to modify the `DJANGO_CLOUDFRONT_PRIVATE_KEY` variable in the `marsha` app and it broke the functionality because the corresponding SSH key was not mounted any more in the container.

## Proposal

Add namespace in front of the `DJANGO_CLOUDFRONT_PRIVATE_KEY` variable where it missing.

