### PR TITLE
🗃(learninglocker) set mongodb 4.0 as the default database version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Upgrade the learninglocker image to v5.2.2 and the xapi-service image to v2.9.10
 - Set MongoDB 4.0 as the default database version for the learninglocker app
 
 ## [4.3.0] - 2019-12-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- Set MongoDB 4.0 as the default database version for the learninglocker app
+
 ## [4.3.0] - 2019-12-13
 
 ### Added

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -5,7 +5,7 @@ learninglocker_host: "learninglocker.{{ project_name}}.{{ domain_name }}"
 
 # -- learninglocker
 learninglocker_image_name: "fundocker/learninglocker"
-learninglocker_image_tag: "v2.6.2"
+learninglocker_image_tag: "v5.2.2"
 learninglocker_secret_name: "learninglocker-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 learninglocker_ui_port: 3000
 learninglocker_api_port: 8080
@@ -16,7 +16,7 @@ learninglocker_ui_replicas: 1
 
 # -- xapi
 learninglocker_xapi_image_name: "fundocker/xapi-service"
-learninglocker_xapi_image_tag: "v2.2.15"
+learninglocker_xapi_image_tag: "v2.9.10"
 learninglocker_xapi_port: 8081
 learninglocker_xapi_secret_name: "learninglocker-xapi-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 learninglocker_xapi_replicas: 1

--- a/apps/learninglocker/vars/settings.yml
+++ b/apps/learninglocker/vars/settings.yml
@@ -2,4 +2,4 @@ is_blue_green_compatible: True
 
 databases:
   - engine: "mongodb"
-    release: "3.2"
+    release: "4.0"


### PR DESCRIPTION
## Purpose

Latest versions of Learning Locker require MongoDB v4.0

## Proposal

- [x] Change default database version in the learninglocker app to v4.0
- [x] upgrade learninglocker to 5.2.2 and xapi-service to 2.9.10
