### PR TITLE
♻️(richie) allow deactivating static/media volumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Allow deactivating volumes for static and media files in the richie app
+
 ### Changed
 
 - Upgrade Ansible to `2.9.0`

--- a/apps/richie/templates/services/app/dc.yml.j2
+++ b/apps/richie/templates/services/app/dc.yml.j2
@@ -81,14 +81,22 @@ spec:
             - configMapRef:
                 name: "richie-app-dotenv-{{ deployment_stamp }}"
           volumeMounts:
+{% if richie_should_activate_media_volume %}
             - name: richie-v-media
               mountPath: /data/media
+{% endif %}
+{% if richie_should_activate_static_volume %}
             - name: richie-v-static
               mountPath: /data/static
+{% endif %}
       volumes:
+{% if richie_should_activate_media_volume %}
         - name: richie-v-media
           persistentVolumeClaim:
             claimName: richie-pvc-media
+{% endif %}
+{% if richie_should_activate_static_volume %}
         - name: richie-v-static
           persistentVolumeClaim:
             claimName: richie-pvc-static
+{% endif %}

--- a/apps/richie/templates/services/app/job_01_collectstatic.yml.j2
+++ b/apps/richie/templates/services/app/job_01_collectstatic.yml.j2
@@ -26,6 +26,7 @@ spec:
       imagePullSecrets:
         - name: "{{ richie_image_pull_secret_name }}"
 {% endif %}
+      restartPolicy: Never
       containers:
         - name: richie-collectstatic
           image: "{{ richie_image_name }}:{{ richie_image_tag }}"
@@ -50,6 +51,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py collectstatic --noinput
+{% if richie_should_activate_static_volume %}
           volumeMounts:
             - mountPath: /data/static
               name: richie-v-static
@@ -57,4 +59,4 @@ spec:
         - name: richie-v-static
           persistentVolumeClaim:
             claimName: richie-pvc-static
-      restartPolicy: Never
+{% endif %}

--- a/apps/richie/templates/services/app/job_04_bootstrap_elasticsearch.yml.j2
+++ b/apps/richie/templates/services/app/job_04_bootstrap_elasticsearch.yml.j2
@@ -51,6 +51,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py bootstrap_elasticsearch
+{% if richie_should_activate_media_volume %}
           volumeMounts:
             - name: richie-v-media
               mountPath: /data/media
@@ -58,3 +59,4 @@ spec:
         - name: richie-v-media
           persistentVolumeClaim:
             claimName: richie-pvc-media
+{% endif %}

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -29,13 +29,18 @@ server {
     try_files $uri @proxy_to_richie_app;
   }
 
+{% if richie_should_activate_media_volume %}
   location ~ ^/media/(?P<file>.*) {
     root /data/media/richie;
     try_files /$file =404;
   }
+{% endif %}
 
+{% if richie_should_activate_static_volume %}
   location ~ ^/static/(?P<file>.*) {
     root /data/static/richie;
     try_files /$file =404;
   }
+{% endif %}
+
 }

--- a/apps/richie/templates/services/nginx/dc.yml.j2
+++ b/apps/richie/templates/services/nginx/dc.yml.j2
@@ -42,16 +42,20 @@ spec:
             - mountPath: /etc/nginx/conf.d
               name: richie-v-nginx
               readOnly: true
+{% if richie_should_activate_media_volume %}
             - mountPath: /data/media/richie
               name: richie-v-media
               readOnly: true
+{% endif %}
+{% if richie_should_activate_static_volume %}
             - mountPath: /data/static/richie
               name: richie-v-static
               readOnly: true
-            {% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
+{% endif %}
+{% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: richie-htpasswd
-            {% endif %}
+{% endif %}
 
           livenessProbe:
             httpGet:
@@ -69,14 +73,18 @@ spec:
         - name: richie-v-nginx
           configMap:
             name: richie-nginx-{{ deployment_stamp }}
+{% if richie_should_activate_media_volume %}
         - name: richie-v-media
           persistentVolumeClaim:
             claimName: richie-pvc-media
+{% endif %}
+{% if richie_should_activate_static_volume %}
         - name: richie-v-static
           persistentVolumeClaim:
             claimName: richie-pvc-static
-        {% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
+{% endif %}
+{% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
         - name: richie-htpasswd
           secret:
             secretName: "{{ richie_nginx_htpasswd_secret_name }}"
-        {% endif %}
+{% endif %}

--- a/apps/richie/templates/volumes/media.yml.j2
+++ b/apps/richie/templates/volumes/media.yml.j2
@@ -1,3 +1,4 @@
+{% if richie_should_activate_media_volume %}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,3 +14,4 @@ spec:
   resources:
     requests:
       storage: {{ richie_media_volume_size }}
+{% endif %}

--- a/apps/richie/templates/volumes/static.yml.j2
+++ b/apps/richie/templates/volumes/static.yml.j2
@@ -1,3 +1,4 @@
+{% if richie_should_activate_static_volume %}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -13,3 +14,4 @@ spec:
   resources:
     requests:
       storage: {{ richie_static_volume_size }}
+{% endif %}

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -58,5 +58,8 @@ richie_extra_dependencies:
 richie_activate_http_basic_auth: false
 
 # -- volumes
+# volume sizes with power of 2 suffices (Ki, Mi, Gi, Ti...) e.g 2Gi and 0 for no volume.
 richie_media_volume_size: 2Gi
 richie_static_volume_size: 2Gi
+richie_should_activate_media_volume: true
+richie_should_activate_static_volume: true


### PR DESCRIPTION
## Purpose

For most of our projects, we use AWS S3 & CloudFront to store and serve our static and media files. In this case, creating volumes in OpenShift is useless. 

## Proposal

I propose to allow setting volumes sizes to 0 to deactivate them.

For the moment, I propose to keep creating volumes by default because it is simpler and works out of the box. Also, relying on AWS requires a Terraform project that is not in richie's sandbox yet.
