### PR TITLE
🚨(playbook) remove deprecation warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Avoid downtime during a switch or rollback
 - Improve `delete_previous` playbook behavior on k8s api failure
+- Remove deprecation warnings in playbooks
 
 ## [4.6.0] - 2020-01-13
 

--- a/tasks/create_app_secrets.yml
+++ b/tasks/create_app_secrets.yml
@@ -21,7 +21,7 @@
   debug:
     var: secrets
     verbosity: 2
-  when: secrets
+  when: secrets is defined
   tags: secret
 
 # Create all secrets for the current application

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -35,7 +35,7 @@
   debug:
     var: builds
     verbosity: 2
-  when: builds
+  when: builds is defined
   tags:
     - deploy
     - build
@@ -44,7 +44,7 @@
   debug:
     var: deployments
     verbosity: 2
-  when: deployments
+  when: deployments is defined
   tags:
     - deploy
     - deployment
@@ -53,7 +53,7 @@
   debug:
     var: endpoints
     verbosity: 2
-  when: deployments
+  when: deployments is defined
   tags:
     - deploy
     - endpoint
@@ -62,7 +62,7 @@
   debug:
     var: services
     verbosity: 2
-  when: services
+  when: services is defined
   tags:
     - deploy
     - service
@@ -71,7 +71,7 @@
   debug:
     var: streams
     verbosity: 2
-  when: streams
+  when: streams is defined
   tags:
     - deploy
     - stream
@@ -80,7 +80,7 @@
   debug:
     var: jobs
     verbosity: 2
-  when: jobs
+  when: jobs is defined
   tags:
     - deploy
     - job
@@ -89,7 +89,7 @@
   debug:
     var: routes
     verbosity: 2
-  when: routes
+  when: routes is defined
   tags:
     - deploy
     - route


### PR DESCRIPTION
## Purpose

There are depreciation warning when running `deploy.yml` playbook like this :

```
DEPRECATION WARNING]: evaluating  ['apps/hello/templates/services/app/dc.yml.j2'] as a bare variable, this behaviour will go away and you might need to add |bool to the expression in the future. Also see CONDITIONAL_BARE_VARS configuration toggle.. This feature  will be removed in version 2.12. Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
```

## Proposal

Fix bare variable evaluations.

Fix #372 