### PR TITLE
Fix pods wait loop and jobs submission

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,5 @@
 .git/
 .gitignore
 openshift.local.clusterup/
+group_vars/customer/*
+!group_vars/customer/eugene

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Added
 
 - Make local docker image build closest to CI conditions
+- Ignore all customers except eugene in local docker image builds
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Fixed
+### Added
 
-* Remove obsolete GitLab CI configuration
+- Make local docker image build closest to CI conditions
+
+### Removed
+
+- Obsolete GitLab CI configuration
 
 ## [1.5.0] - 2019-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Fixed
 
 - Improve DC pods selectors in DC deployment wait loop
+- Fix "jobs" variable collision during jobs submission
 
 ## [1.5.0] - 2019-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - Obsolete GitLab CI configuration
 
+## Fixed
+
+- Improve DC pods selectors in DC deployment wait loop
+
 ## [1.5.0] - 2019-02-20
 
 ### Added

--- a/bin/build
+++ b/bin/build
@@ -1,3 +1,7 @@
 #!/usr/bin/env bash
 
-docker build -t "arnold:$(tr -d '\n' < VERSION)" .
+# Ensure we have the latest base image to fit with the CI
+docker pull python:3.6
+
+# Build without cache to ensure we are close to CI conditions
+docker build --no-cache -t "arnold:$(tr -d '\n' < VERSION)" .

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -64,9 +64,11 @@
   set_fact:
     expected_running_pods: "{{ rendered_deployment_templates.results | json_query('[*].ansible_facts.tpl.spec.replicas') | sum }}"
 
+# The job_stamp label selector is a naive implementation to remove pods that ran
+# jobs from our query: we only want pods created by DCs.
 - name: Define pod label selector
   set_fact:
-    pod_label_selector: "app={{ app.name }}"
+    pod_label_selector: "app={{ app.name }},job_stamp!={{ job_stamp }}"
 
 - name: Add deployment_stamp to label selector
   set_fact:
@@ -79,8 +81,10 @@
     namespace: "{{ project_name }}"
     kind: "Pod"
     label_selectors: ["{{ pod_label_selector }}"]
+    field_selectors:
+      - "status.phase=Running"
   register: pods
-  until: ( pods.resources | length ) == ( expected_running_pods | int )
+  until: pods.resources is defined and ( pods.resources | length ) == ( expected_running_pods | int )
   retries: 120
   delay: 5
 

--- a/tasks/run_job.yml
+++ b/tasks/run_job.yml
@@ -20,10 +20,10 @@
     namespace: "{{ project_name }}"
     kind: "Job"
     name: "{{ submitted_job.result.metadata.name }}"
-  register: jobs
+  register: running_job
   until: >
-    ( jobs.resources | first ).status.succeeded is defined and
-    ( jobs.resources | first ).status.succeeded == 1
+    ( running_job.resources | first ).status.succeeded is defined and
+    ( running_job.resources | first ).status.succeeded == 1
   retries: 360
   delay: 5
   tags:


### PR DESCRIPTION
## Purpose

Recent changes associated to Ansible 2.7 upgrade broke the following deployment tasks:

- pods deployment wait loop (1)
- jobs submissions (2)

We discovered those two bugs while deploying `edxapp` with active pre-deployment jobs (for translations); something that is not tested in the `ci` env unfortunately.

In the first bug (1), we are stuck in an infinite loop since the pre-deployment job creates a pod and thus even if DC pods are properly deployed, we never reach the expected number of pods created for an application with a particular `deployment_stamp`.

The second bug (2) is a side effect of the `jobs` variable name collision in the `run_job` included tasks: running pre-deployment jobs redefines this variable leading to the following failure while running post-deployment jobs:

```
TASK [Run post-deployment jobs] **********************************************
fatal: [local]: FAILED! => {"msg": "'str object' has no attribute 'job_type'"}
```

## Proposal

- [x] improve submitted DC pods selection request
- [x] rename the `jobs` variable in the `run_job` task set

While working on this PR, I also had to check our docker image build reproducibility, and ended up by modifying a bit local builds to make them more close to CI platform conditions.