### PR TITLE
🔧(pyup) switch to weekly updates

### DIFF
--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,0 +1,1 @@
+schedule: "every week"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Configure PyUp to submit dependency updates every week
+
 ### Fixed
 
-- Add missing location to serve media files in the `nginx` configuration of the Richie app.
+- Add missing location to serve media files in the `nginx` configuration of the
+  Richie app.
 
 ## [1.7.0] - 2019-03-22
 


### PR DESCRIPTION
## Purpose

By default, pyup submits a new MR for every new dependency update. We prefer scheduling updates with a weekly frequency.

## Proposal

- [x] add `.pyup.yml` configuration file
