### PR TITLE
Upgrade to ansible 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade OpenShift to OpenShift `0.9.2`
+- Upgrade Ansible to `2.8.5`
 
 ## [2.8.0] - 2019-08-23
 

--- a/env.d/ci
+++ b/env.d/ci
@@ -3,7 +3,4 @@
 
 # ---- OpenShift ----
 # Whether or not to verify the API server's SSL certificates:
-#   whatever is a value for yes
-#   empty for no
-# Bug: https://github.com/ansible/ansible/pull/51836
-K8S_AUTH_VERIFY_SSL=
+K8S_AUTH_VERIFY_SSL=no

--- a/env.d/development
+++ b/env.d/development
@@ -3,7 +3,4 @@
 
 # ---- OpenShift ----
 # Whether or not to verify the API server's SSL certificates:
-#   whatever is a value for yes
-#   empty for no
-# Bug: https://github.com/ansible/ansible/pull/51836
-K8S_AUTH_VERIFY_SSL=
+K8S_AUTH_VERIFY_SSL=no

--- a/lookup_plugins/apps.py
+++ b/lookup_plugins/apps.py
@@ -19,10 +19,10 @@ DOCUMENTATION = """
     version_added: "0.1"
     short_description: walk through an application tree to discover deployable
         applications
-    description:
+    description: >
         Lookup ready-to-deploy applications following recommended Arnold
         applications' tree, e.g. for the "richie" application and the
-        "apps" ``apps_path``:
+        "apps" ``apps_path``::
 
             apps/richie
             ├── templates
@@ -51,6 +51,8 @@ DOCUMENTATION = """
 
         Analysing this tree with the ``apps`` lookup should return the
         following data structure:
+
+        .. code-block:: json
 
             [
                 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Core
-ansible==2.7.12
+ansible==2.8.5
 ansible-lint==4.1.0
 deepmerge==0.1.0
 jmespath==0.9.4

--- a/tests/units/plugins/filter/test_deploy.py
+++ b/tests/units/plugins/filter/test_deploy.py
@@ -2,7 +2,8 @@
 Tests for the "deploy" plugin filter
 """
 
-from ansible.compat.tests import unittest
+import unittest
+
 from ansible.errors import AnsibleFilterError
 
 from filter_plugins.deploy import blue_green_host, blue_green_hosts

--- a/tests/units/plugins/filter/test_merge.py
+++ b/tests/units/plugins/filter/test_merge.py
@@ -1,10 +1,11 @@
 """
 Tests for the "merge" plugin filter
 """
+
 from copy import deepcopy
+from unittest import TestCase
 from unittest.mock import patch
 
-from ansible.compat.tests import unittest
 from ansible.errors import AnsibleFilterError
 
 from filter_plugins.merge import merge_with_app, merge_with_database
@@ -35,7 +36,7 @@ def deep_sort_dict(d):
 
 
 # pylint: disable=no-self-use
-class TestDeepSortDict(unittest.TestCase):
+class TestDeepSortDict(TestCase):
     """Test the ``deep_sort_dict`` utility"""
 
     def test_immutability(self):
@@ -78,7 +79,7 @@ class TestDeepSortDict(unittest.TestCase):
         assert deep_sort_dict(d) == expected
 
 
-class TestMergeWithAppFilter(unittest.TestCase):
+class TestMergeWithAppFilter(TestCase):
     """Tests for the ``merge_with_app`` filter"""
 
     # View the full diff upon test failure
@@ -417,7 +418,7 @@ class TestMergeWithAppFilter(unittest.TestCase):
         self.assertDictDeepEqual(merge_with_app(base, new), expected)
 
 
-class TestMergeWithDatabaseFilter(unittest.TestCase):
+class TestMergeWithDatabaseFilter(TestCase):
     """Tests for the ``merge_with_database`` filter"""
 
     @patch("filter_plugins.merge.random_password", return_value="foo")

--- a/tests/units/plugins/lookup/test_apps.py
+++ b/tests/units/plugins/lookup/test_apps.py
@@ -2,7 +2,8 @@
 Tests for the "apps" plugin lookup
 """
 
-from ansible.compat.tests import unittest
+import unittest
+
 from pyfakefs.fake_filesystem_unittest import \
     TestCaseMixin as fakefsTestCaseMixin
 


### PR DESCRIPTION
## Purpose

Ansible 2.8.x is out for a while now, let's switch to it!

Release changelog:
https://github.com/ansible/ansible/blob/v2.8.5/changelogs/CHANGELOG-v2.8.rst#v2-8-5

## Proposal

- [x] upgrade python requirements to `ansible==2.8.5`
- [x] fix compatibility imports in tests
- [x] fix apps filter module docstring (should be YAML-compatible)