### PR TITLE
✨(marsha) allow to configure the command running marsha contrainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade OpenShift to OpenShift `0.9.2`
+- Set in a variable the command running marsha container
 
 ## [2.8.0] - 2019-08-23
 

--- a/apps/marsha/templates/services/app/dc.yml.j2
+++ b/apps/marsha/templates/services/app/dc.yml.j2
@@ -36,6 +36,11 @@ spec:
         - name: marsha
           image: "{{ marsha_image_name }}:{{ marsha_image_tag }}"
           imagePullPolicy: Always
+          command:
+            - /bin/bash
+            - '-c'
+            - >-
+              {{ marsha_gunicorn_command }}
           livenessProbe:
             httpGet:
               path: /__heartbeat__

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -30,6 +30,7 @@ marsha_django_configuration: "Development"
 marsha_secret_name: "marsha-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"
 marsha_cloudfront_private_key_secret_name: "marsha-sshkey-{{ marsha_vault_checksum | default('undefined_marsha_vault_checksum') }}"
 marsha_cloudfront_private_key_path: "/private/.ssh/aws/ssh-privatekey"
+marsha_gunicorn_command: "gunicorn --threads=6 --worker-class=gthread --worker-tmp-dir /dev/shm -c /usr/local/etc/gunicorn/marsha.py marsha.wsgi:application"
 # Set this to true if you have configured AWS CloudFront to require requests
 # signature with the aforementioned SSH key
 marsha_should_sign_requests: true


### PR DESCRIPTION
## Purpose

Gunicorn in docker need few modifications to run well an application
(see https://pythonspeed.com/articles/gunicorn-in-docker/). For marsha
we want to apply some of these rules, the easiest and flexible way to do
this is to override the command running in the container and set it in a
variable.

## Proposal
- [x] create a variable to set the gunicorn command
- [x] use the command property in the DC template for the marsha container
