### PR TITLE
✏️(edxapp) fix badly named nginx location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- In edxapp application, fix badly named nginx location from `export` to `restricted`
+
 ## [2.4.0] - 2019-05-28
 
 ### Added

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -59,7 +59,7 @@ server {
     try_files /$file =404;
   }
 
-  location ~ ^/export/(?P<file>.*) {
+  location ~ ^/restricted/(?P<file>.*) {
     root /data/export;
     try_files /$file =404;
     internal;


### PR DESCRIPTION
In previous commits related to CSV export, we badly named nginx location
to serve them `export` instead of `restricted`.

see: https://github.com/openfun/fonzie/blob/master/fonzie/views/acl.py#L52