### PR TITLE
🔧(edxapp) configure routing timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [4.3.1] - 2019-12-23
 
+### Added
+
+- Configure routing timeout in edxapp application
+
 ### Changed
 
 - Upgrade the learninglocker image to v5.2.2 and the xapi-service image to v2.9.10

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -24,6 +24,8 @@ server {
   location @proxy_to_cms_app {
     proxy_set_header Host $http_host;
 
+    proxy_read_timeout {{ edxapp_routing_timeout | default("60s") }};
+
     proxy_redirect off;
     proxy_pass http://cms-backend;
   }

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -24,6 +24,8 @@ server {
   location @proxy_to_lms_app {
     proxy_set_header Host $http_host;
 
+    proxy_read_timeout {{ edxapp_routing_timeout | default("60s") }};
+
     proxy_redirect off;
     proxy_pass http://lms-backend;
   }

--- a/apps/edxapp/templates/services/nginx/route_cms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/route_cms.yml.j2
@@ -15,6 +15,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     haproxy.router.openshift.io/disable_cookies: "true"
     haproxy.router.openshift.io/balance: "roundrobin"
+    haproxy.router.openshift.io/timeout: "{{ edxapp_routing_timeout | default("60s") }}"
 spec:
   host: "{{ edxapp_cms_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/edxapp/templates/services/nginx/route_lms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/route_lms.yml.j2
@@ -15,6 +15,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     haproxy.router.openshift.io/disable_cookies: "true"
     haproxy.router.openshift.io/balance: "roundrobin"
+    haproxy.router.openshift.io/timeout: "{{ edxapp_routing_timeout | default("60s") }}"
 spec:
   host: "{{ edxapp_lms_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/edxapp/templates/services/nginx/route_preview.yml.j2
+++ b/apps/edxapp/templates/services/nginx/route_preview.yml.j2
@@ -15,6 +15,7 @@ metadata:
     kubernetes.io/tls-acme: "true"
     haproxy.router.openshift.io/disable_cookies: "true"
     haproxy.router.openshift.io/balance: "roundrobin"
+    haproxy.router.openshift.io/timeout: "{{ edxapp_routing_timeout | default("60s") }}"
 spec:
   host: "{{ edxapp_preview_host | blue_green_host(prefix) }}"
   tls:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -105,6 +105,7 @@ edxapp_nginx_replicas: 1
 edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
 edxapp_nginx_healthcheck_port: 5000
 edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
+edxapp_routing_timeout: "60s"
 
 # -- celery/redis
 


### PR DESCRIPTION
## Purpose

some pages need more time to be computed and we have a timeout error. To
resolve this issue, the LMS and CMS nginx configuration must be adapted
by setting proxy_read_timeout value to a higher one. Also OpenShift
routes, using haproxy, also have a timeout we need to increase. We want
the same timeout everywhere so only one new setting is added at the
edxapp application level: edxapp_routing_timeout

## Proposal

- [x] add a new setting `edxapp_routing_timeout`
- [x] use the setting `edxapp_routing_timeout` in nginx and routes configurations
