### PR TITLE
🐛(forum) fix API key random generator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Upgrade the learninglocker image to v5.2.2 and the xapi-service image to v2.9.10
 - Set MongoDB 4.0 as the default database version for the learninglocker app
 
+### Fixed
+
+- The forum API key generated a syntax error when its last character was a ":"
+
 ## [4.3.0] - 2019-12-13
 
 ### Added

--- a/apps/forum/vars/vault/main.yml.j2
+++ b/apps/forum/vars/vault/main.yml.j2
@@ -12,4 +12,5 @@ MONGODB_DATABASE: {{ mongodb_credentials.name }}
 # Forum
 # Nota bene: the forum API_KEY should match the following edxapp lms settings:
 # COMMENTS_SERVICE_KEY
-API_KEY: "{{ lookup('password','/dev/null length=48') }}"
+# Make sure your forum key does not end with a ":" or the ruby app will break with a syntax error
+API_KEY: "{{ lookup('password','/dev/null length=47') }}{{ lookup('password','/dev/null length=1 chars=ascii_letters') }}"


### PR DESCRIPTION
## Purpose

The forum API key was generating a syntax error when its last character was a ":". 

## Proposal

Forcing it to be a letter will make sure this never happens again.
