### PR TITLE
🔧(richie) change Elasticsearch host setting name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Rename the `ES_CLIENT` setting to `RICHIE_ES_HOST` for compatibility
+  with Richie starting from version v1.0.0-beta.6.
+
 ## [1.9.0] - 2019-04-11
 
 ### Added

--- a/apps/richie/templates/app/dc.yml.j2
+++ b/apps/richie/templates/app/dc.yml.j2
@@ -53,7 +53,7 @@ spec:
               value: "{{ richie_database_port }}"
             - name: DJANGO_ALLOWED_HOSTS
               value: "{{ richie_host | blue_green_hosts }}"
-            - name: ES_CLIENT
+            - name: RICHIE_ES_HOST
               value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
           envFrom:
             - secretRef:

--- a/apps/richie/templates/app/job_03_bootstrap_elasticsearch.yml.j2
+++ b/apps/richie/templates/app/job_03_bootstrap_elasticsearch.yml.j2
@@ -38,7 +38,7 @@ spec:
               value: "{{ richie_database_port }}"
             - name: DJANGO_ALLOWED_HOSTS
               value: "{{ richie_host }}"
-            - name: ES_CLIENT
+            - name: RICHIE_ES_HOST
               value: "richie-{{ richie_elasticsearch_host }}-{{ deployment_stamp }}"
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Purpose

The `ES_CLIENT` setting was renamed to `RICHIE_ES_HOST` in [Richie](https://github.com/openfun/richie) v1.0.0-beta.6 so we should rename it in Arnold as well.

## Proposal

Rename `ES_CLIENT` to `RICHIE_ES_HOST` in the DC and in the job that needs to connect to Elasticsearch.
