### PR TITLE
Fix forum ES hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [4.2.0] - 2019-12-10
+
 ### Changed
 
 - Apply PodAntiAffinity rules to redis-sentinel app
@@ -516,7 +518,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Official Docker image is available at:
   https://hub.docker.com/r/fundocker/arnold/
 
-[unreleased]: https://github.com/openfun/arnold/compare/v4.1.2...master
+[unreleased]: https://github.com/openfun/arnold/compare/v4.2.0...master
+[4.2.0]: https://github.com/openfun/arnold/compare/v4.1.2...v4.2.0
 [4.1.2]: https://github.com/openfun/arnold/compare/v4.1.1...v4.1.2
 [4.1.1]: https://github.com/openfun/arnold/compare/v4.1.0...v4.1.1
 [4.1.0]: https://github.com/openfun/arnold/compare/v4.0.0...v4.1.0
@@ -562,5 +565,4 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 [1.0.0-alpha.4]: https://github.com/openfun/arnold/compare/v1.0.0-alpha.3...v1.0.0-alpha.4
 [1.0.0-alpha.3]: https://github.com/openfun/arnold/compare/v1.0.0-alpha.2...v1.0.0-alpha.3
 [1.0.0-alpha.2]: https://github.com/openfun/arnold/compare/v1.0.0-alpha.1...v1.0.0-alpha.2
-[1.0.0-alpha.1]: https://github.com/openfun/arnold/compare/f9238a2...v1.0.0-alpha.1
 [1.0.0-alpha.1]: https://github.com/openfun/arnold/compare/f9238a2...v1.0.0-alpha.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,14 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Apply PodAntiAffinity rules to redis-sentinel app
 
+### Fixed
+
+- Use the `forum_elasticsearch_host` variable in the forum application to make
+  it overridable
+
 ## [4.1.2] - 2019-12-10
 
-## Fixed
+### Fixed
 
 - Checking the number of running pods was hanging when redeploying an already
   running `redis-sentinel` app.
@@ -29,7 +34,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Create a new app redis-sentinel. This app uses the redis-operator 
+- Create a new app redis-sentinel. This app uses the redis-operator
   (https://github.com/spotahome/redis-operator) and it must be installed
   on your OpenShift cluster before deploying.
 
@@ -557,4 +562,5 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 [1.0.0-alpha.4]: https://github.com/openfun/arnold/compare/v1.0.0-alpha.3...v1.0.0-alpha.4
 [1.0.0-alpha.3]: https://github.com/openfun/arnold/compare/v1.0.0-alpha.2...v1.0.0-alpha.3
 [1.0.0-alpha.2]: https://github.com/openfun/arnold/compare/v1.0.0-alpha.1...v1.0.0-alpha.2
+[1.0.0-alpha.1]: https://github.com/openfun/arnold/compare/f9238a2...v1.0.0-alpha.1
 [1.0.0-alpha.1]: https://github.com/openfun/arnold/compare/f9238a2...v1.0.0-alpha.1

--- a/apps/forum/templates/services/elasticsearch/dc.yml.j2
+++ b/apps/forum/templates/services/elasticsearch/dc.yml.j2
@@ -6,7 +6,7 @@ metadata:
     service: elasticsearch
     version: "{{ forum_elasticsearch_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
-  name: "forum-elasticsearch-{{ deployment_stamp }}"
+  name: "{{ forum_elasticsearch_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   replicas: 1

--- a/apps/forum/templates/services/elasticsearch/svc.yml.j2
+++ b/apps/forum/templates/services/elasticsearch/svc.yml.j2
@@ -7,7 +7,7 @@ metadata:
     version: "{{ forum_elasticsearch_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
   # name of the service should be database host name in settings
-  name: "forum-elasticsearch-{{ deployment_stamp }}"
+  name: "{{ forum_elasticsearch_host }}-{{ deployment_stamp }}"
   namespace: "{{ project_name }}"
 spec:
   ports:

--- a/apps/forum/vars/all/main.yml
+++ b/apps/forum/vars/all/main.yml
@@ -13,7 +13,7 @@ forum_secret_name: "forum-{{ forum_vault_checksum | default('undefined_forum_vau
 # -- elasticsearch
 forum_elasticsearch_image_name: "fundocker/openshift-elasticsearch"
 forum_elasticsearch_image_tag: "1.5.2"
-forum_elasticsearch_host: "elasticsearch"
+forum_elasticsearch_host: "forum-elasticsearch"
 forum_elasticsearch_port: 9200
 
 # -- mongo


### PR DESCRIPTION
## Purpose

For some projects, we may need to override the `forum_elasticsearch_host` variable value. I discovered that this variable wasn't used at all in our templates.

## Proposal

- [x] use the `forum_elasticsearch_host` variable in forum/elasticsearch DC and SVC
- [x] bump release to `4.2.0`
