### PR TITLE
🐛(playbook) improve delete_previous playbook behaviour on k8s api fai…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Avoid downtime during a switch or rollback
+- Improve `delete_previous` playbook behavior on k8s api failure
 
 ## [4.6.0] - 2020-01-13
 

--- a/tasks/delete_app_objects_kind.yml
+++ b/tasks/delete_app_objects_kind.yml
@@ -29,6 +29,6 @@
       - app={{ app.name }}
       - deployment_stamp={{ targeted_deployment_stamp }}
   register: remaining_objects
-  until: ( remaining_objects.resources | length ) == 0
+  until: remaining_objects.failed == True or ( remaining_objects.resources | length ) == 0
   retries: 120
   delay: 5


### PR DESCRIPTION
## Purpose

The delete_previous playbook fails with an unclear error message if the kubernetes API is not responding :
```
fatal: [local]: FAILED! => {"msg": "The conditional check '( remaining_objects.resources | length ) == 0' failed. The error was: error while evaluating conditional (( remaining_objects.resources | length ) == 0): 'dict object' has no attribute 'resources'"}
```

## Proposal

Fix the retry loop condition in `delete_app_objects_kind.yml`
