### PR TITLE
🐛(redis-sentinel) fix command to fetch project's annotation

### DIFF
--- a/apps/redis-sentinel/vars/all/main.yml
+++ b/apps/redis-sentinel/vars/all/main.yml
@@ -1,6 +1,6 @@
 # The following settings can be found in the project's annotation.
 # To retrieve them run the following command:
-#   $ oc project {{ project_name }} -o yaml
+#   $ oc get project $(oc project -q) -o yaml
 # then copy values of the `openshift.io/sa.scc.supplemental-groups` annotation
 redis_sentinel_user_id: null
 redis_sentinel_group_id: null


### PR DESCRIPTION
## Purpose

To configure redis-sentinel application, we need to fetch project's
annotation. The command to do that written in vars/all/main.yml file was
wrong and can be improve to fetch the current project.

## Proposal

- [x] fix oc command in vars/all/main.yml file.
