### PR TITLE
♻️(marsha) use volumes only in trashable environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Marsha volumes are used only in trashable environments
+
 ## [2.1.0] - 2019-05-10
 
 ### Changed

--- a/apps/marsha/templates/services/app/dc.yml.j2
+++ b/apps/marsha/templates/services/app/dc.yml.j2
@@ -73,21 +73,25 @@ spec:
             - secretRef:
                 name: "{{ marsha_secret_name }}"
           volumeMounts:
+{% if env_type in trashable_env_types %}
             - name: marsha-v-media
               mountPath: /data/media
             - name: marsha-v-static
               mountPath: /data/static
+{% endif %}
 {% if marsha_should_sign_requests %}
             - mountPath: "{{ marsha_cloudfront_private_key_path | dirname }}"
               name: marsha-cloudfront-private-key-secret
 {% endif %}
       volumes:
+{% if env_type in trashable_env_types %}
         - name: marsha-v-media
           persistentVolumeClaim:
             claimName: marsha-pvc-media
         - name: marsha-v-static
           persistentVolumeClaim:
             claimName: marsha-pvc-static
+{% endif %}
 {% if marsha_should_sign_requests %}
         - name: marsha-cloudfront-private-key-secret
           secret:

--- a/apps/marsha/templates/services/app/job_collectstatic.yml.j2
+++ b/apps/marsha/templates/services/app/job_collectstatic.yml.j2
@@ -43,6 +43,7 @@ spec:
             - secretRef:
                 name: "{{ marsha_secret_name }}"
           command: ["python", "manage.py", "collectstatic", "--noinput"]
+{% if env_type in trashable_env_types %}
           volumeMounts:
             - mountPath: /data/static
               name: marsha-v-static
@@ -50,4 +51,5 @@ spec:
         - name: marsha-v-static
           persistentVolumeClaim:
             claimName: marsha-pvc-static
+{% endif %}
       restartPolicy: Never

--- a/apps/marsha/templates/volumes/media.yml.j2
+++ b/apps/marsha/templates/volumes/media.yml.j2
@@ -1,3 +1,4 @@
+{% if env_type in trashable_env_types %}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,3 +14,4 @@ spec:
   resources:
     requests:
       storage: {{ marsha_media_volume_size }}
+{% endif %}

--- a/apps/marsha/templates/volumes/static.yml.j2
+++ b/apps/marsha/templates/volumes/static.yml.j2
@@ -1,3 +1,4 @@
+{% if env_type in trashable_env_types %}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,3 +14,4 @@ spec:
   resources:
     requests:
       storage: {{ marsha_static_volume_size }}
+{% endif %}


### PR DESCRIPTION
## Purpose

On marsha, shared volumes will be used only in trashable environments.
For all other environments, statics will be on AWS.

## Proposal

- [x] remove volumes and their usage in DC or jobs if not in a trashable environment.
