### PR TITLE
🚸(apps) run the db_migrate job before starting application pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Run `db_migrate` jobs before starting new pods in a deployment
+
 ## [4.3.0] - 2019-12-13
 
 ### Added

--- a/apps/edxapp/templates/services/cms/job_05_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_05_db_migrate.yml.j2
@@ -6,10 +6,12 @@ metadata:
   namespace: "{{ project_name }}"
   labels:
     app: edxapp
+    deployment_stamp: "{{ deployment_stamp }}"
+    job_stamp: "{{ job_stamp }}"
+    # Jobs with the "pre" job type will be executed prior to deployments
+    job_type: "pre"
     service: cms
     version: "{{ edxapp_image_tag }}"
-    job_stamp: "{{ job_stamp }}"
-    deployment_stamp: "{{ deployment_stamp }}"
 spec:
   template:
     metadata:

--- a/apps/edxapp/templates/services/lms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_04_db_migrate.yml.j2
@@ -6,10 +6,12 @@ metadata:
   namespace: "{{ project_name }}"
   labels:
     app: edxapp
+    deployment_stamp: "{{ deployment_stamp }}"
+    job_stamp: "{{ job_stamp }}"
+    # Jobs with the "pre" job type will be executed prior to deployments
+    job_type: "pre"
     service: lms
     version: "{{ edxapp_image_tag }}"
-    job_stamp: "{{ job_stamp }}"
-    deployment_stamp: "{{ deployment_stamp }}"
 spec:
   template:
     metadata:

--- a/apps/learninglocker/templates/services/app/job_db_migrate.yml.j2
+++ b/apps/learninglocker/templates/services/app/job_db_migrate.yml.j2
@@ -7,10 +7,12 @@ metadata:
   namespace: "{{ project_name }}"
   labels:
     app: learninglocker
+    deployment_stamp: "{{ deployment_stamp }}"
+    job_stamp: "{{ job_stamp }}"
+    # Jobs with the "pre" job type will be executed prior to deployments
+    job_type: "pre"
     service: learninglocker
     version: "{{ learninglocker_image_tag }}"
-    job_stamp: "{{ job_stamp }}"
-    deployment_stamp: "{{ deployment_stamp }}"
 spec:
   template:
     metadata:

--- a/apps/marsha/templates/services/app/job_db_migrate.yml.j2
+++ b/apps/marsha/templates/services/app/job_db_migrate.yml.j2
@@ -5,10 +5,12 @@ metadata:
   namespace: "{{ project_name }}"
   labels:
     app: marsha
-    service: marsha
-    version: "{{ marsha_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
     job_stamp: "{{ job_stamp }}"
+    # Jobs with the "pre" job type will be executed prior to deployments
+    job_type: "pre"
+    service: marsha
+    version: "{{ marsha_image_tag }}"
 spec:
   template:
     metadata:

--- a/apps/richie/templates/services/app/job_02_db_migrate.yml.j2
+++ b/apps/richie/templates/services/app/job_02_db_migrate.yml.j2
@@ -5,10 +5,12 @@ metadata:
   namespace: "{{ project_name }}"
   labels:
     app: richie
-    service: richie
-    version: "{{ richie_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
     job_stamp: "{{ job_stamp }}"
+    # Jobs with the "pre" job type will be executed prior to deployments
+    job_type: "pre"
+    service: richie
+    version: "{{ richie_image_tag }}"
 spec:
   template:
     metadata:


### PR DESCRIPTION
## Purpose

If we run db_migrate after starting the new pod:

- the current pod has to be compatible with the state of the db before and after the migration.
- the new pod has to be compatible with the state of the database before and after a migration. This is not possible for a new database, and not easy for schema updates.

If we run db_migrate before starting a new pod, the new pod only has to be
compatible with the state of the database after the migration.


## Proposal

Tag all `db_migrate` jobs as `pre` jobs.