### PR TITLE
⚡️(playbook) require apps_filter to switch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
 - Publish a Docker image to DockerHub for the master branch
+- The `apps_filter` variable definition is now required to run the `switch.yml`
+  and `deploy.yml` playbooks (if multiple apps are active)
 
 ## [1.3.0] - 2019-01-31
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -13,12 +13,12 @@
       debug: msg="==== Starting deploy playbook ===="
       tags: deploy
 
+    - import_tasks: tasks/set_vars.yml
+
     - name: Check if apps_filter is defined
       fail:
         msg: "Deploy playbook must be used with apps_filter defined"
-      when: apps_filter is not defined
-
-    - import_tasks: tasks/set_vars.yml
+      when: apps_filter is not defined and apps | length > 1
 
     # Set the deployment stamp value for this deployment
     - name: Set deployment stamp

--- a/docs/developer_guide/playbooks.md
+++ b/docs/developer_guide/playbooks.md
@@ -141,20 +141,26 @@ The `switch.yml` playbook moves:
 1. the _current_ stack to the _previous_ route
 2. the _next_ stack to the _current_ route.
 
+_nota bene_: the `apps_filter` environment variable definition is required to
+ensure that you are switching a blue-green compatible application that has been
+recently deployed to the next stack.
+
 ### Usage
 
 ```bash
 # sugar development
-$ bin/switch -e "customer=eugene env_type=staging"
+$ bin/switch -e "customer=eugene env_type=staging apps_filter=richie"
 
 # development
-$ bin/ansible-playbook switch.yml -e "customer=eugene env_type=staging"
+$ bin/ansible-playbook switch.yml \
+    -e "customer=eugene env_type=staging apps_filter=richie"
 
 # native command for production
 $ docker run --rm -it \
     --env-file env.d/production \
     arnold \
-    ansible-playbook switch.yml -e "customer=eugene env_type=staging"
+    ansible-playbook switch.yml \
+        -e "customer=eugene env_type=staging apps_filter=richie"
 ```
 
 ## `create_project.yml`

--- a/switch.yml
+++ b/switch.yml
@@ -18,6 +18,11 @@
 
     - import_tasks: tasks/set_vars.yml
 
+    - name: Check if apps_filter is defined
+      fail:
+        msg: "This project contains several apps, the `apps_filter` variable should be defined"
+      when: apps_filter is not defined and apps | length > 1
+
     - include_tasks: tasks/run_tasks_for_apps.yml
       vars:
         tasks:


### PR DESCRIPTION
## Purpose

The switch playbook is supposed to run against a single application at a time due to unexpected results on non-blue-green apps or not newly deployed apps. 

## Proposal

Thus, as for the deploy playbook, we now require that the apps_filter is defined when invoking the switch playbook.