### PR TITLE
🐛(richie) fix elasticsearch job by mounting the media volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix Richie deployments by mounting the `media` volume in the `bootstrap_elasticsearch` job
+
 ## [1.8.2] - 2019-04-02
 
 ### Fixed

--- a/apps/richie/templates/app/job_03_bootstrap_elasticsearch.yml.j2
+++ b/apps/richie/templates/app/job_03_bootstrap_elasticsearch.yml.j2
@@ -20,34 +20,41 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
         job_stamp: "{{ job_stamp }}"
     spec:
-      containers:
-      - name: richie-bootstrap-elasticsearch
-        env:
-          - name: DJANGO_SETTINGS_MODULE
-            value: settings
-          - name: DJANGO_CONFIGURATION
-            value: "{{ richie_django_configuration }}"
-          - name: DB_ENGINE
-            value: "{{ richie_database_engine }}"
-          - name: DB_NAME
-            value: "{{ richie_database_name }}"
-          - name: DB_HOST
-            value: "richie-{{ richie_database_host }}-{{ deployment_stamp }}"
-          - name: DB_PORT
-            value: "{{ richie_database_port }}"
-          - name: DJANGO_ALLOWED_HOSTS
-            value: "{{ richie_host }}"
-          - name: ES_CLIENT
-            value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
-        envFrom:
-          - secretRef:
-              name: "{{ richie_secret_name }}"
-        # We point to a local registry image build for this "live" image (see
-        # ImageStream and BuildConfig templates)
-        image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
-        command:
-          - "bash"
-          - "-c"
-          - cd sandbox &&
-            python manage.py bootstrap_elasticsearch
       restartPolicy: Never
+      containers:
+        - name: richie-bootstrap-elasticsearch
+          env:
+            - name: DJANGO_SETTINGS_MODULE
+              value: settings
+            - name: DJANGO_CONFIGURATION
+              value: "{{ richie_django_configuration }}"
+            - name: DB_ENGINE
+              value: "{{ richie_database_engine }}"
+            - name: DB_NAME
+              value: "{{ richie_database_name }}"
+            - name: DB_HOST
+              value: "richie-{{ richie_database_host }}-{{ deployment_stamp }}"
+            - name: DB_PORT
+              value: "{{ richie_database_port }}"
+            - name: DJANGO_ALLOWED_HOSTS
+              value: "{{ richie_host }}"
+            - name: ES_CLIENT
+              value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
+          envFrom:
+            - secretRef:
+                name: "{{ richie_secret_name }}"
+          # We point to a local registry image build for this "live" image (see
+          # ImageStream and BuildConfig templates)
+          image: "{{ internal_docker_registry }}/{{ project_name }}/richie:{{ richie_image_tag }}-live"
+          command:
+            - "bash"
+            - "-c"
+            - cd sandbox &&
+              python manage.py bootstrap_elasticsearch
+          volumeMounts:
+            - name: richie-v-media
+              mountPath: /data/media
+      volumes:
+        - name: richie-v-media
+          persistentVolumeClaim:
+            claimName: richie-pvc-media


### PR DESCRIPTION
## Purpose

Deployments were failing on the `bootstrap_elasticsearch` job whenever we tried to redeploy with a non empty database. 

At first, we thought it was an issue in Richie (see https://github.com/openfun/richie/issues/570)

In fact, when generating the Elasticsearch index, some image thumbnails are being created. This will fail if the command does not have access to the file. 

## Proposal

We need to mount the `/media` volume in the `bootstrap_elasticsearch` job for the command to have access to media files.

Fixes https://github.com/openfun/richie/issues/570