### PR TITLE
✨(services) allow to define multiple services object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Allow to define multiple Service objects.
+
 ## [1.0.0-alpha.7] - 2019-01-17
 
 ### Added

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -34,7 +34,7 @@
     builds: "{{ templates | map('regex_search', '.*/bc.*\\.yml\\.j2$') | select('string') | list }}"
     deployments: "{{ templates | map('regex_search', '.*/dc.*\\.yml\\.j2$') | select('string') | list }}"
     endpoints: "{{ templates | map('regex_search', '.*/ep.*\\.yml\\.j2$') | select('string') | list }}"
-    services: "{{ templates | map('regex_search', '.*/svc\\.yml\\.j2$') | select('string') | list }}"
+    services: "{{ templates | map('regex_search', '.*/svc.*\\.yml\\.j2$') | select('string') | list }}"
     streams: "{{ templates | map('regex_search', '.*/is.*\\.yml\\.j2$') | select('string') | list }}"
     jobs: "{{ templates | map('regex_search', '.*/job_.*\\.yml\\.j2$') | select('string') | list }}"
     routes: "{{ templates | map('regex_search', '.*/route.*\\.yml\\.j2$') | select('string') | list }}"


### PR DESCRIPTION
## Purpose

For now, for each service in an application it is not possible to define more than one OKD `Service` object. We want to define several `Service` object like it is possible to do this with `DeploymentConfig` for example.


## Proposal

- [x] change the regex looking for `svc`files in `get_objects_for_app` task
