### PR TITLE
✨(redis-sentinel) apply podAntiAffinity rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Apply PodAntiAffinity rules to redis-sentinel app
+
 ## [4.1.2] - 2019-12-10
 
 ## Fixed

--- a/apps/redis-sentinel/templates/services/app/svc.yml.j2
+++ b/apps/redis-sentinel/templates/services/app/svc.yml.j2
@@ -17,6 +17,18 @@ metadata:
 spec:
   sentinel:
     replicas: {{ redis_sentinel_sentinel_replicas }}
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - sentinel
+              topologyKey: kubernetes.io/hostname
 {% if redis_sentinel_sentinel_custom_config | length > 0 %}
     customConfig:
 {% for config in redis_sentinel_sentinel_custom_config %}
@@ -29,6 +41,18 @@ spec:
       fsGroup: {{ redis_sentinel_fsgroup_id }}
   redis:
     replicas: {{ redis_sentinel_redis_replicas }}
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/component
+                    operator: In
+                    values:
+                      - redis
+              topologyKey: kubernetes.io/hostname
 {% if redis_sentinel_redis_custom_config | length > 0 %}
     customConfig:
 {% for config in redis_sentinel_redis_custom_config %}


### PR DESCRIPTION
## Purpose

We don't want have two instances of the same component on the same
node. For this we can use a podAntiAffinity rule to exclude pod having
the same component value on the same node.

## Proposal

- [x] Apply PodAntiAffinity rules to redis-sentinel app