### PR TITLE
restrict access to /admin to whitelisted ips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Whitelist ips authorized to access /admin on edxapp, marsha and richie
+
 ### Fixed
 
 - In edxapp, add an lms queue to the list of cms Celery queues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Whitelist ips authorized to access /admin on edxapp,
   edxec, marsha and richie
+- Whitelist ips authorized to access learninglocker's UI
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
-- Whitelist ips authorized to access /admin on edxapp, marsha and richie
+- Whitelist ips authorized to access /admin on edxapp,
+  edxec, marsha and richie
 
 ### Fixed
 

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -34,6 +34,24 @@ server {
     try_files $uri @proxy_to_cms_app;
   }
 
+{% if edxapp_nginx_cms_admin_ip_withelist | length > 0 %}
+  location /admin {
+    {# 
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_cms_admin_ip_withelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_cms_app;
+  }
+{% endif %}
+
   location ~ ^/static/(?P<file>.*) {
     root /data/static;
     try_files /$file =404;

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -44,6 +44,24 @@ server {
     try_files $uri @proxy_to_lms_app;
   }
 
+{% if edxapp_nginx_lms_admin_ip_withelist | length > 0 %}
+  location /admin {
+    {# 
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_lms_admin_ip_withelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_lms_app;
+  }
+{% endif %}
+
   # Need a separate location for the image uploads endpoint to limit upload sizes
   location ~ ^/api/profile_images/[^/]*/[^/]*/upload$ {
     try_files $uri @proxy_to_lms_app;

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -106,6 +106,8 @@ edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
 edxapp_nginx_healthcheck_port: 5000
 edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxapp_routing_timeout: "60s"
+edxapp_nginx_cms_admin_ip_withelist: []
+edxapp_nginx_lms_admin_ip_withelist: []
 
 # -- celery/redis
 

--- a/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
@@ -29,6 +29,24 @@ server {
     try_files $uri @proxy_to_edxec_app;
   }
 
+{% if edxec_nginx_admin_ip_withelist | length > 0 %}
+  location /admin {
+    {# 
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ edxec_nginx_admin_ip_withelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_edxec_app;
+  }
+{% endif %}
+
   location ~ ^/static/(?P<file>.*) {
     root /data/static/;
     try_files /$file =404;

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -21,6 +21,7 @@ edxec_nginx_replicas: 1
 edxec_nginx_htpasswd_secret_name: "edxec-htpasswd"
 edxec_nginx_healthcheck_port: 5000
 edxec_nginx_healthcheck_endpoint: "/__healthcheck__"
+edxec_nginx_admin_ip_withelist: []
 
 
 # -- mysql

--- a/apps/learninglocker/templates/services/nginx/configs/default.conf.j2
+++ b/apps/learninglocker/templates/services/nginx/configs/default.conf.j2
@@ -42,6 +42,20 @@ server {
 
   # All other traffic directed to statics or Node server
   location / {
+{% if learninglocker_nginx_admin_ip_withelist | length > 0 %}
+    {# 
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ learninglocker_nginx_admin_ip_withelist | join("|") }})) {
+      return 403;
+    }
+{% endif %}
+
     try_files $uri @node_server;
   }
 

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -12,6 +12,7 @@ learninglocker_api_port: 8080
 learninglocker_api_replicas: 1
 learninglocker_worker_replicas: 1
 learninglocker_ui_replicas: 1
+learninglocker_nginx_admin_ip_withelist: []
 
 
 # -- xapi

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -29,6 +29,24 @@ server {
     try_files $uri @proxy_to_marsha_app;
   }
 
+{% if marsha_nginx_admin_ip_withelist | length > 0 %}
+  location /admin {
+    {# 
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_admin_ip_withelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_marsha_app;
+  }
+{% endif %}
+
   {% if env_type in trashable_env_types %}
   location ~ ^/static/(?P<file>.*) {
     root /data/static/marsha;

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -11,6 +11,7 @@ marsha_nginx_replicas: 1
 marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 marsha_nginx_healthcheck_port: 5000
 marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
+marsha_nginx_admin_ip_withelist: []
 
 # -- postgresql
 marsha_postgresql_version: "9.6"

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -29,6 +29,24 @@ server {
     try_files $uri @proxy_to_richie_app;
   }
 
+{% if richie_nginx_admin_ip_withelist | length > 0 %}
+  location /admin {
+    {# 
+      We want to limit access to a list of whitelisted IP addresses.
+
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
+      which is of interest (other ones have been added by subsequent proxies),
+      hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
+    #}
+    if ($http_x_forwarded_for !~ ^({{ richie_nginx_admin_ip_withelist | join("|") }})) {
+      return 403;
+    }
+
+    try_files $uri @proxy_to_richie_app;
+  }
+{% endif %}
+
 {% if richie_should_activate_media_volume %}
   location ~ ^/media/(?P<file>.*) {
     root /data/media/richie;

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -11,6 +11,7 @@ richie_nginx_replicas: 1
 richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 richie_nginx_healthcheck_port: 5000
 richie_nginx_healthcheck_endpoint: "/__healthcheck__"
+richie_nginx_admin_ip_withelist: []
 
 # -- elasticsearch
 richie_elasticsearch_image_name: "fundocker/openshift-elasticsearch"


### PR DESCRIPTION
## Purpose

We want to give access to /admin path to a restricted list of ips we
want to control. If the whitelist is empty the restriction is disabled and if ips are added to this list they will be used to restrict the access of /admin to this given list.

## Proposal

- [x] configure nginx on edxapp
- [x] configure nginx on richie
- [x] configure nginx on marsha