### PR TITLE
✨(BuildConfig) force to pull last docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,7 @@ aliases:
   # Activate Docker in Docker (aka dind)
   - &dind
     setup_remote_docker:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
   - &ci_env
     run:
@@ -70,8 +70,8 @@ jobs:
   build:
     # We use the machine executor, i.e. a VM, not a container
     machine:
-      # Cache docker layers so that we strongly speed up this job execution
-      docker_layer_caching: true
+      # Prevent cache-related issues
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -163,7 +163,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-hello:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -195,7 +195,7 @@ jobs:
   # Test the redirect application
   test-redirect:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -226,7 +226,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-mailcatcher:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -249,7 +249,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-richie:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -282,7 +282,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-forum:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -315,7 +315,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-edxapp:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -350,7 +350,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-marsha:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -384,7 +384,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-learninglocker:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -407,7 +407,7 @@ jobs:
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-delete-app:
     machine:
-      docker_layer_caching: true
+      docker_layer_caching: false
 
     working_directory: ~/fun
 
@@ -472,8 +472,8 @@ jobs:
   hub:
     # We use the machine executor, i.e. a VM, not a container
     machine:
-      # Cache docker layers so that we strongly speed up this job execution
-      docker_layer_caching: true
+      # Prevent cache-related issues
+      docker_layer_caching: false
       working_directory: ~/fun
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   [lean-delivery/ansible-lint-rules](https://github.com/lean-delivery/ansible-lint-rules)
   maintained project
 - Marsha and richie BuildConfig force to pull the latest available docker image
+- CircleCI docker cache has been inactivated to prevent job failures from cache
+  issues
 
 ## [1.6.0] - 2019-03-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Supplementary `ansible-lint` rules are now provided by the
   [lean-delivery/ansible-lint-rules](https://github.com/lean-delivery/ansible-lint-rules)
   maintained project
+- Marsha and richie BuildConfig force to pull the latest available docker image
 
 ## [1.6.0] - 2019-03-18
 

--- a/apps/marsha/templates/app/bc.yml.j2
+++ b/apps/marsha/templates/app/bc.yml.j2
@@ -24,6 +24,9 @@ metadata:
     version: "{{ marsha_image_tag }}"
 spec:
   strategy:
+    dockerStrategy:
+      forcePull: true
+      noCache: true
     type: Docker
   source:
     dockerfile: |-

--- a/apps/richie/templates/app/bc.yml.j2
+++ b/apps/richie/templates/app/bc.yml.j2
@@ -24,6 +24,9 @@ metadata:
     version: "{{ richie_image_tag }}"
 spec:
   strategy:
+    dockerStrategy:
+      forcePull: true
+      noCache: true
     type: Docker
   source:
     dockerfile: |-


### PR DESCRIPTION
## Purpose

Marsha and Richie use the `master` docker image on staging environment. We want to force the build to force the latest available docker image without having to deploy new  `BuildConfig` object


## Proposal

- [x] set a `dockerStrategy` in the BC template to force pull and no cache.
