### PR TITLE
Create ConfigMaps containing environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Create ConfigMaps to be consumed in environment variables in a DeploymentConfig.
+
 ## [1.0.0] - 2019-01-22
 
 ### Added

--- a/plugins/filter/merge.py
+++ b/plugins/filter/merge.py
@@ -47,11 +47,14 @@ def merge_with_app(base, new):
         if len(new_app_selected_services) != 1:
             continue
         new_service = new_app_selected_services[0]
-        for k in ("configs", "templates"):
+        for k in ("configs", "templates", "environment_variables"):
             if new_service.get(k) is None:
                 continue
-            # Use the list(set()) trick to remove duplicated items
-            base_service[k] = sorted(list(set(new_service[k] + base_service[k])))
+            if isinstance(new_service[k], list):
+                # Use the list(set()) trick to remove duplicated items
+                base_service[k] = sorted(list(set(new_service[k] + base_service[k])))
+            elif isinstance(new_service[k], str):
+                base_service[k] = new_service[k]
 
         # Add service missing keys (could be meta, such as host, etc.)
         for k, v in new_service.iteritems():

--- a/tasks/create_app_config.yml
+++ b/tasks/create_app_config.yml
@@ -1,6 +1,14 @@
 ---
 # Create ConfigMaps for an app
 
+# First we create ConfigMaps dedicated to be used as a volume in a DeploymentContfig [1]
+# Then we will deal with ConfigMaps dedicated to be used as environment variables [2]
+#
+# [1] https://docs.okd.io/latest/dev_guide/configmaps.html#configmaps-use-case-consuming-in-volumes
+# [2] https://docs.okd.io/latest/dev_guide/configmaps.html#configmaps-use-case-consuming-in-env-vars
+
+################# ConfigMaps used in a volume #######################
+
 # Select services with ConfigMaps
 - name: Set ConfigMaps for application {{ app.name }}
   set_fact:
@@ -55,3 +63,26 @@
           deployment_stamp: "{{ deployment_stamp }}"
       data: "{{ item.value }}"
   with_dict: "{{ configmaps }}"
+
+################# ConfigMaps used to populate environment variables #######################
+
+# Select services with ConfigMaps
+- name: Set environment variables ConfigMaps for application {{ app.name }}
+  set_fact:
+    app_configmaps: "{{ app | json_query('services[?environment_variables].{name: name, environment_variables: environment_variables}') }}"
+
+- name: Create environment variables ConfigMaps
+  openshift_raw:
+    state: present
+    name: "{{ app.name }}-{{ item.name }}-dotenv-{{ deployment_stamp }}"
+    namespace: "{{ project_name }}"
+    definition:
+      apiVersion: v1
+      kind: ConfigMap
+      metadata:
+        labels:
+          app: "{{ app.name }}"
+          service: "{{ item.name }}"
+          deployment_stamp: "{{ deployment_stamp }}"
+      data: "{{ lookup('template', item.environment_variables) | from_yaml }}"
+  loop: "{{ app_configmaps }}"

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -211,6 +211,7 @@ class TestMergeWithAppFilter(unittest.TestCase):
                     "name": "bar",
                     "configs": ["bar.conf"],
                     "templates": ["bar/dc.yml", "bar/svc.yml"],
+                    "environment_variables": "/foo/_env.yml.j2",
                 },
                 {
                     "name": "baz",
@@ -230,6 +231,7 @@ class TestMergeWithAppFilter(unittest.TestCase):
                     "name": "bar",
                     "configs": ["bar2.conf"],
                     "templates": ["bar/dc.yml", "bar/ep.yml"],
+                    "environment_variables": "/bar/_env.yml.j2",
                 },
                 {
                     "name": "fun",
@@ -247,6 +249,7 @@ class TestMergeWithAppFilter(unittest.TestCase):
                     "name": "bar",
                     "configs": ["bar.conf", "bar2.conf"],
                     "templates": ["bar/dc.yml", "bar/svc.yml", "bar/ep.yml"],
+                    "environment_variables": "/bar/_env.yml.j2",
                 },
                 {
                     "name": "baz",


### PR DESCRIPTION
## Purpose

In K8s or OKD, ConfigMap can be [consumed in a DeploymentConfig](https://docs.okd.io/latest/dev_guide/configmaps.html#configmaps-use-case-consuming-in-env-vars) to inject environment variables.

In Arnold we cannot create a ConfigMap containing environment variables. This will solve this issue.
The advantage to do that is to have more configurable environment variables allowing to inject more (or less) and modified environment variables in a DeploymentConfig without knowing absolutely every environment variable for a given docker image.

## Proposal

We would like to have a template file describing environment variables. By convention it will be named `_env.yml.j2` and will be in the `templates` directory of a service.
**It will be also possible to override the path to this file when apps are declared in the `main.yml` file present in the customer group_vars**. For `eugene` customer in development, we could have for example:

```
apps:
  - name: mailcatcher
  - name: marsha
    services:
      - name: app
        # We override the file containing environment variables injected in a ConfigMap
        environment_variables: group_vars/customer/eugene/development/environment/app/_env.yml.j2
  - name: forum
  - name: richie
  - name: edxapp
    services:
      - name: cms
        # We override default ConfigMap for this customer/env_type
        #
        # Nota bene: file paths are not enforced, but the override mechanism
        # implies that the file names are identical, e.g. docker_run.py.j2
        configs:
          - group_vars/customer/eugene/development/configs/edxapp/cms/docker_run.py.j2
          - group_vars/customer/eugene/development/configs/edxapp/cms/settings.yml.j2
      - name: lms
        configs:
          - group_vars/customer/eugene/development/configs/edxapp/lms/docker_run.py.j2
          - group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
  - name: redis
  - name: hello
```

- [x] modify plugins to detect and inject in apps definition the `environment_variables` key
- [x] allow to override the `environment_variables` file path
- [x] complete create_app_config task to create new ConfigMaps