### PR TITLE
🐛(richie) fix media routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Add missing location to serve media files in the `nginx` configuration of the Richie app.
+
 ## [1.7.0] - 2019-03-22
 
 ### Added

--- a/apps/richie/templates/nginx/_configs/richie.conf.j2
+++ b/apps/richie/templates/nginx/_configs/richie.conf.j2
@@ -29,6 +29,11 @@ server {
     try_files $uri @proxy_to_richie_app;
   }
 
+  location ~ ^/media/(?P<file>.*) {
+    root /data/media/richie;
+    try_files /$file =404;
+  }
+
   location ~ ^/static/(?P<file>.*) {
     root /data/static/richie;
     try_files /$file =404;


### PR DESCRIPTION
## Purpose

In the Richie app, the nginx configuration did not declare routes to serve media files.

## Proposal

I added a rule in nginx for media files by copying what was done for static files.
