### PR TITLE
🐛(playbook) fix display name for new projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Migrate apps to the new tray package tree
 - Refactor and test the `apps` lookup to support the new tray package tree
 
+### Fixed
+
+- The project display name is no longer empty when creating a new project
+
 ## [1.10.0] - 2019-04-24
 
 ### Added

--- a/create_project.yml
+++ b/create_project.yml
@@ -17,13 +17,14 @@
 
     - name: Make sure the project exists in OpenShift and is up-to-date
       k8s:
-        api_version: v1
-        kind: Project
-        name: "{{ project_name }}"
-        resource_definition:
-          description: "{{ project_description|default(project_display_name)|default(project_name) }}"
-          display_name: "{{ project_display_name|default(project_name) }}"
         state: present
+        definition:
+          apiVersion: project.openshift.io/v1
+          kind: Project
+          description: "{{ project_description | default(project_display_name) | default(project_name) }}"
+          displayName: "{{ project_display_name | default(project_name) }}"
+          metadata:
+            name: "{{ project_name }}"
       register: new_project
       until: new_project.result is defined and new_project.result.status is success
       retries: 30


### PR DESCRIPTION
## Purpose

When creating a new project using the `create_project.yml` playbook, the project display name field is empty.

## Proposal

- [x] fix the expected "display name" field name
- [x] make project definition more explicit

FTR the Project object schema reference is available at:
https://docs.openshift.com/online/rest_api/apis-project.openshift.io/v1.Project.html#object-schema
