### PR TITLE
⚡️(richie) make app templates more generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Richie's application templates are now more generic to easily configure and
+  deploy a custom instance
+
 ## [2.0.0] - 2019-05-07
 
 ### Added

--- a/apps/richie/templates/services/app/dc.yml.j2
+++ b/apps/richie/templates/services/app/dc.yml.j2
@@ -56,7 +56,7 @@ spec:
             periodSeconds: 3
           env:
             - name: DJANGO_SETTINGS_MODULE
-              value: settings
+              value: "{{ richie_django_settings_module }}"
             - name: DJANGO_CONFIGURATION
               value: "{{ richie_django_configuration }}"
             - name: DB_ENGINE

--- a/apps/richie/templates/services/app/job_01_collectstatic.yml.j2
+++ b/apps/richie/templates/services/app/job_01_collectstatic.yml.j2
@@ -28,7 +28,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
-              value: settings
+              value: "{{ richie_django_settings_module }}"
             - name: DJANGO_CONFIGURATION
               value: "{{ richie_django_configuration }}"
             - name: DB_ENGINE
@@ -47,8 +47,7 @@ spec:
           command:
             - "bash"
             - "-c"
-            - cd sandbox &&
-              python manage.py collectstatic --noinput
+            - python manage.py collectstatic --noinput
           volumeMounts:
             - mountPath: /data/static
               name: richie-v-static

--- a/apps/richie/templates/services/app/job_02_db_migrate.yml.j2
+++ b/apps/richie/templates/services/app/job_02_db_migrate.yml.j2
@@ -26,7 +26,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
-              value: settings
+              value: "{{ richie_django_settings_module }}"
             - name: DJANGO_CONFIGURATION
               value: "{{ richie_django_configuration }}"
             - name: DB_ENGINE
@@ -45,6 +45,5 @@ spec:
           command:
             - "bash"
             - "-c"
-            - cd sandbox &&
-              python manage.py migrate
+            - python manage.py migrate
       restartPolicy: Never

--- a/apps/richie/templates/services/app/job_03_bootstrap_elasticsearch.yml.j2
+++ b/apps/richie/templates/services/app/job_03_bootstrap_elasticsearch.yml.j2
@@ -27,7 +27,7 @@ spec:
           imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
-              value: settings
+              value: "{{ richie_django_settings_module }}"
             - name: DJANGO_CONFIGURATION
               value: "{{ richie_django_configuration }}"
             - name: DB_ENGINE
@@ -48,8 +48,7 @@ spec:
           command:
             - "bash"
             - "-c"
-            - cd sandbox &&
-              python manage.py bootstrap_elasticsearch
+            - python manage.py bootstrap_elasticsearch
           volumeMounts:
             - name: richie-v-media
               mountPath: /data/media

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -33,6 +33,7 @@ richie_image_name: "fundocker/richie"
 richie_image_tag: "master"
 richie_django_port: 8000
 richie_app_replicas: 1
+richie_django_settings_module: "settings"
 richie_django_configuration: "Development"
 richie_secret_name: "richie-{{ richie_vault_checksum | default('undefined_richie_vault_checksum') }}"
 # Customize richie Docker image by installing extra dependencies for a


### PR DESCRIPTION
## Purpose

Richie's app templates should be the more generic/configurable so that one can easily deploy a custom Richie's instance without having to override default object templates.

## Proposal

- [x] commands are supposed to be run from the Django's project directory
- [x] make the Django settings module path configurable
