### PR TITLE
✨(playbook) ensure secrets exist before deploying

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Optimize `edxapp` workers liveness probe frequency and replication to lower
   base cluster load
+- Ensure expected secrets exists before deploying an application
 
 ## [2.4.2] - 2019-06-12
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -43,6 +43,7 @@
       vars:
         tasks:
           - tasks/get_objects_for_app
+          - tasks/check_app_secrets
           - tasks/create_app_config
           - tasks/manage_app
       tags:

--- a/tasks/check_app_secrets.yml
+++ b/tasks/check_app_secrets.yml
@@ -1,0 +1,39 @@
+# Check expected app secrets exists. This is useful to avoid deploying an
+# application for which secrets have not been created first.
+
+- name: Does current app has secrets?
+  set_fact:
+    app_has_secrets: "{{
+      app |
+      json_query('services[*].templates[]') |
+      map('regex_search', '.*/secret.*\\.yml\\.j2$') |
+      select('string') | list | length > 0
+    }}"
+  tags: secret
+
+- name: "Get created application secrets for {{ app.name }}"
+  k8s_facts:
+    api_version: "v1"
+    namespace: "{{ project_name }}"
+    kind: Secret
+    label_selectors:
+      - app={{ app.name }}
+  register: existing_secrets
+  when: app_has_secrets
+  tags: secret
+
+- name: "Filter secrets matching expected checksum {{ lookup('vars', app.name + '_vault_checksum') }}"
+  set_fact:
+    selected_secret_names: "{{
+      existing_secrets |
+      json_query('resources[].metadata.name') |
+      select('match', '.*-' + lookup('vars', app.name + '_vault_checksum')) | list
+    }}"
+  when: app_has_secrets
+  tags: secret
+
+- name: Check if secrets matching the current application vault checksum exists
+  fail:
+    msg: "Application secrets should be created first"
+  when: app_has_secrets and selected_secret_names | length < 1
+  tags: secret


### PR DESCRIPTION
## Purpose

When updating a vault content, we often forget to regenerate our secrets before re-deploying an application. In this case, the deployment fails and we need to clean up our newly created orphan stack.

To prevent this failure, @lunika suggested that we check secrets before deploying.

## Proposal

- [x] Add a new `check_app_secrets` task set