### PR TITLE
✨(playbook) add clean up utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add `delete_previous.yml` playbook to delete previous stacks (should be used
   with caution)
 - Add a `rollback.yml` playbook to restore the previous stack as the current one
+- Add a `clean.yml` playbook to remove orphan stacks (not associated to any
+  route) for blue-green-compatible applications
 
 ### Changed
 

--- a/bin/clean
+++ b/bin/clean
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+# shellcheck source=bin/_config.sh
+source "$(dirname "${BASH_SOURCE[0]}")/_config.sh"
+
+# Set OpenShift's environment (you'll need to be logged in to an OpenShift
+# server)
+_set_openshift_env
+
+# Run ansible-playbook
+_ansible_playbook clean.yml "$@"

--- a/clean.yml
+++ b/clean.yml
@@ -1,0 +1,31 @@
+---
+# This playbook removes objects that are no longer used. By used, we mean
+# objects labelled with a deployment stamp that is no longer active, i.e.
+# neither the previous, current or next routes are pointing to a service
+# labelled with this deployment stamp.
+#
+# Warning: this playbook has only effects on blue-green compatible apps.
+
+- hosts: local
+  gather_facts: False
+
+  pre_tasks:
+    - import_tasks: tasks/check_configuration.yml
+    - import_tasks: tasks/check_apps_filter.yml
+
+  tasks:
+    - name: Display playbook name
+      debug: msg="==== Starting clean playbook ===="
+      tags: clean
+
+    - import_tasks: tasks/set_vars.yml
+      tags: clean
+
+    - include_tasks: tasks/run_tasks_for_apps.yml
+      vars:
+        tasks:
+          - get_objects_for_app
+          - clean_app_orphans
+      tags:
+        - route
+        - clean

--- a/tasks/clean_app_orphans.yml
+++ b/tasks/clean_app_orphans.yml
@@ -1,0 +1,44 @@
+---
+# Remove orphan application stacks (i.e. outdated, unused objects)
+
+- include_tasks: deploy_get_stamp_from_route.yml
+  vars:
+    prefix: "{{ item }}"
+  loop: ["previous", "current", "next"]
+  tags: clean
+
+# The select filter removes empty deployment stamps (empty strings)
+- name: Set active_deployment_stamps
+  set_fact:
+    active_deployment_stamps: "{{
+      [ previous_app_deployment_stamp,
+        current_app_deployment_stamp,
+        next_app_deployment_stamp ] |
+      select() | list
+    }}"
+
+- name: "Select objects (CM + pods) for app {{ app.name }}"
+  k8s_facts:
+    api_version: "v1"
+    namespace: "{{ project_name }}"
+    kind: "{{ item }}"
+    label_selectors:
+      - app={{ app.name }}
+  loop:
+    - "Pod"
+    - "ConfigMap"
+  register: app_selected_objects
+
+- name: Set orphan deployment stamps
+  set_fact:
+    orphan_deployment_stamps: "{{
+      app_selected_objects |
+      json_query('results[*].resources[*].metadata.labels.deployment_stamp') |
+      flatten |
+      difference(active_deployment_stamps)
+    }}"
+
+- include_tasks: delete_app.yml
+  vars:
+    app_deployment_stamp: "{{ item }}"
+  loop: "{{ orphan_deployment_stamps }}"

--- a/tasks/deploy_get_stamp_from_route.yml
+++ b/tasks/deploy_get_stamp_from_route.yml
@@ -31,10 +31,14 @@
   set_fact:
     app_deployment_stamp: ""
 
-- name: set_fact app_deployment_stamp
+- name: Set app_deployment_stamp
   set_fact:
     app_deployment_stamp: "{{ (targeted_service.resources | first ).metadata.labels.deployment_stamp | default(none) }}"
   when: targeted_service.resources is defined and targeted_service.resources | length == 1
+
+- name: "Set {{ prefix }}_app_deployment_stamp"
+  set_fact:
+    "{{ prefix }}_app_deployment_stamp": "{{ app_deployment_stamp }}"
 
 - name: Print app_deployment_stamp
   debug:

--- a/tasks/rollback_routes.yml
+++ b/tasks/rollback_routes.yml
@@ -6,10 +6,6 @@
     prefix: next
   tags: switch
 
-- name: Save next_app_deployment_stamp
-  set_fact:
-    next_app_deployment_stamp: "{{ app_deployment_stamp }}"
-
 - include_tasks: switch_route.yml
   vars:
     prefix_route_src:  "{{ prefix_route.src }}"

--- a/tasks/switch_routes.yml
+++ b/tasks/switch_routes.yml
@@ -6,10 +6,6 @@
     prefix: "previous"
   tags: switch
 
-- name: Save previous_app_deployment_stamp
-  set_fact:
-    previous_app_deployment_stamp: "{{ app_deployment_stamp }}"
-
 - include_tasks: switch_route.yml
   vars:
     prefix_route_src:  "{{ prefix_route.src }}"


### PR DESCRIPTION
## Purpose

When a deployment fails or old objects cleanup has not been exhaustive, remaining objects may consume resources they are not supposed to. Until now, we used `oc` to delete old, unused, orphan applications stacks deployment stamp by deployment stamp.

## Proposal

The proposed playbook now automates the clean up step by looking for all Pod or ConfigMap deployment stamps that are not associated with active routes (previous, current or next) and deleting all objects labelled with these deployment stamps.

Fix #135 