### PR TITLE
🚑(playbook) handle permission issues for secrets check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Ignore expected secrets checking for logged users with no permission on
+  secrets
+
 ## [2.5.0] - 2019-06-21
 
 ### Added

--- a/tasks/check_app_secrets.yml
+++ b/tasks/check_app_secrets.yml
@@ -9,16 +9,28 @@
       map('regex_search', '.*/secret.*\\.yml\\.j2$') |
       select('string') | list | length > 0
     }}"
+    app_should_check_secrets: true
   tags: secret
 
-- name: "Get created application secrets for {{ app.name }}"
-  k8s_facts:
-    api_version: "v1"
-    namespace: "{{ project_name }}"
-    kind: Secret
-    label_selectors:
-      - app={{ app.name }}
-  register: existing_secrets
+- name: Handle permission on Secret objects
+  block:
+    - name: "Get created application secrets for {{ app.name }}"
+      k8s_facts:
+        api_version: "v1"
+        namespace: "{{ project_name }}"
+        kind: Secret
+        label_selectors:
+          - app={{ app.name }}
+      register: existing_secrets
+  rescue:
+    - name: Debug k8s query failure
+      debug:
+        msg: >
+          Cannot get created secrets for application "{{ app.name }}". Logged user probably
+          does not have permissions for this kind of object!
+    - name: Ignore app secrets checking
+      set_fact:
+        app_should_check_secrets: false
   when: app_has_secrets
   tags: secret
 
@@ -29,11 +41,11 @@
       json_query('resources[].metadata.name') |
       select('match', '.*-' + lookup('vars', app.name + '_vault_checksum')) | list
     }}"
-  when: app_has_secrets
+  when: app_has_secrets and app_should_check_secrets
   tags: secret
 
 - name: Check if secrets matching the current application vault checksum exists
   fail:
     msg: "Application secrets should be created first"
-  when: app_has_secrets and selected_secret_names | length < 1
+  when: app_has_secrets and app_should_check_secrets and selected_secret_names | length < 1
   tags: secret


### PR DESCRIPTION
## Purpose

Checking that application secrets exists requires that the logged user is allowed to list them in the active namespace. Typically, a deployment bot has not such permission and the deployment cannot be pursued.

## Proposal

To mitigate this issue, we have inactivated this checking for user without permission on secrets.
