### PR TITLE
🐛(marsha) test if sentry is defined before setting in secret

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Upgrade OpenShift to `0.10.0`
 - Upgrade `yq` ti `2.8.1`
 
+### Fixed
+
+- Set sentry in marsha secret only if present in the vault
+
 ## [3.2.0] - 2019-10-25
 
 ### Changed

--- a/apps/marsha/templates/services/app/secret.yml.j2
+++ b/apps/marsha/templates/services/app/secret.yml.j2
@@ -16,7 +16,9 @@ data:
   DJANGO_CLOUDFRONT_DOMAIN: "{{ MARSHA_VAULT.DJANGO_CLOUDFRONT_DOMAIN | default('foo.com') | b64encode }}"
   DJANGO_JWT_SIGNING_KEY: "{{ MARSHA_VAULT.DJANGO_JWT_SIGNING_KEY | default('secret') | b64encode }}"
   DJANGO_SECRET_KEY: "{{ MARSHA_VAULT.DJANGO_SECRET_KEY | default('supersecret') | b64encode }}"
-  DJANGO_SENTRY_DSN: "{{ MARSHA_VAULT.DJANGO_SENTRY_DSN | default('fakedsn') | b64encode }}"
+{% if MARSHA_VAULT.DJANGO_SENTRY_DSN is defined and MARSHA_VAULT.DJANGO_SENTRY_DSN is not none %}
+  DJANGO_SENTRY_DSN: "{{ MARSHA_VAULT.DJANGO_SENTRY_DSN | b64encode }}"
+{% endif %}
   DJANGO_AWS_S3_REGION_NAME: "{{ MARSHA_VAULT.DJANGO_AWS_S3_REGION_NAME | default('eu-west-1') | b64encode }}"
 {% if MARSHA_VAULT.DJANGO_LRS_AUTH_TOKEN is defined %}
   DJANGO_LRS_AUTH_TOKEN: "{{ MARSHA_VAULT.DJANGO_LRS_AUTH_TOKEN | b64encode }}"


### PR DESCRIPTION
## Purpose

Using sentry is not mandatory and using a default value in the secret is
wrong because the sdk will warn us that the dsn is incorrect. The good
way is to declare it in the secret only it was set in marsha's vault.

## Proposal

- [x] set sentry in marsha secret only if present in the vault
