### PR TITLE
manage conditional volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Set sentry in marsha secret only if present in the vault
+- Ignore creating empty volume templates
 
 ## [3.2.0] - 2019-10-25
 

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -29,8 +29,10 @@ server {
     try_files $uri @proxy_to_marsha_app;
   }
 
+  {% if env_type in trashable_env_types %}
   location ~ ^/static/(?P<file>.*) {
     root /data/static/marsha;
     try_files /$file =404;
   }
+  {% endif %}
 }

--- a/apps/marsha/templates/services/nginx/dc.yml.j2
+++ b/apps/marsha/templates/services/nginx/dc.yml.j2
@@ -42,16 +42,18 @@ spec:
             - mountPath: /etc/nginx/conf.d
               name: marsha-v-nginx
               readOnly: true
+{% if env_type in trashable_env_types %}
             - mountPath: /data/media/marsha
               name: marsha-v-media
               readOnly: true
             - mountPath: /data/static/marsha
               name: marsha-v-static
               readOnly: true
-            {% if activate_http_basic_auth or marsha_activate_http_basic_auth -%}
+{% endif %}
+{% if activate_http_basic_auth or marsha_activate_http_basic_auth %}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: marsha-htpasswd
-            {% endif %}
+{% endif %}
 
           livenessProbe:
             httpGet:
@@ -69,14 +71,16 @@ spec:
         - name: marsha-v-nginx
           configMap:
             name: marsha-nginx-{{ deployment_stamp }}
+{% if env_type in trashable_env_types %}
         - name: marsha-v-media
           persistentVolumeClaim:
             claimName: marsha-pvc-media
         - name: marsha-v-static
           persistentVolumeClaim:
             claimName: marsha-pvc-static
-        {% if activate_http_basic_auth or marsha_activate_http_basic_auth -%}
+{% endif %}
+{% if activate_http_basic_auth or marsha_activate_http_basic_auth %}
         - name: marsha-htpasswd
           secret:
             secretName: "{{ marsha_nginx_htpasswd_secret_name }}"
-        {% endif %}
+{% endif %}

--- a/tasks/create_app_volumes.yml
+++ b/tasks/create_app_volumes.yml
@@ -6,10 +6,24 @@
     msg: "App name {{ app.name }}"
   tags: volume
 
+# Remove empty rendered volume templates (e.g. inactivated for an env_type)
+- name: Ignore empty rendered volume templates
+  set_fact:
+    path: "{{ item }}"
+  register: filtered_volumes
+  with_items: "{{ app.volumes }}"
+  when: app.volumes is defined and lookup('template', item) | length > 1
+  tags: deploy
+
+- name: Update volume templates list for this app
+  set_fact:
+    volumes: "{{ filtered_volumes | json_query('results[*].ansible_facts.path') | list }}"
+  when: app.volumes is defined
+  
 - name: Make sure application volumes exist
   k8s:
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: present
-  with_items: "{{ app.volumes }}"
+  with_items: "{{ volumes }}"
   when: app.volumes is defined
   tags: volume


### PR DESCRIPTION
## Purpose

Creating volume can be conditioned by the env used when the application is
deployed. Templates can be empty and the creation will fail. We have to
filter volume templates to remove empty template and then create non
empty volumes.


## Proposal

- [x] filter empty volume templates
- [x] ignore volumes in marsha's nginx DC if not in trashable env