### PR TITLE
🐛(edxapp) declare an lms queue in the cms celery queues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- In edxapp, add an lms queue to the list of cms Celery queues
 - Add edxec to eugene/development apps list
 
 ## [4.5.0] - 2020-01-08

--- a/apps/edxapp/templates/services/cms/configs/settings.yml.j2
+++ b/apps/edxapp/templates/services/cms/configs/settings.yml.j2
@@ -19,9 +19,15 @@ CELERY_BROKER_USER: ""
 CELERY_BROKER_PASSWORD: ""
 
 # Celery queues
-HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}-{{ deployment_stamp }}"
 DEFAULT_PRIORITY_QUEUE: "{{ edxapp_celery_cms_default_priority_queue }}-{{ deployment_stamp }}"
+HIGH_PRIORITY_QUEUE: "{{ edxapp_celery_cms_high_priority_queue }}-{{ deployment_stamp }}"
 LOW_PRIORITY_QUEUE: "{{ edxapp_celery_cms_low_priority_queue }}-{{ deployment_stamp }}"
+
+CELERY_QUEUES:
+  {{ edxapp_celery_cms_default_priority_queue }}-{{ deployment_stamp }}: {}
+  {{ edxapp_celery_cms_high_priority_queue }}-{{ deployment_stamp }}: {}
+  {{ edxapp_celery_cms_low_priority_queue }}-{{ deployment_stamp }}: {}
+  {{ edxapp_celery_lms_default_priority_queue }}-{{ deployment_stamp }}: {}
 
 # Memcached
 MEMCACHED_HOST: "edxapp-memcached-{{ deployment_stamp }}"


### PR DESCRIPTION
## Purpose

In Open edX, some tasks are routed from the cms wsgi to the lms Celery worker.

For this to work, the task router will look for an lms queue in the list of queues declared for the cms.

## Proposal

Override the `CELERY_QUEUES` setting to declare the lms default queue in the list of queues in cms pods.

After this, the list of cms queues will look like this:
```
>>> settings.CELERY_QUEUES
{
    'edx.cms.core.default-d-200109-16h53m15s': {},
    'edx.cms.core.low-d-200109-16h53m15s': {},
    'edx.lms.core.default-d-200109-16h53m15s': {},
    'edx.cms.core.high-d-200109-16h53m15s': {}
}
```