### PR TITLE
⚡️(edxapp) decrease workers healthcheck frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Optimize `edxapp` workers liveness probe frequency and replication to lower
+  base cluster load
+
 ## [2.4.2] - 2019-06-12
 
 ### Changed

--- a/apps/edxapp/templates/services/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_dc_base.yml.j2
@@ -93,7 +93,7 @@ spec:
               - "-c"
               - "python manage.py {{ service_variant }} celery inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
           initialDelaySeconds: 120
-          periodSeconds: 30
+          periodSeconds: 400
         readinessProbe:
           exec:
             command:
@@ -101,7 +101,7 @@ spec:
               - "-c"
               - "python manage.py {{ service_variant }} celery inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
           initialDelaySeconds: 60
-          periodSeconds: 10
+          periodSeconds: 15
 {% else %}
         # Pod probes that only apply for wsgi services
         livenessProbe:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -126,7 +126,7 @@ edxapp_celery_lms_default_priority_worker:
     - *lms_default
     - *lms_low
     - *lms_high_mem
-  replicas: 1
+  replicas: 2
 edxapp_celery_lms_low_priority_worker:
   name: "lms-low"
   queues: [*lms_low]
@@ -147,7 +147,7 @@ edxapp_celery_cms_default_priority_worker:
     - *cms_high
     - *cms_default
     - *cms_low
-  replicas: 1
+  replicas: 2
 edxapp_celery_cms_low_priority_worker:
   name: "cms-low"
   queues: [*cms_low]


### PR DESCRIPTION
## Purpose

Current `edxapp` workers health checks are too frequent given the command execution time leadiing to a high base cluster load. This must be optimized.

## Proposal

To lower our k8s cluster load, we need to adapt our strategy by checking the liveness status of our workers every 5 minutes with two replicas for the default worker. This combination is a good compromise between base server load and service redundancy.
