### PR TITLE
⚡️(edxapp) configure memcached default cache backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - The `apps_filter` variable definition is now required to run the `switch.yml`
   and `deploy.yml` playbooks (if multiple apps are active)
 - Upgraded Richie to its latest release (1.0.0-beta.1)
+- Upgrade default `edxapp` image to `hawthorn.1-2.6.0`
+- Add default `memcached` configuration for `edxapp`
 
 ## [1.3.0] - 2019-01-31
 

--- a/apps/edxapp/templates/cms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/cms/_configs/settings.yml.j2
@@ -22,6 +22,10 @@ HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}-{{ deployment_
 DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}-{{ deployment_stamp }}"
 LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}-{{ deployment_stamp }}"
 
+# Memcached
+MEMCACHED_HOST: "edxapp-memcached-{{ deployment_stamp }}"
+MEMCACHED_PORT: {{ edxapp_memcached_port }}
+
 # MySQL
 DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"
 DATABASE_PORT: {{ edxapp_mysql_port }}

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -23,6 +23,10 @@ DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_lms_default_priority_queue }}-{{ deplo
 LOW_PRIORITY_QUEUE: "{{ edxapp_celery_lms_low_priority_queue }}-{{ deployment_stamp }}"
 HIGH_MEM_QUEUE: "{{ edxapp_celery_lms_high_mem_queue }}-{{ deployment_stamp }}"
 
+# Memcached
+MEMCACHED_HOST: "edxapp-memcached-{{ deployment_stamp }}"
+MEMCACHED_PORT: {{ edxapp_memcached_port }}
+
 # MySQL
 DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"
 DATABASE_PORT: {{ edxapp_mysql_port }}

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -7,7 +7,7 @@ edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "hawthorn.1-2.3.0"
+edxapp_image_tag: "hawthorn.1-2.6.0"
 edxapp_django_port: 8000
 edxapp_lms_replicas: 1
 edxapp_cms_replicas: 1


### PR DESCRIPTION
## Purpose

We have recently improved `memcached` configuration in openedx-docker (see https://github.com/openfun/openedx-docker/pull/96). Now it's time to add relevant default in Arnold.

## Proposal

- [x] add `MEMCACHED_HOST` and `MEMCACHED_PORT` defaults for the CMS and the LMS
- [x] upgrade base `edxapp` image to the latest one that ships memcached configuration