### PR TITLE
✨(richie) add a _env file to richie application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- Add an environment file to Richie application
+
 ### Changed
 
 - Increase length of secret keys to 50 characters
@@ -23,7 +27,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 
-- add an environment file to Marsha application
+- Add an environment file to Marsha application
 
 ### Changed
 

--- a/apps/richie/templates/services/app/_env.yml.j2
+++ b/apps/richie/templates/services/app/_env.yml.j2
@@ -1,0 +1,1 @@
+DJANGO_SILENCED_SYSTEM_CHECKS: security.W008,security.W004

--- a/apps/richie/templates/services/app/dc.yml.j2
+++ b/apps/richie/templates/services/app/dc.yml.j2
@@ -74,6 +74,8 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ richie_secret_name }}"
+            - configMapRef:
+                name: "richie-app-dotenv-{{ deployment_stamp }}"
           volumeMounts:
             - name: richie-v-media
               mountPath: /data/media


### PR DESCRIPTION
## Purpose

We need to configure the `DJANGO_SILENCED_SYSTEM_CHECKS` environment variable to silence DockerFlow's SSL checks (because the SSL endpoint in our deployments is OpenShift's HAProxy which handles redirects).

## Proposal

Port what was done for Marsha in PR https://github.com/openfun/arnold/pull/320.
