### PR TITLE
👷(circle) check that the changelog has been filled

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,6 +133,16 @@ jobs:
       - *docker_load
       - run: bin/lint plugins
 
+  check-changelog:
+    <<: *defaults
+
+    steps:
+      - checkout
+      - run:
+          name: Check that the CHANGELOG has been modified in the current branch
+          command: |
+            git whatchanged --name-only --pretty="" origin..HEAD | grep CHANGELOG
+
   test-built:
     <<: *defaults
 
@@ -439,6 +449,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - check-changelog:
+          filters:
+            branches:
+              ignore: master
+            tags:
+              ignore: /.*/
       - test-built:
           requires:
             - lint-bash

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+- Add a new check in the CI to ensure that the CHANGELOG has been modified in a
+  submitted pull request.
+
 ## [1.0.0-alpha.6] - 2019-01-09
 
 ### Added


### PR DESCRIPTION
## Purpose

We need a way to check that the changelog has been filled for every submitted PR. This check should not be a requirement, it's just a friendly reminder for our co-workers.

## Proposal

- [x] add the check-changelog new step in the CI. 

