### PR TITLE
♻️(registry) use local lookupPolicy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Configure MongoDB to use replicaSet and read_preference settings for all
   applications working with MongoDB
 
+### Changed
+
+- Use local lookupPolicy to fetch image from internal registry first
+
 ## [3.3.1] - 2019-11-25
 
 ### Fixed

--- a/apps/edxapp/templates/services/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_dc_base.yml.j2
@@ -85,7 +85,7 @@ spec:
           value: {{ service_variant }}.envs.fun.docker_run
         # We point to a local registry image build for this "live" image (see
         # ImageStream and BuildConfig templates)
-        image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name(service_variant, edxapp_image_tag, edxapp_theme_tag) }}"
+        image: "{{ image_name(service_variant, edxapp_image_tag, edxapp_theme_tag) }}"
         imagePullPolicy: Always
 {% if celery_worker is defined %}
         livenessProbe:

--- a/apps/edxapp/templates/services/cms/is.yml.j2
+++ b/apps/edxapp/templates/services/cms/is.yml.j2
@@ -6,3 +6,6 @@ metadata:
   labels:
     app: "edxapp"
     service: "cms"
+spec:
+  lookupPolicy:
+    local: true

--- a/apps/edxapp/templates/services/cms/job_01_internationalization.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_01_internationalization.yml.j2
@@ -28,7 +28,7 @@ spec:
         - name: edxapp-cms-internationalization-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          image: "{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_02_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_02_collectstatic.yml.j2
@@ -27,7 +27,7 @@ spec:
         - name: edxapp-cms-collectstatic-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          image: "{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_05_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_05_db_migrate.yml.j2
@@ -25,7 +25,7 @@ spec:
         - name: edxapp-cms-dbmigrate-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          image: "{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_06_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_06_load_fixtures.yml.j2
@@ -26,7 +26,7 @@ spec:
         - name: edxapp-cms-load-fixtures-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          image: "{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/lms/is.yml.j2
+++ b/apps/edxapp/templates/services/lms/is.yml.j2
@@ -6,3 +6,6 @@ metadata:
   labels:
     app: "edxapp"
     service: "lms"
+spec:
+  lookupPolicy:
+    local: true

--- a/apps/edxapp/templates/services/lms/job_03_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_03_collectstatic.yml.j2
@@ -27,7 +27,7 @@ spec:
         - name: edxapp-lms-collectstatic-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
+          image: "{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/lms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_04_db_migrate.yml.j2
@@ -25,7 +25,7 @@ spec:
         - name: edxapp-lms-dbmigrate-{{ job_stamp }}
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
+          image: "{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run

--- a/apps/forum/templates/services/app/dc.yml.j2
+++ b/apps/forum/templates/services/app/dc.yml.j2
@@ -37,7 +37,7 @@ spec:
         - name: forum
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
-          image: "{{ internal_docker_registry }}/{{ project_name }}/forum:{{ forum_image_tag }}-live"
+          image: "forum:{{ forum_image_tag }}-live"
           imagePullPolicy: Always
           livenessProbe:
             httpGet:

--- a/apps/forum/templates/services/app/is.yml.j2
+++ b/apps/forum/templates/services/app/is.yml.j2
@@ -6,3 +6,6 @@ metadata:
   labels:
     app: "forum"
     service: "forum"
+spec:
+  lookupPolicy:
+    local: true

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -67,9 +67,6 @@ deployment_stamp: null
 # never be used as is, but initiated in a playbook using a "set_fact" task.
 job_stamp: null
 
-# OpenShift's internal docker registry server
-internal_docker_registry: "docker-registry.default.svc:5000"
-
 # ACME (Automated Certificate Management Environment) We use the letsencrypt
 # staging environment except in (pre)production (see:
 # https://letsencrypt.org/docs/staging-environment)

--- a/group_vars/env_type/ci.yml
+++ b/group_vars/env_type/ci.yml
@@ -2,12 +2,6 @@
 project_description: "A minimal project to test apps bootstrapping ({{ env_type }})"
 domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 
-# OpenShift's internal docker registry server
-#
-# FIXME: use docker registry server IP address instead of the service name (i.e.
-# docker-registry.default.svc) to prevent oc cluster DNS issues
-internal_docker_registry: "172.30.1.1:5000"
-
 apps:
   - name: mailcatcher
   - name: marsha

--- a/group_vars/env_type/development.yml
+++ b/group_vars/env_type/development.yml
@@ -1,12 +1,6 @@
 # Variables specific to development environments
 domain_name: "{{ lookup('env', 'OPENSHIFT_DOMAIN') }}.nip.io"
 
-# OpenShift's internal docker registry server
-#
-# FIXME: use docker registry server IP address instead of the service name (i.e.
-# docker-registry.default.svc) to prevent oc cluster DNS issues
-internal_docker_registry: "172.30.1.1:5000"
-
 apps:
   - name: mailcatcher
   - name: marsha


### PR DESCRIPTION
## Purpose

ImageStream can use first the local registry and then fetch on
docker hub if the image is not present. To do that the local
lookupPolicy must be set to true and there is no need anymore to refer
to the internal docker registry in the image name used in every
DeploymentConfig or jobs.

## Proposal

- [x] configure ImageStream with local lookupPolicy set to true
