### PR TITLE
🐛 (script:dev) fix local ip detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Update eugene/development vault file for learninglocker
 - Fix MONGODB_HOST for eugene/development environment
+- Fix local ip address detection in dev script
 
 ## [4.3.1] - 2019-12-23
 

--- a/bin/dev
+++ b/bin/dev
@@ -38,7 +38,7 @@ function _get_local_ip() {
         (>&2 echo -n "==> ${ip} ... ")
 
         # Ping google from this interface to check internet access
-        if ! ping -I "${ip}" -W 1 -c 1 www.google.com &> /dev/null; then
+        if ping -I "${ip}" -W 1 -c 1 www.google.com &> /dev/null; then
             echo "${ip}"
             (>&2 echo "yes")
             return 0


### PR DESCRIPTION

## Purpose

The `bin/dev` script does not detect any address with internet connectivity on my machine : 

```
$ bin/dev 
Looking for a network interface with internet access...
==> 192.168.1.24 ... no
==> 192.168.1.11 ... no
==> 172.17.0.1 ... no
Error: cannot find an interface that has access to the internet. Please provide your local IP address as a script argument: bin/dev 192.168.1.100

```

 But the ping command used in the test is working when executed manually : 

```
PING www.google.com (172.217.19.228) from 192.168.1.24 : 56(84) bytes of data.
64 bytes from par21s11-in-f4.1e100.net (172.217.19.228): icmp_seq=1 ttl=53 time=26.3 ms

--- www.google.com ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 26.307/26.307/26.307/0.000 ms
```

## Proposal

Fix the condition testing the ping exit status.
