### PR TITLE
🔒(apps) increase length of secrets keys to 50

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Increase length of secret keys to 50 characters
+
 ## [2.3.0] - 2019-05-23
 
 ### Added

--- a/apps/learninglocker/vars/vault/main.yml.j2
+++ b/apps/learninglocker/vars/vault/main.yml.j2
@@ -9,7 +9,7 @@ MONGODB_PATH: mongodb://{{ mongodb_credentials.user }}:{{ mongodb_credentials.pa
 # secrets variable injected in a secret object
 SECRETS:
   SITE_URL:
-  APP_SECRET: {{ lookup('password', '/dev/null length=30') }}
+  APP_SECRET: {{ lookup('password', '/dev/null length=50') }}
   MONGODB_PATH: mongodb://{{ mongodb_credentials.user }}:{{ mongodb_credentials.password }}@{{ learninglocker_mongodb_host }}:{{ learninglocker_mongodb_port }}/{{ mongodb_credentials.name }}
   REDIS_HOST: redis
   REDIS_PORT: {{ redis_app_port }}

--- a/apps/marsha/vars/vault/main.yml.j2
+++ b/apps/marsha/vars/vault/main.yml.j2
@@ -7,7 +7,7 @@ POSTGRESQL_USER: {{ postgresql_credentials.user }}
 POSTGRESQL_PASSWORD: {{ postgresql_credentials.password }}
 
 # marsha environment
-DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=30') }}
+DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=50') }}
 # FIXME uncomment thie variable and replace with your sentry's credentials
 # DJANGO_SENTRY_DSN: https://super:marsha@sentry.io/foo
 
@@ -27,7 +27,7 @@ DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=30') }}
 # DJANGO_CLOUDFRONT_PRIVATE_KEY:
 
 # JWT Token
-DJANGO_JWT_SIGNING_KEY: {{ lookup('password', '/dev/null length=30') }}
+DJANGO_JWT_SIGNING_KEY: {{ lookup('password', '/dev/null length=50') }}
 
 # Learning Locker variables
 # DJANGO_LRS_AUTH_TOKEN is the token provided by a LRS to authenticate requests

--- a/apps/richie/vars/vault/main.yml.j2
+++ b/apps/richie/vars/vault/main.yml.j2
@@ -8,5 +8,5 @@ DB_USER: {{ postgresql_credentials.user }}
 DB_PASSWORD: {{ postgresql_credentials.password }}
 
 # richie
-DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=30') }}
+DJANGO_SECRET_KEY: {{ lookup('password', '/dev/null length=50') }}
 # DJANGO_SENTRY_DSN: https://super:richie@sentry.io/foo


### PR DESCRIPTION
## Purpose

Our DockerFlow health check monitor was raising warnings because the Django secret keys were too short.

## Proposal

Bump all secret keys length to 50 characters.