### PR TITLE
✨(marsha) add a _env file to marsha application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- add an environment file to Marsha application
+
 ### Changed
 
 - Marsha volumes are used only in trashable environments

--- a/apps/marsha/templates/services/app/_env.yml.j2
+++ b/apps/marsha/templates/services/app/_env.yml.j2
@@ -1,0 +1,1 @@
+DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004

--- a/apps/marsha/templates/services/app/dc.yml.j2
+++ b/apps/marsha/templates/services/app/dc.yml.j2
@@ -72,6 +72,8 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ marsha_secret_name }}"
+            - configMapRef:
+                name: "marsha-app-dotenv-{{ deployment_stamp }}"
           volumeMounts:
 {% if env_type in trashable_env_types %}
             - name: marsha-v-media


### PR DESCRIPTION
## Purpose

We want to define custom environment variables freely without the need
to store them in a secret managed by vault because they contain no
sensible data, just configuration.


## Proposal

- [x] create a `_env.yml.j2` file in the app service
- [x] use it in the deployment config
