### PR TITLE
Add applications health check probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- We now perform health checks to every service pods by implementing and
+  defining `livenessProbe` and `readinessProbe` (except for Learninglocker
+  applications).
+
 ### Fixed
 
-* Remove obsolete GitLab CI configuration
+- Remove obsolete GitLab CI configuration
 
 ## [1.5.0] - 2019-02-20
 

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -7,6 +7,9 @@
 {# The dc_name should be unique #}
 {%- set dc_name = "edxapp-%s-%s-%s" | format(service_variant, worker_type, deployment_stamp) -%}
 
+{# Set the expected target current host for this DC #}
+{%- set host = (service_variant == "cms") | ternary(edxapp_cms_host, edxapp_lms_host) -%}
+
 {#
   In case of a worker, we need to:
     1. patch attached queue names to make them specific to this deployment
@@ -82,6 +85,44 @@ spec:
         # ImageStream and BuildConfig templates)
         image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-{{ service_variant }}:{{ edxapp_image_tag }}-live"
         imagePullPolicy: Always
+{% if celery_worker is defined %}
+        livenessProbe:
+          exec:
+            command:
+              - "/bin/bash"
+              - "-c"
+              - "python manage.py {{ service_variant }} celery inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
+          initialDelaySeconds: 120
+          periodSeconds: 5
+        readinessProbe:
+          exec:
+            command:
+              - "/bin/bash"
+              - "-c"
+              - "python manage.py {{ service_variant }} celery inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
+          initialDelaySeconds: 60
+          periodSeconds: 3
+{% else %}
+        # Pod probes that only apply for wsgi services
+        livenessProbe:
+          httpGet:
+            path: /heartbeat
+            port: {{ edxapp_django_port }}
+            httpHeaders:
+              - name: Host
+                value: "{{ host }}"
+          initialDelaySeconds: 120
+          periodSeconds: 5
+        readinessProbe:
+          httpGet:
+            path: /heartbeat
+            port: {{ edxapp_django_port }}
+            httpHeaders:
+              - name: Host
+                value: "{{ host }}"
+          initialDelaySeconds: 60
+          periodSeconds: 3
+{% endif %}
         volumeMounts:
         - mountPath: /config
           name: edxapp-config

--- a/apps/edxapp/templates/memcached/dc.yml.j2
+++ b/apps/edxapp/templates/memcached/dc.yml.j2
@@ -9,7 +9,7 @@ metadata:
   name: edxapp-memcached-{{ deployment_stamp }}
   namespace: "{{ project_name }}"
 spec:
-  replicas: 1  # number of pods we want
+  replicas: 1 # number of pods we want
   template:
     metadata:
       labels:
@@ -22,3 +22,59 @@ spec:
       containers:
         - name: memcached
           image: "{{ edxapp_memcached_image_name }}:{{ edxapp_memcached_image_tag }}"
+          ports:
+            - containerPort: {{ edxapp_memcached_port }}
+              protocol: TCP
+          # We use a shared volume between the memcached container and its
+          # sidecar container to check if memcached is responding: if the file
+          # /tmp/healthcheck/ok does not exist, then it means that the sidecar
+          # container probe failed and both containers should be restarted.
+          livenessProbe:
+            exec:
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "test -f /tmp/healthcheck/ok"
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "test -f /tmp/healthcheck/ok"
+            initialDelaySeconds: 5
+            periodSeconds: 3
+          volumeMounts:
+            - mountPath: /tmp/healthcheck
+              name: tmp-healthcheck
+
+        - name: memcached-sidecar
+          image: "busybox:latest"
+          command: ["/bin/sh", "-c"]
+          # At first, consider memcached as up and running by creating the
+          # /tmp/healthcheck/ok file, and, then keep the container up by running
+          # an infinite loop.
+          args:
+            - |
+              mkdir -p /tmp/healthcheck &&
+              touch /tmp/healthcheck/ok &&
+              while true; do echo $(date); sleep 3600; done
+          livenessProbe:
+            exec:
+              command:
+                # Set a "healtz: ok" entry, then get healtz and check it's
+                # value. If it's not "ok" or none, then remove the healthcheck
+                # ok file.
+                - "/bin/sh"
+                - "-c"
+                - echo -e "set healtz 0 0 2\r\nok\r\nget healtz\r" | nc edxapp-memcached-{{ deployment_stamp }} {{ edxapp_memcached_port }} | grep ok || rm /tmp/healthcheck/ok
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          volumeMounts:
+            - mountPath: /tmp/healthcheck
+              name: tmp-healthcheck
+
+      volumes:
+        - name: tmp-healthcheck
+          emptyDir: {}

--- a/apps/edxapp/templates/nginx/_configs/healthcheck.conf.j2
+++ b/apps/edxapp/templates/nginx/_configs/healthcheck.conf.j2
@@ -1,0 +1,9 @@
+server {
+  listen {{ edxapp_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ edxapp_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+}

--- a/apps/edxapp/templates/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/nginx/dc.yml.j2
@@ -53,6 +53,18 @@ spec:
               name: edxapp-htpasswd
             {% endif %}
 
+          livenessProbe:
+            httpGet:
+              path: "{{ edxapp_nginx_healthcheck_endpoint }}"
+              port: {{ edxapp_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "{{ edxapp_nginx_healthcheck_endpoint }}"
+              port: {{ edxapp_nginx_healthcheck_port }}
+            initialDelaySeconds: 5
+            periodSeconds: 3
       volumes:
         - name: edxapp-v-nginx
           configMap:

--- a/apps/edxapp/templates/nginx/svc.yml.j2
+++ b/apps/edxapp/templates/nginx/svc.yml.j2
@@ -18,6 +18,10 @@ spec:
       port: {{ edxapp_nginx_lms_port }}
       protocol: TCP
       targetPort: {{ edxapp_nginx_lms_port }}
+    - name: "{{ edxapp_nginx_healthcheck_port }}-tcp"
+      port: {{ edxapp_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ edxapp_nginx_healthcheck_port }}
   selector:
     app: edxapp
     deploymentconfig: "edxapp-nginx-{{ deployment_stamp }}"

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -92,6 +92,8 @@ edxapp_nginx_cms_port: 8081
 edxapp_nginx_lms_port: 8071
 edxapp_nginx_replicas: 1
 edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
+edxapp_nginx_healthcheck_port: 5000
+edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
 
 # -- celery/redis
 

--- a/apps/forum/templates/app/dc.yml.j2
+++ b/apps/forum/templates/app/dc.yml.j2
@@ -38,6 +38,24 @@ spec:
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/forum:{{ forum_image_tag }}-live"
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /heartbeat
+              port: {{ forum_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ forum_host }}"
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /heartbeat
+              port: {{ forum_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ forum_host }}"
+            initialDelaySeconds: 5
+            periodSeconds: 3
           ports:
             - containerPort: "{{ forum_port }}"
               protocol: TCP

--- a/apps/learninglocker/templates/nginx/_configs/healthcheck.conf.j2
+++ b/apps/learninglocker/templates/nginx/_configs/healthcheck.conf.j2
@@ -1,0 +1,9 @@
+server {
+  listen {{ learninglocker_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ learninglocker_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+}

--- a/apps/learninglocker/templates/nginx/dc.yml.j2
+++ b/apps/learninglocker/templates/nginx/dc.yml.j2
@@ -24,6 +24,18 @@ spec:
           ports:
             - containerPort: {{ learninglocker_nginx_port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "{{ learninglocker_nginx_healthcheck_endpoint }}"
+              port: {{ learninglocker_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "{{ learninglocker_nginx_healthcheck_endpoint }}"
+              port: {{ learninglocker_nginx_healthcheck_port }}
+            initialDelaySeconds: 5
+            periodSeconds: 3
           volumeMounts:
             - mountPath: /etc/nginx/conf.d
               name: learninglocker-v-nginx

--- a/apps/learninglocker/templates/nginx/svc.yml.j2
+++ b/apps/learninglocker/templates/nginx/svc.yml.j2
@@ -13,6 +13,10 @@ spec:
       port: {{ learninglocker_nginx_port }}
       protocol: TCP
       targetPort: {{ learninglocker_nginx_port }}
+    - name: "{{ learninglocker_nginx_healthcheck_port }}-tcp"
+      port: {{ learninglocker_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ learninglocker_nginx_healthcheck_port }}
   selector:
     app: learninglocker
     deploymentconfig: "learninglocker-nginx"

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -3,21 +3,21 @@
 # -- route
 learninglocker_host: "learninglocker.{{ project_name}}.{{ domain_name }}"
 
-# learning locker info
+# -- learninglocker
 learninglocker_image_name: "fundocker/learninglocker"
 learninglocker_image_tag: "v2.6.2"
 learninglocker_secret_name: "learninglocker-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 learninglocker_ui_port: 3000
 learninglocker_api_port: 8080
 
-# learning locker xapi info
+# -- xapi
 learninglocker_xapi_image_name: "fundocker/xapi-service"
 learninglocker_xapi_image_tag: "v2.2.15"
 learninglocker_xapi_port: 8081
 learninglocker_xapi_secret_name: "learninglocker-xapi-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 learnonglocker_xapi_storage_volume_size: 2Gi
 
-#learning locker monogo db connection info
+# -- monogodb
 learninglocker_mongodb_version: "3.2"
 learninglocker_mongodb_image_name: "centos/mongodb-32-centos7"
 learninglocker_mongodb_image_tag: "3.2"
@@ -25,10 +25,12 @@ learninglocker_mongodb_port: 27017
 learninglocker_mongodb_host: "learninglocker-mongodb"
 learninglocker_mongodb_secret_name: "learninglocker-mongodb-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 
-# learninglocker nginx info
+# -- nginx
 learninglocker_nginx_image_name: "fundocker/openshift-nginx"
 learninglocker_nginx_image_tag: "1.13"
 learninglocker_nginx_port: 8888
+learninglocker_nginx_healthcheck_port: 5000
+learninglocker_nginx_healthcheck_endpoint: "/__healthcheck__"
 
 # -- misc
 #

--- a/apps/marsha/templates/app/dc.yml.j2
+++ b/apps/marsha/templates/app/dc.yml.j2
@@ -38,6 +38,24 @@ spec:
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/marsha:{{ marsha_image_tag }}-live"
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /__heartbeat__
+              port: {{ marsha_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ marsha_host }}"
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: {{ marsha_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ marsha_host }}"
+            initialDelaySeconds: 5
+            periodSeconds: 3
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: marsha.settings

--- a/apps/marsha/templates/nginx/_configs/healthcheck.conf.j2
+++ b/apps/marsha/templates/nginx/_configs/healthcheck.conf.j2
@@ -1,0 +1,9 @@
+server {
+  listen {{ marsha_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ marsha_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+}

--- a/apps/marsha/templates/nginx/dc.yml.j2
+++ b/apps/marsha/templates/nginx/dc.yml.j2
@@ -53,6 +53,18 @@ spec:
               name: marsha-htpasswd
             {% endif %}
 
+          livenessProbe:
+            httpGet:
+              path: "{{ marsha_nginx_healthcheck_endpoint }}"
+              port: {{ marsha_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "{{ marsha_nginx_healthcheck_endpoint }}"
+              port: {{ marsha_nginx_healthcheck_port }}
+            initialDelaySeconds: 5
+            periodSeconds: 3
       volumes:
         - name: marsha-v-nginx
           configMap:

--- a/apps/marsha/templates/nginx/svc.yml.j2
+++ b/apps/marsha/templates/nginx/svc.yml.j2
@@ -14,6 +14,10 @@ spec:
       port: {{ marsha_nginx_port }}
       protocol: TCP
       targetPort: {{ marsha_nginx_port }}
+    - name: "{{ marsha_nginx_healthcheck_port }}-tcp"
+      port: {{ marsha_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ marsha_nginx_healthcheck_port }}
   selector:
     app: marsha
     deploymentconfig: "marsha-nginx-{{ deployment_stamp }}"

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -9,6 +9,8 @@ marsha_nginx_image_tag: "1.13"
 marsha_nginx_port: 8061
 marsha_nginx_replicas: 1
 marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
+marsha_nginx_healthcheck_port: 5000
+marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
 
 # -- postgresql
 marsha_postgresql_version: "9.6"

--- a/apps/redis/templates/app/dc.yml.j2
+++ b/apps/redis/templates/app/dc.yml.j2
@@ -25,6 +25,22 @@ spec:
       containers:
         - name: redis
           image: "{{ redis_app_image_name }}:{{ redis_app_image_tag }}"
+          livenessProbe:
+            exec:
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "redis-cli ping"
+            initialDelaySeconds: 120
+            periodSeconds: 5
+          readinessProbe:
+            exec:
+              command:
+                - "/bin/bash"
+                - "-c"
+                - "redis-cli ping"
+            initialDelaySeconds: 60
+            periodSeconds: 3
           volumeMounts:
             - mountPath: /data
               name: redis-v-data

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -38,6 +38,24 @@ spec:
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /__heartbeat__
+              port: {{ richie_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ richie_host }}"
+            initialDelaySeconds: 60
+            periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /__lbheartbeat__
+              port: {{ richie_django_port }}
+              httpHeaders:
+                - name: Host
+                  value: "{{ richie_host }}"
+            initialDelaySeconds: 5
+            periodSeconds: 3
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: settings

--- a/apps/richie/templates/nginx/_configs/healthcheck.conf.j2
+++ b/apps/richie/templates/nginx/_configs/healthcheck.conf.j2
@@ -1,0 +1,9 @@
+server {
+  listen {{ richie_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ richie_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+}

--- a/apps/richie/templates/nginx/dc.yml.j2
+++ b/apps/richie/templates/nginx/dc.yml.j2
@@ -53,6 +53,18 @@ spec:
               name: richie-htpasswd
             {% endif %}
 
+          livenessProbe:
+            httpGet:
+              path: "{{ richie_nginx_healthcheck_endpoint }}"
+              port: {{ richie_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "{{ richie_nginx_healthcheck_endpoint }}"
+              port: {{ richie_nginx_healthcheck_port }}
+            initialDelaySeconds: 5
+            periodSeconds: 3
       volumes:
         - name: richie-v-nginx
           configMap:

--- a/apps/richie/templates/nginx/svc.yml.j2
+++ b/apps/richie/templates/nginx/svc.yml.j2
@@ -14,6 +14,10 @@ spec:
       port: {{ richie_nginx_port }}
       protocol: TCP
       targetPort: {{ richie_nginx_port }}
+    - name: "{{ richie_nginx_healthcheck_port }}-tcp"
+      port: {{ richie_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ richie_nginx_healthcheck_port }}
   selector:
     app: richie
     deploymentconfig: "richie-nginx-{{ deployment_stamp }}"

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -9,6 +9,8 @@ richie_nginx_image_tag: "1.13"
 richie_nginx_port: 8061
 richie_nginx_replicas: 1
 richie_nginx_htpasswd_secret_name: "richie-htpasswd"
+richie_nginx_healthcheck_port: 5000
+richie_nginx_healthcheck_endpoint: "/__healthcheck__"
 
 # -- elasticsearch
 richie_elasticsearch_image_name: "fundocker/openshift-elasticsearch"

--- a/core_apps/redirect/templates/nginx/_configs/healthcheck.conf.j2
+++ b/core_apps/redirect/templates/nginx/_configs/healthcheck.conf.j2
@@ -1,0 +1,9 @@
+server {
+  listen {{ redirect_nginx_healthcheck_port }};
+  server_name localhost;
+
+  location {{ redirect_nginx_healthcheck_endpoint }} {
+    add_header Content-Type text/plain;
+    return 200 "OK";
+  }
+}

--- a/core_apps/redirect/templates/nginx/dc.yml.j2
+++ b/core_apps/redirect/templates/nginx/dc.yml.j2
@@ -39,6 +39,18 @@ spec:
           ports:
             - containerPort: {{ redirect_nginx_port }}
               protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: "{{ redirect_nginx_healthcheck_endpoint }}"
+              port: {{ redirect_nginx_healthcheck_port }}
+            initialDelaySeconds: 60
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: "{{ redirect_nginx_healthcheck_endpoint }}"
+              port: {{ redirect_nginx_healthcheck_port }}
+            initialDelaySeconds: 5
+            periodSeconds: 3
           volumeMounts:
             - mountPath: /etc/nginx/conf.d
               name: redirect-v-nginx

--- a/core_apps/redirect/templates/nginx/svc.yml.j2
+++ b/core_apps/redirect/templates/nginx/svc.yml.j2
@@ -13,6 +13,10 @@ spec:
       port: {{ redirect_nginx_port }}
       protocol: TCP
       targetPort: {{ redirect_nginx_port }}
+    - name: "{{ redirect_nginx_healthcheck_port }}-tcp"
+      port: {{ redirect_nginx_healthcheck_port }}
+      protocol: TCP
+      targetPort: {{ redirect_nginx_healthcheck_port }}
   selector:
     app: redirect
     deploymentconfig: "redirect-nginx"

--- a/core_apps/redirect/vars/all/main.yml
+++ b/core_apps/redirect/vars/all/main.yml
@@ -5,3 +5,5 @@ redirect_nginx_image_name: "fundocker/openshift-nginx"
 redirect_nginx_image_tag: "1.13"
 redirect_nginx_replicas: 1
 redirect_nginx_port: 8999
+redirect_nginx_healthcheck_port: 5000
+redirect_nginx_healthcheck_endpoint: "/__healthcheck__"


### PR DESCRIPTION
## Purpose

We need a way to automate container restart when it is failing or not yet ready to accept connections. This could be achieved thanks to the health check probes that Kubernetes offers.

## Proposal

- [x] add probes for `edxapp` WSGI servers and Celery workers
- [x] add probes for `edxapp` memcache
- [x] add probes for `nginx` services
- [x] add probes for the `redis` app
- [x] add probes for `richie`
- [x] ~Upgrade richie's image tag to a health check ready release~ This already been done in #247 
- [x] add probes for `marsha`
- [x] add probes for `forum`
- [ ] ~add probes for `learninglocker`~ postponed to a future PR depending on https://github.com/LearningLocker/learninglocker/issues/1311 (see #258)

Fixes #69 