### PR TITLE
🐛(edxapp) fix frontend translations management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Fixed
 
+- Frontend translations are now properly updated while deploying `edxapp`
 - The bin/job was broken due to recent changes in the `_docker_run` usage
 
 ## [1.8.1] - 2019-04-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- The bin/job was broken due to recent changes in the `_docker_run` usage
+
 ## [1.8.1] - 2019-04-02
 
 ### Fixed

--- a/apps/edxapp/templates/cms/job_01_internationalization.yml.j2
+++ b/apps/edxapp/templates/cms/job_01_internationalization.yml.j2
@@ -34,6 +34,19 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ edxapp_tx_secret_name }}"
+          # Once transifex client is installed, we use it to fetch recent
+          # reviewed translations for a target release (pointed by the
+          # .tx/config bundled in edx-platform for a release). We only keep
+          # django.po and djangojs.po files corresponding to this release. We
+          # remove all other translation files before copying the new ones to
+          # avoid conflicts in separated and merged .po files (apparently not
+          # required but cleaner).
+          #
+          # Once frontend translation files have been fetched they also need to
+          # be compiled (with the compilejsi18n management command), but this
+          # will be achieved during the collectstatics job since we have no way
+          # to make compiled frontend translated statics persistant from the
+          # current job to a subsequent one.
           command:
             - "bash"
             - "-c"
@@ -41,10 +54,13 @@ spec:
               cp -R .tx /tmp &&
 {% for lang in edxapp_i18n_languages %}
               HOME="/tmp" PYTHONPATH=/tmp/lib/python2.7/site-packages/ /tmp/bin/tx --root /tmp pull --mode=reviewed -l {{ lang }} &&
-              cp -Rf /tmp/conf/locale/{{ lang }} conf/locale/ &&
+              mkdir -p conf/locale/{{ lang }}/LC_MESSAGES &&
+              rm -fr conf/locale/{{ lang }}/LC_MESSAGES/* &&
+              cp -f /tmp/conf/locale/{{ lang }}/LC_MESSAGES/{django,djangojs}.po conf/locale/{{ lang }}/LC_MESSAGES/ &&
               python manage.py cms compilemessages -l {{ lang }} &&
 {% endfor %}
-              python manage.py cms compilejsi18n
+              echo "translations:" &&
+              ls -l conf/locale/*/LC_MESSAGES/
           volumeMounts:
             - mountPath: /edx/app/edxapp/edx-platform/conf/locale
               name: edxapp-v-locale

--- a/apps/edxapp/templates/cms/job_02_collectstatic.yml.j2
+++ b/apps/edxapp/templates/cms/job_02_collectstatic.yml.j2
@@ -28,12 +28,25 @@ spec:
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run
-          command: ["python", "manage.py", "cms", "collectstatic", "--noinput"]
+          # FIXME: as mentioned in the internationalization job, we need to
+          # compile frontend translation files right before collecting them from
+          # applications statics. Hence, we call the compilejsi18n management
+          # command in this job. This is not ideal, but we haven't a better
+          # solution for now.
+          command:
+            - "bash"
+            - "-c"
+            - {% if edxapp_should_update_i18n %}python manage.py cms compilejsi18n &&{% endif %}
+              python manage.py cms collectstatic --noinput
           volumeMounts:
             - mountPath: /config
               name: edxapp-config
             - mountPath: /edx/app/edxapp/staticfiles
               name: edxapp-v-static
+{% if edxapp_should_update_i18n %}
+            - mountPath: /edx/app/edxapp/edx-platform/conf/locale
+              name: edxapp-v-locale
+{% endif %}
       initContainers:
         # This initContainer has nothing mounted on its "/config" directory. We
         # copy the content of its "/config" directory (fun-platform default
@@ -83,4 +96,9 @@ spec:
         - name: edxapp-v-static
           persistentVolumeClaim:
             claimName: edxapp-pvc-static
+{% if edxapp_should_update_i18n %}
+        - name: edxapp-v-locale
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-locale
+{% endif %}
       restartPolicy: Never

--- a/apps/edxapp/templates/lms/job_03_collectstatic.yml.j2
+++ b/apps/edxapp/templates/lms/job_03_collectstatic.yml.j2
@@ -28,12 +28,25 @@ spec:
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run
-          command: ["python", "manage.py", "lms", "collectstatic", "--noinput"]
+          # FIXME: as mentioned in the internationalization job, we need to
+          # compile frontend translation files right before collecting them from
+          # applications statics. Hence, we call the compilejsi18n management
+          # command in this job. This is not ideal, but we haven't a better
+          # solution for now.
+          command:
+            - "bash"
+            - "-c"
+            - {% if edxapp_should_update_i18n %}python manage.py lms compilejsi18n &&{% endif %}
+              python manage.py lms collectstatic --noinput
           volumeMounts:
             - mountPath: /config
               name: edxapp-config
             - mountPath: /edx/app/edxapp/staticfiles
               name: edxapp-v-static
+{% if edxapp_should_update_i18n %}
+            - mountPath: /edx/app/edxapp/edx-platform/conf/locale
+              name: edxapp-v-locale
+{% endif %}
       initContainers:
         # This initContainer has nothing mounted on its "/config" directory. We
         # copy the content of its "/config" directory (fun-platform default
@@ -83,4 +96,9 @@ spec:
         - name: edxapp-v-static
           persistentVolumeClaim:
             claimName: edxapp-pvc-static
+{% if edxapp_should_update_i18n %}
+        - name: edxapp-v-locale
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-locale
+{% endif %}
       restartPolicy: Never

--- a/bin/job
+++ b/bin/job
@@ -53,7 +53,7 @@ function main() {
     echo "deployment stamp: $deployment_stamp"
     echo "job             : $job_template"
 
-    _docker_run ansible-playbook create_object.yml --ask-vault-pass \
+    _docker_run -mt ansible-playbook create_object.yml \
         -e "customer=$customer" \
         -e "env_type=$env_type" \
         -e "object_template=$job_template" \


### PR DESCRIPTION
## Purpose

Frontend translation files were not compiled nor collected resulting to UI partially translated (only backend translations where taken into account).

## Proposal

- [x] only copy concatenated release translation files (`django.po` & `djangojs.po`)
- [x] postpone the `compilejsi18n` task to the `collectstatic` jobs (the first command generates a static file that should be collected)

During this work, I also had to:

- [x] fix the `bin/job` script
