### PR TITLE
🐛(edxapp) fix jobs image name when using custom theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Upgrade Ansible to `2.8.6`
 - Generate `edxapp` theme translations in target image build configuration
 
+### Fixed
+
+- Fixed broken `edxapp` jobs container image name when enabling a custom theme
+
 ## [3.1.1] - 2019-10-09
 
 ### Fixed

--- a/apps/edxapp/templates/services/cms/job_01_internationalization.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_01_internationalization.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
 {% if edxapp_should_update_i18n %}
 apiVersion: batch/v1
 kind: Job
@@ -27,7 +28,7 @@ spec:
         - name: edxapp-cms-internationalization-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_02_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_02_collectstatic.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -26,7 +27,7 @@ spec:
         - name: edxapp-cms-collectstatic-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_05_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_05_db_migrate.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,7 +25,7 @@ spec:
         - name: edxapp-cms-dbmigrate-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_06_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_06_load_fixtures.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
 {% if env_type in trashable_env_types %}
 apiVersion: batch/v1
 kind: Job
@@ -25,7 +26,7 @@ spec:
         - name: edxapp-cms-load-fixtures-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-cms:{{ edxapp_image_tag }}-live"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/lms/job_03_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_03_collectstatic.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -26,7 +27,7 @@ spec:
         - name: edxapp-lms-collectstatic-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-lms:{{ edxapp_image_tag }}-live"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/lms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_04_db_migrate.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -24,7 +25,7 @@ spec:
         - name: edxapp-lms-dbmigrate-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/edxapp-lms:{{ edxapp_image_tag }}-live"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run


### PR DESCRIPTION
## Purpose

When using a custom theme, `edxapp` jobs containers are supposed to run using a non-existing image since the theme version is included in the image name reference.

## Proposal

- [x] use the `image_name` macro in `edxapp` jobs