### PR TITLE
✨(learninglocker) create a volume dedicated to storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- create a volume for learning locker. This volume will be mounted in the storage repository.
+
 ## [1.5.1] - 2019-02-27
 
 ### Added

--- a/apps/learninglocker/templates/_volumes/storage.yml.j2
+++ b/apps/learninglocker/templates/_volumes/storage.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: learninglocker-pvc-storage
+  namespace: "{{ project_name }}"
+  labels:
+    app: learninglocker
+    version: "{{ learninglocker_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  accessModes:
+  - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ learninglocker_storage_volume_size }}

--- a/apps/learninglocker/templates/app/_dc_base.yml.j2
+++ b/apps/learninglocker/templates/app/_dc_base.yml.j2
@@ -21,8 +21,6 @@ spec:
     spec:
       containers:
         - name: "{{ service_variant }}"
-          # We point to a local registry image build for this "live" image (see
-          # ImageStream and BuildConfig templates)
           image: "{{ learninglocker_image_name }}:{{ learninglocker_image_tag }}"
           imagePullPolicy: Always
 {% if learninglocker_port %}
@@ -36,3 +34,10 @@ spec:
                 name: "{{ learninglocker_secret_name }}"
             - configMapRef:
                 name: "learninglocker-app-dotenv-{{ deployment_stamp }}"
+          volumeMounts:
+            - name: learninglocker-v-storage
+              mountPath: /app/storage
+      volumes:
+        - name: learninglocker-v-storage
+          persistentVolumeClaim:
+            claimName: learninglocker-pvc-storage

--- a/apps/learninglocker/templates/app/job_storage.yml.j2
+++ b/apps/learninglocker/templates/app/job_storage.yml.j2
@@ -1,0 +1,30 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "learninglocker-job-storage"
+  namespace: "{{ project_name }}"
+  labels:
+    app: learninglocker
+    service: learninglocker
+    version: "{{ learninglocker_image_tag }}"
+spec:
+  template:
+    metadata:
+      name: "learninglocker-job-storage"
+      labels:
+        app: learninglocker
+        service: learninglocker
+        version: "{{ learninglocker_image_tag }}"
+    spec:
+      containers:
+      - name: learninglocker-job-storage
+        image: "busybox:1.30"
+        command: ["mkdir", "-p", "/data/tmp", "/data/downloads", "/data/logos", "/data/storage", "/data/tests"]
+        volumeMounts:
+        - name: learninglocker-v-storage
+          mountPath: /data
+      volumes:
+      - name: learninglocker-v-storage
+        persistentVolumeClaim:
+          claimName: learninglocker-pvc-storage
+      restartPolicy: Never

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -30,6 +30,9 @@ learninglocker_nginx_image_name: "fundocker/openshift-nginx"
 learninglocker_nginx_image_tag: "1.13"
 learninglocker_nginx_port: 8888
 
+# -- volumes
+learninglocker_storage_volume_size: 2Gi
+
 # -- misc
 #
 # The following variables are defaults required to compile all learning locker templates.


### PR DESCRIPTION
## Purpose

We discover in https://github.com/openfun/learninglocker-docker/issues/21 that LL create a `storage` repository at the project's root. This directory should be mounted in a PVC **and** used in every LL instances (api, ui, worker).

## Proposal

Description...

- [x] create a volume where `storage` will be saved
- [x] use this volume base learning locker DeploymentConfig.
