### PR TITLE
🐛(playbook) avoid downtime during switch or rollback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Avoid downtime during a switch or rollback
+
 ## [4.6.0] - 2020-01-13
 
 ### Added

--- a/tasks/rollback_routes.yml
+++ b/tasks/rollback_routes.yml
@@ -10,9 +10,11 @@
   vars:
     prefix_route_src:  "{{ prefix_route.src }}"
     prefix_route_dest: "{{ prefix_route.dest }}"
+    update_src: "{{ prefix_route.update_src | default(True)}}"
   with_items:
     - src:  current
       dest: next
+      update_src: False
     - src:  previous
       dest: current
   loop_control:

--- a/tasks/switch_route.yml
+++ b/tasks/switch_route.yml
@@ -20,3 +20,5 @@
   vars:
     prefix: "{{ prefix_route_src }}"
   tags: switch
+  when: update_src is defined and update_src == True
+

--- a/tasks/switch_routes.yml
+++ b/tasks/switch_routes.yml
@@ -10,9 +10,11 @@
   vars:
     prefix_route_src:  "{{ prefix_route.src }}"
     prefix_route_dest: "{{ prefix_route.dest }}"
+    update_src: "{{ prefix_route.update_src | default(True)}}"
   with_items:
     - src:  current
       dest: previous
+      update_src: False
     - src:  next
       dest: current
   loop_control:


### PR DESCRIPTION

## Purpose

The _switch_routes_  ansible task leave the _current_  route in an invalid state  for a few  seconds when switch or  rollback playbooks are executed. It can introduce an unnecessary downtime during a deployment.

For example, I have the _hello_ app deployed with the following versions :

- **next** : `d-200113-09h05m11s`
- **current** : `d-200113-08h58m09s`
- **previous** : `d-200113-08h55m23s`

If I execute a switch, I can find this in my logs : 
```
$ bin/switch -e "apps_filter=hello" | grep --line-buffered -i "patching routes with prefix" | ts '[%Y-%m-%d %H:%M:%.S]'

[2020-01-13 10:08:25.433209] TASK [Patching routes with prefix previous for the hello application with deployment_stamp d-200113-08h58m09s] ***
[2020-01-13 10:08:26.760792] TASK [Patching routes with prefix current for the hello application with deployment_stamp] ***
[2020-01-13 10:08:29.672389] TASK [Patching routes with prefix current for the hello application with deployment_stamp d-200113-09h05m11s] ***
[2020-01-13 10:08:30.687389] TASK [Patching routes with prefix next for the hello application with deployment_stamp] ***
```
Between `10:08:26` and `10:08:29`, the _current_ route  is pointing to an undefined deployment stamp.

## Proposal

Do not execute the second step in the above example.