### PR TITLE
Add nginx cache for served static and media files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Configured nginx cache for statics and media files for the following apps:
   - richie
+  - marsha
 
 ## [4.7.0] - 2020-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Configured nginx cache for statics and media files for the following apps:
-  - richie
-  - marsha
+  - `richie`
+  - `marsha`
+  - `edxec`
 
 ## [4.7.0] - 2020-01-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Configured nginx cache for statics and media files for the following apps:
+  - richie
+
 ## [4.7.0] - 2020-01-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   - `richie`
   - `marsha`
   - `edxec`
+  - `edxapp`
 
 ## [4.7.0] - 2020-01-17
 

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -36,10 +36,10 @@ server {
 
 {% if edxapp_nginx_cms_admin_ip_withelist | length > 0 %}
   location /admin {
-    {# 
+    {#
       We want to limit access to a list of whitelisted IP addresses.
 
-      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
       header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
@@ -53,6 +53,12 @@ server {
 {% endif %}
 
   location ~ ^/static/(?P<file>.*) {
+    access_log off;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    expires {{ edxapp_nginx_cms_static_cache_expires }};
+    add_header Cache-Control public;
     root /data/static;
     try_files /$file =404;
   }

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -46,10 +46,10 @@ server {
 
 {% if edxapp_nginx_lms_admin_ip_withelist | length > 0 %}
   location /admin {
-    {# 
+    {#
       We want to limit access to a list of whitelisted IP addresses.
 
-      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
       header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
@@ -64,17 +64,28 @@ server {
 
   # Need a separate location for the image uploads endpoint to limit upload sizes
   location ~ ^/api/profile_images/[^/]*/[^/]*/upload$ {
+    access_log off;
+    expires {{ edxapp_nginx_lms_profile_cache_expires }};
+    add_header Cache-Control public;
     try_files $uri @proxy_to_lms_app;
     client_max_body_size 1049576;
   }
 
   location ~ ^/media/(?P<file>.*) {
+    access_log off;
+    expires {{ edxapp_nginx_lms_media_cache_expires }};
+    add_header Cache-Control public;
     root /data/media;
     try_files /$file =404;
-    expires 31536000s;
   }
 
   location ~ ^/static/(?P<file>.*) {
+    access_log off;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    expires {{ edxapp_nginx_lms_static_cache_expires }};
+    add_header Cache-Control public;
     root /data/static;
     try_files /$file =404;
   }

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -110,6 +110,10 @@ edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxapp_routing_timeout: "60s"
 edxapp_nginx_cms_admin_ip_withelist: []
 edxapp_nginx_lms_admin_ip_withelist: []
+edxapp_nginx_cms_static_cache_expires: "1M"
+edxapp_nginx_lms_media_cache_expires: "1y"
+edxapp_nginx_lms_profile_cache_expires: "1y"
+edxapp_nginx_lms_static_cache_expires: "1M"
 
 # -- celery/redis
 

--- a/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
@@ -31,10 +31,10 @@ server {
 
 {% if edxec_nginx_admin_ip_withelist | length > 0 %}
   location /admin {
-    {# 
+    {#
       We want to limit access to a list of whitelisted IP addresses.
 
-      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
       header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
@@ -48,11 +48,20 @@ server {
 {% endif %}
 
   location ~ ^/static/(?P<file>.*) {
+    access_log off;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    expires {{ edxec_nginx_static_cache_expires }};
+    add_header Cache-Control public;
     root /data/static/;
     try_files /$file =404;
   }
 
   location ~ ^/media/(?P<file>.*) {
+    access_log off;
+    expires {{ edxec_nginx_media_cache_expires }};
+    add_header Cache-Control public;
     root /data/media/;
     try_files /$file =404;
   }

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -22,7 +22,8 @@ edxec_nginx_htpasswd_secret_name: "edxec-htpasswd"
 edxec_nginx_healthcheck_port: 5000
 edxec_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxec_nginx_admin_ip_withelist: []
-
+edxec_nginx_static_cache_expires: "1M"
+edxec_nginx_media_cache_expires: "1M"
 
 # -- mysql
 edxec_mysql_version: "5.7"

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -31,10 +31,10 @@ server {
 
 {% if marsha_nginx_admin_ip_withelist | length > 0 %}
   location /admin {
-    {# 
+    {#
       We want to limit access to a list of whitelisted IP addresses.
 
-      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
       header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
@@ -49,6 +49,12 @@ server {
 
   {% if env_type in trashable_env_types %}
   location ~ ^/static/(?P<file>.*) {
+    access_log off;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    expires {{ marsha_nginx_static_cache_expires }};
+    add_header Cache-Control public;
     root /data/static/marsha;
     try_files /$file =404;
   }

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -12,6 +12,7 @@ marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 marsha_nginx_healthcheck_port: 5000
 marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
 marsha_nginx_admin_ip_withelist: []
+marsha_nginx_static_cache_expires: "1M"
 
 # -- postgresql
 marsha_postgresql_version: "9.6"

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -31,10 +31,10 @@ server {
 
 {% if richie_nginx_admin_ip_withelist | length > 0 %}
   location /admin {
-    {# 
+    {#
       We want to limit access to a list of whitelisted IP addresses.
 
-      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR 
+      $http_x_forwarded_for variable contains a list of IPs listed from the HTTP_X_FORWARED_FOR
       header (e.g. w.x.y.z, 10.0.0.1). The first IP corresponds to the client's public address,
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
@@ -49,6 +49,9 @@ server {
 
 {% if richie_should_activate_media_volume %}
   location ~ ^/media/(?P<file>.*) {
+    access_log off;
+    expires {{ richie_nginx_media_cache_expires }};
+    add_header Cache-Control public;
     root /data/media/richie;
     try_files /$file =404;
   }
@@ -56,6 +59,12 @@ server {
 
 {% if richie_should_activate_static_volume %}
   location ~ ^/static/(?P<file>.*) {
+    access_log off;
+    gzip on;
+    gzip_comp_level 5;
+    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    expires {{ richie_nginx_static_cache_expires }};
+    add_header Cache-Control public;
     root /data/static/richie;
     try_files /$file =404;
   }

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -12,6 +12,8 @@ richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 richie_nginx_healthcheck_port: 5000
 richie_nginx_healthcheck_endpoint: "/__healthcheck__"
 richie_nginx_admin_ip_withelist: []
+richie_nginx_static_cache_expires: "1M"
+richie_nginx_media_cache_expires: "1M"
 
 # -- elasticsearch
 richie_elasticsearch_image_name: "fundocker/openshift-elasticsearch"


### PR DESCRIPTION
## Purpose

Static files should only be downloaded once by a given browser. It should be stored in the browser cache and generate a 304 on every further request.

## Proposal

Add `nginx` cache support for the following applications:

- [x] `richie`
- [x] `marsha`
- [x] `edxec`
- [x] `edxapp/cms`
- [x] `edxapp/lms`

Fixes #442