### PR TITLE
⚡️(redis) improve healthcheck reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- `redis` app heath check probes now check that the data volume is accessible
+  with write permissions
+
 ### Security
 
 - Upgrade Ansible to `2.7.12` (see

--- a/apps/redis/templates/services/app/dc.yml.j2
+++ b/apps/redis/templates/services/app/dc.yml.j2
@@ -30,7 +30,7 @@ spec:
               command:
                 - "/bin/bash"
                 - "-c"
-                - "redis-cli ping"
+                - "'redis-cli ping && touch /data/healthcheck'"
             initialDelaySeconds: 120
             periodSeconds: 30
           readinessProbe:
@@ -38,7 +38,7 @@ spec:
               command:
                 - "/bin/bash"
                 - "-c"
-                - "redis-cli ping"
+                - "'redis-cli ping && touch /data/healthcheck'"
             initialDelaySeconds: 60
             periodSeconds: 10
           volumeMounts:


### PR DESCRIPTION
## Purpose

When for some reason the `/data` mounted volume is lost, `redis` is not able to dump the current database on disk and it is no longer responding to requests. This is a SPOF as other apps crashes subsequently (_e.g._ `edxapp`).

## Proposal

We now check that we are able to write to `/data` to ensure that the volume is properly mounted with write permissions.
