### PR TITLE
🚸(playbook) disallow switching if next stack is not deployed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -523,6 +523,47 @@ jobs:
             # Perform running pods test
             test $(eval "${cmd} | grep Running | wc -l") -eq 1
 
+  test-prevent-switch-to-nothing:
+    machine:
+      docker_layer_caching: false
+
+    working_directory: ~/fun
+
+    steps:
+      - checkout
+      - *attach_workspace
+      - *docker_load
+      - *ci_env
+      - *install_openshift_cluster
+      - *configure_openshift_cluster
+      - *run_openshift_cluster
+
+      - run:
+          name: Prepare "hello" application bootstrapping
+          command: |
+            # Bootstrap app
+            bin/ci-ansible-playbook bootstrap.yml "hello"
+            # Test service deployed with the next route
+            bin/ci-test-service "hello" "Hello OpenShift! by Arnold" "/" "next"
+
+      - run:
+          name: Test "hello"'s switch
+          command: |
+            # Switch next route to current
+            bin/ci-ansible-playbook switch.yml "hello"
+            # Test service on the current route
+            bin/ci-test-service "hello" "Hello OpenShift! by Arnold" "/" "current"
+            # Test that the service is not responding on next route
+            bin/ci-test-service "hello" "Hello OpenShift! by Arnold" "/" "next" && exit 1 || true
+
+      - run:
+          name: Test that a second switch fails to execute with an error
+          command: |
+            # Execute the switch playbook and test that the exit code is not 0
+            bin/ci-ansible-playbook switch.yml "hello" &> /tmp/switch-to-nothing.out && exit 1 || true
+            # Test error message displayed by switch playbook
+            grep "next stack is not deployed, aborting switch" /tmp/switch-to-nothing.out
+
   # FIXME: we have deactivated plugins test coverage as the container user is
   # not allowed to write to /app/.coverage and CircleCI does not allow to mount
   # volumes with "docker run" commands.
@@ -740,6 +781,12 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-prevent-switch-to-nothing:
+          requires:
+            - test-bootstrap-hello
+          filters:
+            tags:
+              only: /.*/
       - test-plugins:
           requires:
             - lint-bash
@@ -767,6 +814,7 @@ workflows:
             - test-bootstrap-learninglocker
             - test-redirect
             - test-delete-app
+            - test-prevent-switch-to-nothing
           filters:
             branches:
               only: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Use the `k8s_info` module instead of the deprecated `k8s_facts` module
+- Prevent switching if next stack is not deployed
 
 ### Fixed
 

--- a/tasks/switch_routes.yml
+++ b/tasks/switch_routes.yml
@@ -6,6 +6,15 @@
     prefix: "previous"
   tags: switch
 
+- include_tasks: deploy_get_stamp_from_route.yml
+  vars:
+    prefix: "next"
+  tags: switch
+
+- fail:
+    msg: "next stack is not deployed, aborting switch"
+  when: next_app_deployment_stamp == ''
+
 - include_tasks: switch_route.yml
   vars:
     prefix_route_src:  "{{ prefix_route.src }}"


### PR DESCRIPTION
## Purpose

As described in #416 : When running the `switch` playbook, the current stack will be moved to the previous  route even if there  is no replacing stack  connected to the next route. This can cause a service downtime.



## Proposal

Disallow switching if next stack is not deployed.
