### PR TITLE
🚨(playbook) use the k8s_info module instead k8s_facts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Use the `k8s_info` module instead of the deprecated `k8s_facts` module
+
 ### Fixed
 
 - Avoid downtime during a switch or rollback

--- a/create_redirect.yml
+++ b/create_redirect.yml
@@ -50,7 +50,7 @@
     # Check if the nginx service already exists and recreate it only if not
     # (parts of an OpenShift Service definition are immutable).
     - name: Check if the redirect nginx service already exists
-      k8s_facts:
+      k8s_info:
         api_version: "v1"
         namespace: "{{ project_name }}"
         kind: "Service"

--- a/delete_project.yml
+++ b/delete_project.yml
@@ -18,7 +18,7 @@
     # We must check if the project exists first. Without this condition, k8s
     # will try to delete a missing project and returns a 403 ¯\_(ツ)_/¯
     - name: Check if project exists
-      k8s_facts:
+      k8s_info:
         api_version: v1
         kind: Project
         field_selectors:

--- a/tasks/check_app_secrets.yml
+++ b/tasks/check_app_secrets.yml
@@ -15,7 +15,7 @@
 - name: Handle permission on Secret objects
   block:
     - name: "Get created application secrets for {{ app.name }}"
-      k8s_facts:
+      k8s_info:
         api_version: "v1"
         namespace: "{{ project_name }}"
         kind: Secret

--- a/tasks/clean_app_orphans.yml
+++ b/tasks/clean_app_orphans.yml
@@ -18,7 +18,7 @@
     }}"
 
 - name: "Select objects (CM + pods) for app {{ app.name }}"
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "{{ item }}"

--- a/tasks/create_app_builds.yml
+++ b/tasks/create_app_builds.yml
@@ -24,7 +24,7 @@
   tags: build
 
 - name: Wait for target images to be available
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "ImageStreamTag"

--- a/tasks/delete_app_objects_kind.yml
+++ b/tasks/delete_app_objects_kind.yml
@@ -1,6 +1,6 @@
 # Delete a kind of objects for the targeted deployment_stamp
 - name: Lookup {{ kind }} to delete with deployment_stamp {{ targeted_deployment_stamp }} for app {{ app.name }}
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "{{ kind }}"
@@ -21,7 +21,7 @@
     loop_var: object
 
 - name: Wait for objects of kind {{ kind }} to be deleted
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "{{ kind }}"

--- a/tasks/deploy_get_stamp_from_route.yml
+++ b/tasks/deploy_get_stamp_from_route.yml
@@ -7,7 +7,7 @@
 # then the service targeted by this route. TThis service will be labelled with the
 # deploy_stamp we are looking for.
 - name: Get route for application {{ app.name }} with prefix {{ prefix }}
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "Route"
@@ -18,7 +18,7 @@
   when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True)
 
 - name: Get targeted service
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "Service"

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -76,7 +76,7 @@
   when: app.settings.is_blue_green_compatible | default(True) == True
 
 - name: Wait for pods to be running
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "Pod"

--- a/tasks/run_job.yml
+++ b/tasks/run_job.yml
@@ -15,7 +15,7 @@
     - job
 
 - name: Wait for job completion
-  k8s_facts:
+  k8s_info:
     api_version: "v1"
     namespace: "{{ project_name }}"
     kind: "Job"


### PR DESCRIPTION
## Purpose

The ansible module `k8s_facts` is deprecated in ansible 2.9.
It has been renamed to `k8s_info`.

## Proposal

Use `k8s_info` module instead of `k8s_facts`.