### PR TITLE
✨(plugins) allow application template override

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - We now perform health checks to every service pods by implementing and
   defining `livenessProbe` and `readinessProbe` (except for Learninglocker
   applications).
+- The `merge_with_app` filter now allows to override templates for a namespace
+  (_e.g._ for an application/service) based on its file name.
 
 ### Changed
 
@@ -116,7 +118,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Changed
 
 - Upgrade Richie to the `master` docker image by default
-
 
 ## [1.5.1] - 2019-02-27
 

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -267,6 +267,55 @@ class TestMergeWithAppFilter(unittest.TestCase):
 
         self.assertDictDeepEqual(merge_with_app(base, new), expected)
 
+    def test_services_merge_with_template_overriding(self):
+        """Test app services merging with template overrides"""
+
+        base = {
+            "name": "foo",
+            "services": [
+                {
+                    "name": "bar",
+                    "configs": ["bar.conf"],
+                    "templates": ["bar/dc.yml", "bar/svc.yml"],
+                    "environment_variables": "/foo/_env.yml.j2",
+                },
+                {
+                    "name": "baz",
+                    "configs": ["baz.conf"],
+                    "templates": ["baz/dc.yml", "baz/svc.yml", "baz/ep.yml"],
+                },
+            ],
+            "volumes": ["volumes/foo_bar.yml", "volumes/foo_baz.yml"],
+        }
+
+        new = {
+            "name": "foo",
+            "services": [
+                {"name": "bar", "templates": ["baz/dc.yml"]},
+                {"name": "baz", "templates": ["foo/svc.yml"]},
+            ],
+        }
+
+        expected = {
+            "name": "foo",
+            "services": [
+                {
+                    "name": "bar",
+                    "configs": ["bar.conf"],
+                    "templates": ["baz/dc.yml", "bar/svc.yml"],
+                    "environment_variables": "/foo/_env.yml.j2",
+                },
+                {
+                    "name": "baz",
+                    "configs": ["baz.conf"],
+                    "templates": ["baz/dc.yml", "foo/svc.yml", "baz/ep.yml"],
+                },
+            ],
+            "volumes": ["volumes/foo_bar.yml", "volumes/foo_baz.yml"],
+        }
+
+        self.assertDictDeepEqual(merge_with_app(base, new), expected)
+
     def test_services_merge_with_new_keys(self):
         """Test app services merge with new keys (meta)"""
 


### PR DESCRIPTION
## Purpose

We often need to redefine a single template file for a tray, _i.e._ to customize a secret or a deployment for a customer/environment.

## Proposal

We made this possible using the `merge_with_app` filter: considering that we want to override only Richie's application secret, one will need to declare a new secret template and override the secret path in the customer/environment variables file (_e.g._ `group_vars/customer/foo/staging/main.yml`):

```yaml
apps:
  - name: richie
    services:
      - name: app
        templates:
          - group_vars/customer/fun/apps/richie/templates/richie/secret.yml.j2
```

This will override the default secret template (refered as `apps/richie/templates/richie/secret.yml.j2`).
