### PR TITLE
Configure MongoDB to use a list IPs, a replicaSet and read_preference settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Configure MongoDB to use replicaSet and read_preference settings for all
+  applications working with MongoDB
+
 ## [3.3.1] - 2019-11-25
 
 ### Fixed

--- a/apps/edxapp/templates/services/cms/configs/settings.yml.j2
+++ b/apps/edxapp/templates/services/cms/configs/settings.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/mongodb_host.yml.j2" import mongodb_host with context -%}
 # Settings for edxapp cms
 
 PLATFORM_NAME: "{{ customer }}"
@@ -31,5 +32,12 @@ DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"
 DATABASE_PORT: {{ edxapp_mysql_port }}
 
 # Mongo
-MONGODB_HOST: "edxapp-mongo-{{ deployment_stamp }}"
-MONGODB_PORT: {{ edxapp_mongodb_port }}
+MONGODB_HOST: "{{ mongodb_host(env_type, trashable_env_types, deployment_stamp, endpoint_mongodb_ips, edxapp_mongodb_port, edxapp_mongodb_host) }}"
+{% if edxapp_mongodb_replicaset is defined and edxapp_mongodb_replicaset | length > 1 %}
+MONGODB_REPLICASET: {{ edxapp_mongodb_replicaset }}
+
+{% if edxapp_mongodb_read_preference is defined and edxapp_mongodb_read_preference | length > 1 %}
+MONGODB_READ_PREFERENCE: {{ edxapp_mongodb_read_preference }}
+{% endif %}
+
+{% endif %}

--- a/apps/edxapp/templates/services/cms/macros/mongodb_host.yml.j2
+++ b/apps/edxapp/templates/services/cms/macros/mongodb_host.yml.j2
@@ -1,0 +1,16 @@
+{# compute mongodb host #}
+{%- macro mongodb_host(env_type, trashable_env_types, deployment_stamp, endpoint_mongodb_ips, edxapp_mongodb_port, edxapp_mongodb_host) %}
+    {%- if env_type in trashable_env_types -%}
+        {{ edxapp_mongodb_host }}-{{ deployment_stamp }}:{{ edxapp_mongodb_port }}
+    {%- else -%}
+        {%- set mongodb_service_name = "%s-%s" | format(edxapp_mongodb_host, deployment_stamp) -%}
+        {%- set ns = namespace(hosts="") -%}
+        {%- for ip in endpoint_mongodb_ips -%}
+            {%- set ns.hosts = "%s%s:%s" | format(ns.hosts, mongodb_service_name, edxapp_mongodb_port | int + loop.index0) -%}
+            {%- if loop.index < endpoint_mongodb_ips | length -%}
+                {%- set ns.hosts = "%s," | format(ns.hosts) -%}
+            {%- endif -%}
+        {%- endfor -%}
+        {{ ns.hosts }}        
+    {%- endif -%}
+{%- endmacro %}

--- a/apps/edxapp/templates/services/lms/configs/settings.yml.j2
+++ b/apps/edxapp/templates/services/lms/configs/settings.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/edxapp/templates/services/cms/macros/mongodb_host.yml.j2" import mongodb_host with context -%}
 # Settings for edxapp lms
 
 PLATFORM_NAME: "{{ customer }}"
@@ -32,8 +33,15 @@ DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"
 DATABASE_PORT: {{ edxapp_mysql_port }}
 
 # Mongo
-MONGODB_HOST: "edxapp-mongo-{{ deployment_stamp }}"
-MONGODB_PORT: {{ edxapp_mongodb_port }}
+MONGODB_HOST: "{{ mongodb_host(env_type, trashable_env_types, deployment_stamp, endpoint_mongodb_ips, edxapp_mongodb_port, edxapp_mongodb_host) }}"
+{% if edxapp_mongodb_replicaset is defined and edxapp_mongodb_replicaset | length > 1 %}
+MONGODB_REPLICASET: {{ edxapp_mongodb_replicaset }}
+
+{% if edxapp_mongodb_read_preference is defined and edxapp_mongodb_read_preference | length > 1 %}
+MONGODB_READ_PREFERENCE: {{ edxapp_mongodb_read_preference }}
+{% endif %}
+
+{% endif %}
 
 GRADES_DOWNLOAD:
   STORAGE_TYPE: localfs

--- a/apps/edxapp/templates/services/mongodb/dc.yml.j2
+++ b/apps/edxapp/templates/services/mongodb/dc.yml.j2
@@ -7,7 +7,7 @@ metadata:
     service: mongodb
     version: "{{ edxapp_mongodb_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
-  name: "edxapp-mongodb-{{ deployment_stamp }}"
+  name: "{{ edxapp_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
@@ -17,7 +17,7 @@ spec:
         app: edxapp
         service: mongodb
         version: "{{ edxapp_mongodb_image_tag }}"
-        deploymentconfig: "edxapp-mongodb-{{ deployment_stamp }}"
+        deploymentconfig: "{{ edxapp_mongodb_host }}-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:

--- a/apps/edxapp/templates/services/mongodb/ep.yml.j2
+++ b/apps/edxapp/templates/services/mongodb/ep.yml.j2
@@ -1,4 +1,4 @@
-{% if endpoint_mongodb_ip | ipaddr != false %}
+{% if endpoint_mongodb_ips | length > 1 %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -7,12 +7,17 @@ metadata:
     endpoint: mongodb
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the endpoint should be the same as the corresponding service
-  name: "edxapp-mongo-{{ deployment_stamp }}"
+  name: "{{ edxapp_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 subsets:
-  - addresses:
-    - ip: "{{ endpoint_mongodb_ip }}"
+{% for ip in endpoint_mongodb_ips -%}
+  - 
+    addresses:
+      - 
+        ip: "{{ ip }}"
     ports:
-    - port: "{{ edxapp_mongodb_port }}"
-      name: "{{ edxapp_mongodb_port}}-tcp"
+      - 
+        port: "{{ edxapp_mongodb_port }}"
+        name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
+{% endfor -%}
 {% endif %}

--- a/apps/edxapp/templates/services/mongodb/svc.yml.j2
+++ b/apps/edxapp/templates/services/mongodb/svc.yml.j2
@@ -7,21 +7,29 @@ metadata:
     version: "{{ edxapp_mongodb_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the service should be mongodb host name in settings
-  name: "edxapp-mongo-{{ deployment_stamp }}"
+  name: "{{ edxapp_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   ports:
+{% if env_type in trashable_env_types %}
   - name: "{{ edxapp_mongodb_port }}-tcp"
     port: {{ edxapp_mongodb_port }}
     protocol: TCP
     targetPort: {{ edxapp_mongodb_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
+# not trashable. In this case, we use a mongodb cluster outside of
 # OpenShift.
-{% if env_type in trashable_env_types %}
   selector:
     app: edxapp
-    deploymentconfig: "edxapp-mongodb-{{ deployment_stamp }}"
+    deploymentconfig: "{{ edxapp_mongodb_host }}-{{ deployment_stamp }}"
   type: ClusterIP
-{% endif%}
+{% else %}
+{% for ip in endpoint_mongodb_ips %}
+  - 
+    name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
+    port: {{ edxapp_mongodb_port | int + loop.index0 }} 
+    protocol: TCP
+    targetPort: {{ edxapp_mongodb_port }}
+{% endfor %}
+{% endif %}

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -7,7 +7,7 @@ edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "hawthorn.1-2.6.0"
+edxapp_image_tag: "hawthorn.1-oee-2.11.0"
 edxapp_django_port: 8000
 edxapp_lms_replicas: 1
 edxapp_cms_replicas: 1
@@ -83,6 +83,9 @@ edxapp_mongodb_version: "3.2"
 edxapp_mongodb_image_name: "centos/mongodb-32-centos7"
 edxapp_mongodb_image_tag: "3.2"
 edxapp_mongodb_port: 27017
+edxapp_mongodb_host: "edxapp-mongodb"
+edxapp_mongodb_replicaset: ""
+edxapp_mongodb_read_preference: ""
 edxapp_mongodb_secret_name: "edxapp-mongo-{{ edxapp_vault_checksum | default('undefined_edxapp_vault_checksum') }}"
 
 # -- mysql

--- a/apps/forum/templates/services/app/dc.yml.j2
+++ b/apps/forum/templates/services/app/dc.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/forum/templates/services/app/macros/mongodb_uri.yml.j2" import mongodb_uri with context -%}
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
@@ -65,7 +66,9 @@ spec:
           env:
             - name: SEARCH_SERVER
               value: "http://forum-elasticsearch-{{ deployment_stamp }}:{{ forum_elasticsearch_port }}"
+            - name: MONGOHQ_URL
+              value: "{{ mongodb_uri(env_type, trashable_env_types, forum_mongodb_host, deployment_stamp, endpoint_mongodb_ips, forum_mongodb_replicaset, forum_mongodb_port, forum_mongodb_read_preference) }}"
           command:
             - "/bin/bash"
             - "-c"
-            - MONGOHQ_URL=mongodb://${MONGODB_USER}:${MONGODB_PASSWORD_URLENCODED}@forum-mongo-{{ deployment_stamp }}:{{ forum_mongodb_port }}/${MONGODB_DATABASE} bundle exec puma
+            - bundle exec puma

--- a/apps/forum/templates/services/app/job_01_init_index.yml.j2
+++ b/apps/forum/templates/services/app/job_01_init_index.yml.j2
@@ -1,3 +1,4 @@
+{%- from "apps/forum/templates/services/app/macros/mongodb_uri.yml.j2" import mongodb_uri with context -%}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -29,8 +30,10 @@ spec:
           env:
             - name: SEARCH_SERVER
               value: "http://forum-elasticsearch-{{ deployment_stamp }}:{{ forum_elasticsearch_port }}"
+            - name: MONGOHQ_URL
+              value: "{{ mongodb_uri(env_type, trashable_env_types, forum_mongodb_host, deployment_stamp, endpoint_mongodb_ips, forum_mongodb_replicaset, forum_mongodb_port, forum_mongodb_read_preference) }}"
           command:
             - "/bin/bash"
             - "-c"
-            - MONGOHQ_URL=mongodb://${MONGODB_USER}:${MONGODB_PASSWORD_URLENCODED}@forum-mongo-{{ deployment_stamp }}:{{ forum_mongodb_port }}/${MONGODB_DATABASE} bin/rake search:initialize
+            - bin/rake search:initialize
       restartPolicy: Never

--- a/apps/forum/templates/services/app/macros/mongodb_uri.yml.j2
+++ b/apps/forum/templates/services/app/macros/mongodb_uri.yml.j2
@@ -1,0 +1,28 @@
+{# compute the mongodb URI #}
+{%- macro mongodb_uri(env_type, trashable_env_types, forum_mongodb_host, deployment_stamp, endpoint_mongodb_ips, forum_mongodb_replicaset, forum_mongodb_port, forum_mongodb_read_preference) -%}
+    {%- if env_type in trashable_env_types -%}
+        mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD_URLENCODED)@{{ forum_mongodb_host }}-{{ deployment_stamp }}:{{ forum_mongodb_port }}/$(MONGODB_DATABASE)
+    {%- else -%}
+        {%- set mondogdb_service_name = "%s-%s" | format(forum_mongodb_host, deployment_stamp) -%}
+        {%- set ns = namespace(services="") -%}
+        {%- for ip in endpoint_mongodb_ips -%}
+            {%- set ns.services = "%s%s:%s" | format(ns.services, mondogdb_service_name, forum_mongodb_port | int + loop.index0) -%}
+            {%- if loop.index < endpoint_mongodb_ips | length -%}
+                {%- set ns.services = "%s," | format(ns.services) -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set uri = "mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD_URLENCODED)@%s/$(MONGODB_DATABASE)" | format(ns.services) -%}
+        {%- set isReplicasetDefined = forum_mongodb_replicaset is defined and forum_mongodb_replicaset | length > 1 -%}
+
+        {%- if isReplicasetDefined -%}
+            {%- set uri = "%s?replicaSet=%s" | format(uri, forum_mongodb_replicaset) -%}
+        {%- endif -%}
+
+        {% if isReplicasetDefined and forum_mongodb_read_preference is defined and forum_mongodb_read_preference | length > 1 %}
+            {%- set uri = "%s&readPreference=%s" | format(uri, forum_mongodb_read_preference) -%}
+        {% endif %}
+
+        {{uri}}
+    {%- endif -%}
+{%- endmacro %}

--- a/apps/forum/templates/services/mongodb/dc.yml.j2
+++ b/apps/forum/templates/services/mongodb/dc.yml.j2
@@ -7,7 +7,7 @@ metadata:
     service: mongodb
     version: "{{ forum_mongodb_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
-  name: "forum-mongodb-{{ deployment_stamp }}"
+  name: "{{ forum_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   replicas: 1
@@ -17,7 +17,7 @@ spec:
         app: forum
         service: mongodb
         version: "{{ forum_mongodb_image_tag }}"
-        deploymentconfig: "forum-mongodb-{{ deployment_stamp }}"
+        deploymentconfig: "{{ forum_mongodb_host }}-{{ deployment_stamp }}"
         deployment_stamp: "{{ deployment_stamp }}"
     spec:
       containers:

--- a/apps/forum/templates/services/mongodb/ep.yml.j2
+++ b/apps/forum/templates/services/mongodb/ep.yml.j2
@@ -1,4 +1,4 @@
-{% if endpoint_mongodb_ip | ipaddr != false %}
+{% if endpoint_mongodb_ips | length > 1 %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -7,12 +7,17 @@ metadata:
     endpoint: mongodb
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the endpoint should be the same as the corresponding service
-  name: "forum-mongo-{{ deployment_stamp }}"
+  name: "{{ forum_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 subsets:
-  - addresses:
-    - ip: "{{ endpoint_mongodb_ip }}"
+{% for ip in endpoint_mongodb_ips -%}
+  - 
+    addresses:
+      - 
+        ip: "{{ ip }}"
     ports:
-    - port: "{{ forum_mongodb_port }}"
-      name: "{{ forum_mongodb_port}}-tcp"
+      - 
+        port: "{{ forum_mongodb_port }}"
+        name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
+{% endfor -%}
 {% endif %}

--- a/apps/forum/templates/services/mongodb/svc.yml.j2
+++ b/apps/forum/templates/services/mongodb/svc.yml.j2
@@ -7,21 +7,30 @@ metadata:
     version: "{{ forum_mongodb_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the service should be mongodb host name in settings
-  name: "forum-mongo-{{ deployment_stamp }}"
+  name: "{{ forum_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   ports:
+{% if env_type in trashable_env_types %}
   - name: "{{ forum_mongodb_port }}-tcp"
     port: {{ forum_mongodb_port }}
     protocol: TCP
     targetPort: {{ forum_mongodb_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
+# not trashable. In this case, we use a mongodb cluster outside of
 # OpenShift.
-{% if env_type in trashable_env_types %}
   selector:
     app: forum
-    deploymentconfig: "forum-mongodb-{{ deployment_stamp }}"
+    deploymentconfig: "{{ forum_mongodb_host }}-{{ deployment_stamp }}"
   type: ClusterIP
-{% endif%}
+{% else %}
+{% for ip in endpoint_mongodb_ips %}
+  - 
+    name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
+    port: {{ forum_mongodb_port | int + loop.index0 }} 
+    protocol: TCP
+    targetPort: {{ forum_mongodb_port }}
+{% endfor %}
+{% endif %}
+

--- a/apps/forum/vars/all/main.yml
+++ b/apps/forum/vars/all/main.yml
@@ -21,4 +21,7 @@ forum_mongodb_version: "3.2"
 forum_mongodb_image_name: "centos/mongodb-32-centos7"
 forum_mongodb_image_tag: "3.2"
 forum_mongodb_port: 27017
+forum_mongodb_host: "forum-mongodb"
+forum_mongodb_replicaset: ""
+forum_mongodb_read_preference: ""
 forum_mongodb_secret_name: "forum-mongo-{{ forum_vault_checksum | default('undefined_forum_vault_checksum') }}"

--- a/apps/learninglocker/templates/services/app/_dc_base.yml.j2
+++ b/apps/learninglocker/templates/services/app/_dc_base.yml.j2
@@ -1,5 +1,7 @@
 {%- set dc_name = "learninglocker-%s" | format(service_variant) -%}
 
+{%- from "apps/learninglocker/templates/services/app/macros/mongodb_uri.yml.j2" import mongodb_uri with context -%}
+
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
@@ -38,7 +40,7 @@ spec:
                 name: "learninglocker-app-dotenv-{{ deployment_stamp }}"
           env:
             - name: MONGODB_PATH
-              value: "mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD)@{{ learninglocker_mongodb_host }}-{{ deployment_stamp }}:{{ learninglocker_mongodb_port }}/$(MONGODB_DATABASE)"
+              value: "{{ mongodb_uri(env_type, trashable_env_types, learninglocker_mongodb_host, deployment_stamp, endpoint_mongodb_ips, learninglocker_mongodb_replicaset, learninglocker_mongodb_read_preference) }}"
           volumeMounts:
             - name: learninglocker-v-storage
               mountPath: /app/storage

--- a/apps/learninglocker/templates/services/app/job_db_migrate.yml.j2
+++ b/apps/learninglocker/templates/services/app/job_db_migrate.yml.j2
@@ -1,3 +1,5 @@
+{%- from "apps/learninglocker/templates/services/app/macros/mongodb_uri.yml.j2" import mongodb_uri with context -%}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -31,7 +33,7 @@ spec:
               name: "learninglocker-app-dotenv-{{ deployment_stamp }}"
         env:
           - name: MONGODB_PATH
-            value: "mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD)@{{ learninglocker_mongodb_host }}-{{ deployment_stamp }}:{{ learninglocker_mongodb_port }}/$(MONGODB_DATABASE)"
+            value: "{{ mongodb_uri(env_type, trashable_env_types, learninglocker_mongodb_host, deployment_stamp, endpoint_mongodb_ips, learninglocker_mongodb_replicaset, learninglocker_mongodb_read_preference) }}"
         volumeMounts:
           - name: learninglocker-v-storage
             mountPath: /app/storage

--- a/apps/learninglocker/templates/services/app/macros/mongodb_uri.yml.j2
+++ b/apps/learninglocker/templates/services/app/macros/mongodb_uri.yml.j2
@@ -1,0 +1,28 @@
+{# compute the mongodb URI #}
+{%- macro mongodb_uri(env_type, trashable_env_types, learninglocker_mongodb_host, deployment_stamp, endpoint_mongodb_ips, learninglocker_mongodb_replicaset, learninglocker_mongodb_read_preference) -%}
+    {%- if env_type in trashable_env_types -%}
+        mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD)@{{ learninglocker_mongodb_host }}-{{ deployment_stamp }}/$(MONGODB_DATABASE)
+    {%- else -%}
+        {%- set mondogdb_service_name = "learninglocker-mongodb-%s" | format(deployment_stamp) -%}
+        {%- set ns = namespace(services="") -%}
+        {%- for ip in endpoint_mongodb_ips -%}
+            {%- set ns.services = "%s%s:%s" | format(ns.services, mondogdb_service_name, learninglocker_mongodb_port | int + loop.index0) -%}
+            {%- if loop.index < endpoint_mongodb_ips | length -%}
+                {%- set ns.services = "%s," | format(ns.services) -%}
+            {%- endif -%}
+        {%- endfor -%}
+
+        {%- set uri = "mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD)@%s/$(MONGODB_DATABASE)" | format(ns.services) -%}
+        {%- set isReplicasetDefined = learninglocker_mongodb_replicaset is defined and learninglocker_mongodb_replicaset | length > 1 -%}
+
+        {%- if isReplicasetDefined -%}
+            {%- set uri = "%s?replicaSet=%s" | format(uri, learninglocker_mongodb_replicaset) -%}
+        {%- endif -%}
+
+        {% if isReplicasetDefined and learninglocker_mongodb_read_preference is defined and learninglocker_mongodb_read_preference | length > 1 %}
+            {%- set uri = "%s&readPreference=%s" | format(uri, learninglocker_mongodb_read_preference) -%}
+        {% endif %}
+
+        {{uri}}
+    {%- endif -%}
+{%- endmacro %}

--- a/apps/learninglocker/templates/services/mongodb/ep.yml.j2
+++ b/apps/learninglocker/templates/services/mongodb/ep.yml.j2
@@ -1,4 +1,4 @@
-{% if endpoint_mongodb_ip | ipaddr != false %}
+{% if endpoint_mongodb_ips | length > 1 %}
 apiVersion: v1
 kind: Endpoints
 metadata:
@@ -10,9 +10,14 @@ metadata:
   name: "learninglocker-mongodb-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 subsets:
-  - addresses:
-    - ip: "{{ endpoint_mongodb_ip }}"
+{% for ip in endpoint_mongodb_ips -%}
+  - 
+    addresses:
+      - 
+        ip: "{{ ip }}"
     ports:
-    - port: "{{ learninglocker_mongodb_port }}"
-      name: "{{ learninglocker_mongodb_port}}-tcp"
+      - 
+        port: "{{ learninglocker_mongodb_port }}"
+        name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
+{% endfor -%}
 {% endif %}

--- a/apps/learninglocker/templates/services/mongodb/svc.yml.j2
+++ b/apps/learninglocker/templates/services/mongodb/svc.yml.j2
@@ -7,10 +7,11 @@ metadata:
     version: "{{ learninglocker_mongodb_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the service should be mongodb host name in settings
-  name: "learninglocker-mongodb-{{ deployment_stamp }}"
+  name: "{{ learninglocker_mongodb_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   ports:
+{% if env_type in trashable_env_types %}
   - name: "{{ learninglocker_mongodb_port }}-tcp"
     port: {{ learninglocker_mongodb_port }}
     protocol: TCP
@@ -19,9 +20,16 @@ spec:
 # so that it does not rely on a deployment configuration when the "env_type" is
 # not trashable. In this case, we use a mongodb cluster outside of
 # OpenShift.
-{% if env_type in trashable_env_types %}
   selector:
     app: learninglocker
     deploymentconfig: "learninglocker-mongodb-{{ deployment_stamp }}"
   type: ClusterIP
-{% endif%}
+{% else %}
+{% for ip in endpoint_mongodb_ips %}
+  - 
+    name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
+    port: {{ learninglocker_mongodb_port | int + loop.index0 }} 
+    protocol: TCP
+    targetPort: {{ learninglocker_mongodb_port }}
+{% endfor %}
+{% endif %}

--- a/apps/learninglocker/templates/services/xapi/dc.yml.j2
+++ b/apps/learninglocker/templates/services/xapi/dc.yml.j2
@@ -1,3 +1,5 @@
+{%- from "apps/learninglocker/templates/services/app/macros/mongodb_uri.yml.j2" import mongodb_uri with context -%}
+
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
@@ -31,7 +33,7 @@ spec:
                 name: "learninglocker-xapi-dotenv-{{ deployment_stamp }}"
           env:
             - name: MONGO_URL
-              value: "mongodb://$(MONGODB_USER):$(MONGODB_PASSWORD)@{{ learninglocker_mongodb_host }}-{{ deployment_stamp }}:{{ learninglocker_mongodb_port }}/$(MONGODB_DATABASE)"
+              value: "{{ mongodb_uri(env_type, trashable_env_types, learninglocker_mongodb_host, deployment_stamp, endpoint_mongodb_ips, learninglocker_mongodb_replicaset, learninglocker_mongodb_read_preference) }}"
           volumeMounts:
             - name: learninglocker-xapi-storage
               mountPath: /app/storage

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -27,6 +27,8 @@ learninglocker_mongodb_image_name: "centos/mongodb-32-centos7"
 learninglocker_mongodb_image_tag: "3.2"
 learninglocker_mongodb_port: 27017
 learninglocker_mongodb_host: "learninglocker-mongodb"
+learninglocker_mongodb_replicaset: ""
+learninglocker_mongodb_read_preference: ""
 learninglocker_mongodb_secret_name: "learninglocker-mongodb-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 
 # -- nginx

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -105,7 +105,8 @@ force_route: false
 # In trashable environments these endpoints will not be used because everything will
 # run inside OpenShift pods. in Production and Pre-production environments you should consider using a dedicated cluster
 # for your databases.
-# Endpoint IPs are initialized at "null" by default and you SHOULD overwrite them in the corresponding environment where you will use them.
-endpoint_mongodb_ip:     null
+# Endpoint IPs are initialized at "null" (except for mongodb we initalize it with an empty list) by default 
+# and you SHOULD overwrite them in the corresponding environment where you will use them.
+endpoint_mongodb_ips:     []
 endpoint_mysql_ip:       null
 endpoint_postgresql_ip:  null


### PR DESCRIPTION
## Purpose

We want to configure all the applications to use a MongoDB replicaset and also configure the read_preference setting. To do that all the applications should be configured with a list of MongoDB IPs and also use a setting to configure the replicaSet and the read_preference.


## Proposal

- [x] transform MongoDB ip in a list of IPs
- [x] configure learninglocker to use MongoDB replicaset
- [x] configure forum to use MongoDB replicaset
- [x] configure edxapp to use MongoDB replicaset

/!\ This PR is a BC break

