### PR TITLE
🐛(learninglocker) Inject XAPI secret as environment variable in XAPI DC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Inject XAPI secret as environment variable in XAPI DeploymentConfig
+
 ## [4.1.0] - 2019-12-06
 
 ### Added

--- a/apps/learninglocker/templates/services/xapi/dc.yml.j2
+++ b/apps/learninglocker/templates/services/xapi/dc.yml.j2
@@ -29,6 +29,8 @@ spec:
             - containerPort: "{{ learninglocker_xapi_port }}"
               protocol: TCP
           envFrom:
+            - secretRef:
+                name: "{{ learninglocker_xapi_secret_name }}"
             - configMapRef:
                 name: "learninglocker-xapi-dotenv-{{ deployment_stamp }}"
           env:


### PR DESCRIPTION
## Purpose

A secret is created for the XAPI service but unused by the XAPI DC.
Without it, it is not possible to connect to MongoDB because the
credentials are in this secret and must be injected as environment
variable.


## Proposal

- [x] inject XAPI secret as environment variable in XAPI DC.
