### PR TITLE
🔖(fix) bump release to 2.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.4.1] - 2019-06-03
+
 ### Fixed
 
 - In edxapp application, fix badly named nginx location from `export` to `restricted`
@@ -333,7 +335,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - First Arnold's public release
 - Official Docker image is available at: https://hub.docker.com/r/fundocker/arnold/
 
-[unreleased]: https://github.com/openfun/arnold/compare/v2.4.0...master
+[unreleased]: https://github.com/openfun/arnold/compare/v2.4.1...master
+[2.4.1]: https://github.com/openfun/arnold/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/openfun/arnold/compare/v2.3.0...v2.4.0
 [2.3.0]: https://github.com/openfun/arnold/compare/v2.2.0...v2.3.0
 [2.2.0]: https://github.com/openfun/arnold/compare/v2.1.0...v2.2.0


### PR DESCRIPTION
Fixed

- In edxapp application, fix badly named nginx location from `export` to
  `restricted`
