### PR TITLE
⚡️(apps) increase healthchecks periodicity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade `openshift` to `0.8.9`
+- Increase pods liveness/readiness probes periodicity to smooth pods replacement
+  scheduling
 
 ## [2.4.1] - 2019-06-04
 

--- a/apps/edxapp/templates/services/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_dc_base.yml.j2
@@ -93,7 +93,7 @@ spec:
               - "-c"
               - "python manage.py {{ service_variant }} celery inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
           initialDelaySeconds: 120
-          periodSeconds: 5
+          periodSeconds: 30
         readinessProbe:
           exec:
             command:
@@ -101,7 +101,7 @@ spec:
               - "-c"
               - "python manage.py {{ service_variant }} celery inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
           initialDelaySeconds: 60
-          periodSeconds: 3
+          periodSeconds: 10
 {% else %}
         # Pod probes that only apply for wsgi services
         livenessProbe:
@@ -112,7 +112,7 @@ spec:
               - name: Host
                 value: "{{ host }}"
           initialDelaySeconds: 120
-          periodSeconds: 5
+          periodSeconds: 30
         readinessProbe:
           httpGet:
             path: /heartbeat
@@ -121,7 +121,7 @@ spec:
               - name: Host
                 value: "{{ host }}"
           initialDelaySeconds: 60
-          periodSeconds: 3
+          periodSeconds: 10
 {% endif %}
         volumeMounts:
         - mountPath: /config

--- a/apps/edxapp/templates/services/memcached/dc.yml.j2
+++ b/apps/edxapp/templates/services/memcached/dc.yml.j2
@@ -36,7 +36,7 @@ spec:
                 - "-c"
                 - "test -f /tmp/healthcheck/ok"
             initialDelaySeconds: 60
-            periodSeconds: 5
+            periodSeconds: 30
           readinessProbe:
             exec:
               command:
@@ -44,7 +44,7 @@ spec:
                 - "-c"
                 - "test -f /tmp/healthcheck/ok"
             initialDelaySeconds: 5
-            periodSeconds: 3
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /tmp/healthcheck
               name: tmp-healthcheck
@@ -70,7 +70,7 @@ spec:
                 - "-c"
                 - echo -e "set healtz 0 0 2\r\nok\r\nget healtz\r" | nc edxapp-memcached-{{ deployment_stamp }} {{ edxapp_memcached_port }} | grep ok || rm /tmp/healthcheck/ok
             initialDelaySeconds: 60
-            periodSeconds: 5
+            periodSeconds: 30
           volumeMounts:
             - mountPath: /tmp/healthcheck
               name: tmp-healthcheck

--- a/apps/edxapp/templates/services/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/services/nginx/dc.yml.j2
@@ -61,13 +61,13 @@ spec:
               path: "{{ edxapp_nginx_healthcheck_endpoint }}"
               port: {{ edxapp_nginx_healthcheck_port }}
             initialDelaySeconds: 60
-            periodSeconds: 10
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: "{{ edxapp_nginx_healthcheck_endpoint }}"
               port: {{ edxapp_nginx_healthcheck_port }}
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
       volumes:
         - name: edxapp-v-nginx
           configMap:

--- a/apps/forum/templates/services/app/dc.yml.j2
+++ b/apps/forum/templates/services/app/dc.yml.j2
@@ -46,7 +46,7 @@ spec:
                 - name: Host
                   value: "{{ forum_host }}"
             initialDelaySeconds: 60
-            periodSeconds: 5
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /heartbeat
@@ -54,8 +54,8 @@ spec:
               httpHeaders:
                 - name: Host
                   value: "{{ forum_host }}"
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
           ports:
             - containerPort: "{{ forum_port }}"
               protocol: TCP

--- a/apps/learninglocker/templates/services/nginx/dc.yml.j2
+++ b/apps/learninglocker/templates/services/nginx/dc.yml.j2
@@ -29,13 +29,13 @@ spec:
               path: "{{ learninglocker_nginx_healthcheck_endpoint }}"
               port: {{ learninglocker_nginx_healthcheck_port }}
             initialDelaySeconds: 60
-            periodSeconds: 10
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: "{{ learninglocker_nginx_healthcheck_endpoint }}"
               port: {{ learninglocker_nginx_healthcheck_port }}
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
           volumeMounts:
             - mountPath: /etc/nginx/conf.d
               name: learninglocker-v-nginx

--- a/apps/marsha/templates/services/app/dc.yml.j2
+++ b/apps/marsha/templates/services/app/dc.yml.j2
@@ -44,7 +44,7 @@ spec:
                 - name: Host
                   value: "{{ marsha_host }}"
             initialDelaySeconds: 60
-            periodSeconds: 5
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /__lbheartbeat__
@@ -52,8 +52,8 @@ spec:
               httpHeaders:
                 - name: Host
                   value: "{{ marsha_host }}"
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: marsha.settings

--- a/apps/marsha/templates/services/nginx/dc.yml.j2
+++ b/apps/marsha/templates/services/nginx/dc.yml.j2
@@ -58,13 +58,13 @@ spec:
               path: "{{ marsha_nginx_healthcheck_endpoint }}"
               port: {{ marsha_nginx_healthcheck_port }}
             initialDelaySeconds: 60
-            periodSeconds: 10
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: "{{ marsha_nginx_healthcheck_endpoint }}"
               port: {{ marsha_nginx_healthcheck_port }}
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
       volumes:
         - name: marsha-v-nginx
           configMap:

--- a/apps/redis/templates/services/app/dc.yml.j2
+++ b/apps/redis/templates/services/app/dc.yml.j2
@@ -32,7 +32,7 @@ spec:
                 - "-c"
                 - "redis-cli ping"
             initialDelaySeconds: 120
-            periodSeconds: 5
+            periodSeconds: 30
           readinessProbe:
             exec:
               command:
@@ -40,7 +40,7 @@ spec:
                 - "-c"
                 - "redis-cli ping"
             initialDelaySeconds: 60
-            periodSeconds: 3
+            periodSeconds: 10
           volumeMounts:
             - mountPath: /data
               name: redis-v-data

--- a/apps/richie/templates/services/app/dc.yml.j2
+++ b/apps/richie/templates/services/app/dc.yml.j2
@@ -44,7 +44,7 @@ spec:
                 - name: Host
                   value: "{{ richie_host }}"
             initialDelaySeconds: 60
-            periodSeconds: 5
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: /__lbheartbeat__
@@ -52,8 +52,8 @@ spec:
               httpHeaders:
                 - name: Host
                   value: "{{ richie_host }}"
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: "{{ richie_django_settings_module }}"

--- a/apps/richie/templates/services/nginx/dc.yml.j2
+++ b/apps/richie/templates/services/nginx/dc.yml.j2
@@ -58,13 +58,13 @@ spec:
               path: "{{ richie_nginx_healthcheck_endpoint }}"
               port: {{ richie_nginx_healthcheck_port }}
             initialDelaySeconds: 60
-            periodSeconds: 10
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: "{{ richie_nginx_healthcheck_endpoint }}"
               port: {{ richie_nginx_healthcheck_port }}
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
       volumes:
         - name: richie-v-nginx
           configMap:

--- a/core_apps/redirect/templates/services/nginx/dc.yml.j2
+++ b/core_apps/redirect/templates/services/nginx/dc.yml.j2
@@ -44,13 +44,13 @@ spec:
               path: "{{ redirect_nginx_healthcheck_endpoint }}"
               port: {{ redirect_nginx_healthcheck_port }}
             initialDelaySeconds: 60
-            periodSeconds: 10
+            periodSeconds: 30
           readinessProbe:
             httpGet:
               path: "{{ redirect_nginx_healthcheck_endpoint }}"
               port: {{ redirect_nginx_healthcheck_port }}
-            initialDelaySeconds: 5
-            periodSeconds: 3
+            initialDelaySeconds: 10
+            periodSeconds: 5
           volumeMounts:
             - mountPath: /etc/nginx/conf.d
               name: redirect-v-nginx


### PR DESCRIPTION
## Purpose

When a database service is not available, the frequency of our pods healthcheck is so high that our platform suffers then from a heavy load.

## Proposal

- [x] increase liveness/readiness probes `periodSeconds`
