### PR TITLE
🐛 (edxapp) fix MONGODB_HOST in eugene/development configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Update eugene/development vault file for learninglocker
+- Fix MONGODB_HOST for eugene/development environment
 
 ## [4.3.1] - 2019-12-23
 

--- a/group_vars/customer/eugene/development/configs/edxapp/cms/settings.yml.j2
+++ b/group_vars/customer/eugene/development/configs/edxapp/cms/settings.yml.j2
@@ -30,7 +30,7 @@ DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"
 DATABASE_PORT: {{ edxapp_mysql_port }}
 
 # Mongo
-MONGODB_HOST: "edxapp-mongo-{{ deployment_stamp }}"
+MONGODB_HOST: "edxapp-mongodb-{{ deployment_stamp }}"
 MONGODB_PORT: {{ edxapp_mongodb_port }}
 
 # Email

--- a/group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
+++ b/group_vars/customer/eugene/development/configs/edxapp/lms/settings.yml.j2
@@ -37,7 +37,7 @@ DATABASE_HOST: "edxapp-mysql-{{ deployment_stamp }}"
 DATABASE_PORT: {{ edxapp_mysql_port }}
 
 # Mongo
-MONGODB_HOST: "edxapp-mongo-{{ deployment_stamp }}"
+MONGODB_HOST: "edxapp-mongodb-{{ deployment_stamp }}"
 MONGODB_PORT: {{ edxapp_mongodb_port }}
 
 # Email


### PR DESCRIPTION
## Purpose

Some pods where crashing when I tried to deploy edxapp on eugene/development
environment, with the following error in pymongo client : Temporary failure
in name resolution

## Proposal

Fix MONGODB_HOST configuration for eugene/development.