### PR TITLE
🐛(secrets) fix private docker registry task when checking if file exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Task that creates a secret with credentials for private Docker registries.
+
 ## [3.1.0] - 2019-10-07
 
 ### Added

--- a/tasks/create_docker_registry_secrets.yml
+++ b/tasks/create_docker_registry_secrets.yml
@@ -11,7 +11,7 @@
       debug:
         msg: "No registries vault is associated with the project"
     - meta: end_play
-  when: registries_vault.stat.exists
+  when: not registries_vault.stat.exists
 
 - name: Import registries variable
   include_vars:


### PR DESCRIPTION
## Purpose

The condition was reversed when checking if a secrets file exists with credentials to private Docker registries.

## Proposal

I modified the condition to proceed when a secrets file exists and stop otherwise.
