### PR TITLE
✨(app) create a redis-sentinel application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- Create a new app redis-sentinel. This app uses the redis-operator 
+  (https://github.com/spotahome/redis-operator) and it must be installed
+  on your OpenShift cluster before deploying.
+
 ## [4.0.0] - 2019-11-26
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   (https://github.com/spotahome/redis-operator) and it must be installed
   on your OpenShift cluster before deploying.
 
+### Removed
+
+- Probes on edxapp workers. Existing probes are not compatible with redis sentinel.
+  To use them with redis sentinel, we must use a Django management command or Celery
+  using Django settings, but doing so is too slow to be considered as a relevant alternative.
+  This removal is temporary, a new solution will be developped soon.
+
 ## [4.0.0] - 2019-11-26
 
 ### Added

--- a/apps/edxapp/templates/services/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_dc_base.yml.j2
@@ -87,24 +87,7 @@ spec:
         # ImageStream and BuildConfig templates)
         image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name(service_variant, edxapp_image_tag, edxapp_theme_tag) }}"
         imagePullPolicy: Always
-{% if celery_worker is defined %}
-        livenessProbe:
-          exec:
-            command:
-              - "/bin/bash"
-              - "-c"
-              - "celery -b redis://redis:{{ redis_app_port }} inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
-          initialDelaySeconds: 120
-          periodSeconds: 600
-        readinessProbe:
-          exec:
-            command:
-              - "/bin/bash"
-              - "-c"
-              - "celery -b redis://redis:{{ redis_app_port }} inspect ping -d celery@{{ celery_worker.name }}.%$(hostname)"
-          initialDelaySeconds: 60
-          periodSeconds: 15
-{% else %}
+{% if celery_worker is not defined %}
         # Pod probes that only apply for wsgi services
         livenessProbe:
           httpGet:

--- a/apps/redis-sentinel/templates/services/app/svc.yml.j2
+++ b/apps/redis-sentinel/templates/services/app/svc.yml.j2
@@ -1,0 +1,56 @@
+{# 
+  Disclaimer: This template is not relative to an OpenShift Service object but to a RedisFailover object.
+  RedisFailover is part of the redis-operator (https://github.com/spotahome/redis-operator) and must be
+  deploy at the same time of other OpenShift Service, this is why we decided to created in this file.
+#}
+apiVersion: databases.spotahome.com/v1
+kind: RedisFailover
+metadata:
+  labels:
+    app: redis-sentinel
+    service: app
+    version: RedisFailover
+  # Nota bene: the name of the service should be the host name in edxapp configuration,
+  # prefixed by "rfs-", e.g. "rfs-redis-sentinel"
+  name: redis-sentinel
+  namespace: "{{ project_name }}"
+spec:
+  sentinel:
+    replicas: {{ redis_sentinel_sentinel_replicas }}
+{% if redis_sentinel_sentinel_custom_config | length > 0 %}
+    customConfig:
+{% for config in redis_sentinel_sentinel_custom_config %}
+      - "{{ config }}"
+{% endfor %}
+{% endif %}
+    securityContext:
+      runAsUser: {{ redis_sentinel_user_id }}
+      runAsGroup: {{ redis_sentinel_group_id }}
+      fsGroup: {{ redis_sentinel_fsgroup_id }}
+  redis:
+    replicas: {{ redis_sentinel_redis_replicas }}
+{% if redis_sentinel_redis_custom_config | length > 0 %}
+    customConfig:
+{% for config in redis_sentinel_redis_custom_config %}
+      - "{{ config }}"
+{% endfor %}
+{% endif %}
+    storage:
+      keepAfterDeletion: true
+      persistentVolumeClaim:
+        metadata:
+          name: redis-sentinel-pvc-data
+          namespace: "{{ project_name }}"
+          labels:
+            app: redis-sentinel
+            version: RedisFailover
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: {{ redis_sentinel_redis_data_volume_size }}
+    securityContext:
+      runAsUser: {{ redis_sentinel_user_id }}
+      runAsGroup: {{ redis_sentinel_group_id }}
+      fsGroup: {{ redis_sentinel_fsgroup_id }}

--- a/apps/redis-sentinel/tray.yml
+++ b/apps/redis-sentinel/tray.yml
@@ -1,0 +1,3 @@
+metadata:
+  name: redis-sentinel
+  version: redis-operator

--- a/apps/redis-sentinel/vars/all/main.yml
+++ b/apps/redis-sentinel/vars/all/main.yml
@@ -1,0 +1,26 @@
+# The following settings can be found in the project's annotation.
+# To retrieve them run the following command:
+#   $ oc project {{ project_name }} -o yaml
+# then copy values of the `openshift.io/sa.scc.supplemental-groups` annotation
+redis_sentinel_user_id: null
+redis_sentinel_group_id: null
+redis_sentinel_fsgroup_id: null
+
+## Sentinel configuration
+# Number of sentinel replicas 
+redis_sentinel_sentinel_replicas: 3
+# If you need custom sentinel configuration you should add
+# them in this list with one configuration per item, e.g.:
+#   - "sentinel down-after-milliseconds mymaster 2000"
+#   - "down-after-milliseconds 2000"
+redis_sentinel_sentinel_custom_config: []
+
+## Redis configuration
+# Number of redis replicas
+redis_sentinel_redis_replicas: 3
+redis_sentinel_redis_data_volume_size: 2Gi
+# If you need custom redis configuration you should add
+# them in this list. One configuration is a new entry
+# eg:
+#   - "stop-writes-on-bgsave-error no"
+redis_sentinel_redis_custom_config: []

--- a/apps/redis-sentinel/vars/settings.yml
+++ b/apps/redis-sentinel/vars/settings.yml
@@ -1,0 +1,1 @@
+is_blue_green_compatible: false


### PR DESCRIPTION
## Purpose

we choose to use the redis-operator
(https://github.com/spotahome/redis-operator) to deploy a redis
configured with sentinel. Only one OpenShift object is used and deployed as a
Service.


## Proposal

- [x] implement the redis-sentinel app
