### PR TITLE
🔧(edxapp) add new volume to store CSV exports files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add new volume to `edxapp` to store CSV reports
+
 ### Changed
 
 - Upgrade Ansible to the 2.7.10 release

--- a/apps/edxapp/templates/_volumes/exports.yml.j2
+++ b/apps/edxapp/templates/_volumes/exports.yml.j2
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: edxapp-pvc-exports
+  namespace: "{{ project_name }}"
+  labels:
+    app: edxapp
+    version: "{{ edxapp_image_tag }}"
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: {{ edxapp_export_volume_size }}

--- a/apps/edxapp/templates/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/cms/_dc_base.yml.j2
@@ -91,6 +91,8 @@ spec:
           name: edxapp-v-static
         - mountPath: /edx/app/edxapp/data
           name: edxapp-v-data
+        - mountPath: {{ edxapp_export_volume_path }}
+          name: edxapp-v-exports
 {% if edxapp_should_update_i18n %}
         - mountPath: /edx/app/edxapp/edx-platform/conf/locale
           name: edxapp-v-locale
@@ -142,6 +144,9 @@ spec:
         - name: edxapp-v-data
           persistentVolumeClaim:
             claimName: edxapp-pvc-data
+        - name: edxapp-v-exports
+          persistentVolumeClaim:
+            claimName: edxapp-pvc-exports
 {% if edxapp_should_update_i18n %}
         - name: edxapp-v-locale
           persistentVolumeClaim:

--- a/apps/edxapp/templates/lms/_configs/settings.yml.j2
+++ b/apps/edxapp/templates/lms/_configs/settings.yml.j2
@@ -34,3 +34,7 @@ DATABASE_PORT: {{ edxapp_mysql_port }}
 # Mongo
 MONGODB_HOST: "edxapp-mongo-{{ deployment_stamp }}"
 MONGODB_PORT: {{ edxapp_mongodb_port }}
+
+GRADES_DOWNLOAD:
+  STORAGE_TYPE: localfs
+  ROOT_PATH: "{{ edxapp_export_volume_path }}/grades-download"

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -67,6 +67,10 @@ edxapp_data_volume_size: 2Gi
 edxapp_media_volume_size: 2Gi
 edxapp_static_volume_size: 2Gi
 edxapp_locale_volume_size: 200Mi
+edxapp_export_volume_size: 100Mi
+
+# -- volume names
+edxapp_export_volume_path: /edx/var/edxapp/exports
 
 # -- memcached
 edxapp_memcached_image_name: memcached


### PR DESCRIPTION
We find out edxapp lms was missing a volume to store student grades and
financial reports CSV exports. (GRADES_DOWNLOAD and FINANCIAL_REPORTS settings)

