### PR TITLE
✨(apps) make HTTP basic auth configurable per app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Implement support for docker private registry secrets
 - Make private docker registry usage available for richie
+- Allow to configure HTTP Basic Auth protection on a per-app basis
 
 ## [3.0.1] - 2019-10-04
 

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -6,7 +6,7 @@ server {
   listen {{ edxapp_nginx_cms_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth -%}
+  {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
   {% endif %}

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -6,7 +6,7 @@ server {
   listen {{ edxapp_nginx_lms_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth -%}
+  {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
   {% endif %}

--- a/apps/edxapp/templates/services/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/services/nginx/dc.yml.j2
@@ -51,7 +51,7 @@ spec:
             - mountPath: /data/export
               name: edxapp-v-export
               readOnly: true
-            {% if activate_http_basic_auth -%}
+            {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: edxapp-htpasswd
             {% endif %}

--- a/apps/edxapp/templates/services/nginx/secret.yml.j2
+++ b/apps/edxapp/templates/services/nginx/secret.yml.j2
@@ -1,4 +1,4 @@
-{% if activate_http_basic_auth %}
+{% if activate_http_basic_auth or edxapp_activate_http_basic_auth %}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -13,6 +13,7 @@ edxapp_lms_replicas: 1
 edxapp_cms_replicas: 1
 edxapp_sql_dump_url: "https://gist.githubusercontent.com/jmaupetit/76fe7db4a8314fe1fa10895edf14248e/raw/1fd2aab7d57273bbe4cf40603c119a1c8026cbc1/edx-database-hawthorn.sql"
 edxapp_secret_name: "edxapp-{{ edxapp_vault_checksum | default('undefined_edxapp_vault_checksum') }}"
+edxapp_activate_http_basic_auth: false
 
 # i18n
 # Should we download and compile latest translations?

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -6,7 +6,7 @@ server {
   listen {{ marsha_nginx_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth -%}
+  {% if activate_http_basic_auth or marsha_activate_http_basic_auth -%}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
   {% endif %}

--- a/apps/marsha/templates/services/nginx/dc.yml.j2
+++ b/apps/marsha/templates/services/nginx/dc.yml.j2
@@ -48,7 +48,7 @@ spec:
             - mountPath: /data/static/marsha
               name: marsha-v-static
               readOnly: true
-            {% if activate_http_basic_auth -%}
+            {% if activate_http_basic_auth or marsha_activate_http_basic_auth -%}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: marsha-htpasswd
             {% endif %}

--- a/apps/marsha/templates/services/nginx/secret.yml.j2
+++ b/apps/marsha/templates/services/nginx/secret.yml.j2
@@ -1,4 +1,4 @@
-{% if activate_http_basic_auth %}
+{% if activate_http_basic_auth or marsha_activate_http_basic_auth %}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -33,6 +33,7 @@ marsha_cloudfront_private_key_path: "/private/.ssh/aws/ssh-privatekey"
 # Set this to true if you have configured AWS CloudFront to require requests
 # signature with the aforementioned SSH key
 marsha_should_sign_requests: true
+marsha_activate_http_basic_auth: false
 
 # -- volumes
 marsha_media_volume_size: 2Gi

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -6,7 +6,7 @@ server {
   listen {{ richie_nginx_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth -%}
+  {% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
   {% endif %}

--- a/apps/richie/templates/services/nginx/dc.yml.j2
+++ b/apps/richie/templates/services/nginx/dc.yml.j2
@@ -48,7 +48,7 @@ spec:
             - mountPath: /data/static/richie
               name: richie-v-static
               readOnly: true
-            {% if activate_http_basic_auth -%}
+            {% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: richie-htpasswd
             {% endif %}

--- a/apps/richie/templates/services/nginx/secret.yml.j2
+++ b/apps/richie/templates/services/nginx/secret.yml.j2
@@ -1,4 +1,4 @@
-{% if activate_http_basic_auth %}
+{% if activate_http_basic_auth or richie_activate_http_basic_auth %}
 apiVersion: v1
 kind: Secret
 metadata:

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -55,6 +55,8 @@ richie_extra_dependencies:
   # - "raven>=6.0.0"
   # - "requests"
 
+richie_activate_http_basic_auth: false
+
 # -- volumes
 richie_media_volume_size: 2Gi
 richie_static_volume_size: 2Gi

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -82,7 +82,10 @@ has_acme_cluster_role: false
 # Expected vault path
 vault_path: "group_vars/customer/{{ customer }}/{{ env_type }}/secrets"
 
-# Protect public services behind HTTP basic authentication
+# Protect public services behind HTTP basic authentication (global setting that
+# applies for every compatible app of the project). Note that some apps (e.g.
+# edxapp, Richie, Marsha...) can be protected individually by setting the "{{
+# app.name }}_activate_http_basic_auth" variable to true.
 activate_http_basic_auth: false
 # The message that will be displayed by the client browser
 http_basic_auth_message: "Restricted Area"

--- a/tasks/get_vault_for_app.yml
+++ b/tasks/get_vault_for_app.yml
@@ -18,9 +18,14 @@
   register: app_htpasswd_file
   tags: htpasswd
 
+- name: Get application activate_http_basic_auth value
+  set_fact:
+    app_activate_http_basic_auth: "{{ lookup('vars', app.name + '_activate_http_basic_auth', default=false) }}"
+  tags: htpasswd
+
 - name: Set application htpasswd variable
   set_fact:
     "{{ app.name }}_htpasswd": "{{ app_htpasswd_file.stat.path }}"
   # Only set this variable when the htpasswd file exists and is a regular file
-  when: activate_http_basic_auth and app_htpasswd_file.stat.exists and app_htpasswd_file.stat.isreg
+  when: (activate_http_basic_auth or app_activate_http_basic_auth) and app_htpasswd_file.stat.exists and app_htpasswd_file.stat.isreg
   tags: htpasswd


### PR DESCRIPTION
## Purpose

Until now, the HTTP basic auth activation was a global setting for a project, but in some case, one need to deploy and test a new service for a project without protecting all services but only the new one.

## Proposal

- [x] add per-app setting (`edxapp`, `richie`, `marsha`)
- [x] use app setting in app's `nginx` configuration and secret
