### PR TITLE
✨(richie) add support for extra dependencies installation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,6 +278,18 @@ jobs:
             # Test service switched to the current route
             bin/ci-test-service "richie" "Installation successful!"
 
+      - run:
+          name: Test extra dependencies installation
+          command: |
+            # Switch project
+            oc project ci-eugene
+            # Select Richie's service pods
+            cmd="oc get pods -l app=richie,service=richie --field-selector 'status.phase=Running' -o name | sed 's/^pods\///'"
+            # Run command to debug output (eventually)
+            eval "${cmd}"
+            # Check extra dependencies installation
+            oc exec $(eval "${cmd}") -- python -c "import factory"
+
   # Test the bootstrap playbook on the "forum" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-forum:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Richie's app BuildConfig now supports extra dependencies installation
+
 ### Changed
 
 - Python dependencies have been upgraded thanks to pyup bot.

--- a/apps/richie/templates/app/bc.yml.j2
+++ b/apps/richie/templates/app/bc.yml.j2
@@ -31,7 +31,11 @@ spec:
   source:
     dockerfile: |-
       FROM {{ richie_image_name }}:{{ richie_image_tag }}
-      # Add new statements here
+      USER 0
+      {% if richie_extra_dependencies is defined and richie_extra_dependencies | length -%}
+      RUN pip install {{ richie_extra_dependencies | join(" ") }}
+      {% endif -%}
+      USER 10000
   triggers:
     - type: "ConfigChange"
   output:

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -33,6 +33,21 @@ richie_django_port: 8000
 richie_app_replicas: 1
 richie_django_configuration: "Development"
 richie_secret_name: "richie-{{ richie_vault_checksum | default('undefined_richie_vault_checksum') }}"
+# Customize richie Docker image by installing extra dependencies for a
+# customer/environment. This var is expected to be a list of dependencies
+# following the pip requirement specifier (see example below).
+#
+# NOTA BENE:
+#
+# This is only intended for side packages not directly related to richie and
+# specific to a customer/environment or to the way you handle operations (e.g.
+# log handlers, monitoring agents, etc.).
+richie_extra_dependencies:
+  []
+  # Example values:
+  # - "graypy==0.3.1"
+  # - "raven>=6.0.0"
+  # - "requests"
 
 # -- volumes
 richie_media_volume_size: 2Gi

--- a/group_vars/customer/eugene/ci/main.yml
+++ b/group_vars/customer/eugene/ci/main.yml
@@ -3,3 +3,8 @@ redirections:
   - to: "hello.{{ project_name}}.{{ domain_name }}"
     from:
       - "www.hello.{{ project_name}}.{{ domain_name }}"
+
+# Richie
+# Test extra dependencies installation
+richie_extra_dependencies:
+  - "factory-boy[django]>=2.11.1"


### PR DESCRIPTION
## Purpose

Given deployed flavor, we sometimes need to install new dependencies that haven't been installed in Richie's base Docker image.

## Proposal

- [x] add `richie_extra_dependencies` setting and update Richie's BC consequently
- [x] test extra dependencies installation in the CI
