### PR TITLE
Bypass htaccess using a ip whitelist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   - `marsha`
   - `edxec`
   - `edxapp`
+- Bypass htaccess using a whitelist ip for the following apps:
+  - `richie`
+  - `marsha`
+  - `edxec`
+  - `edxapp`
+
 
 ### Changed
 

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -1,3 +1,5 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or edxapp_activate_http_basic_auth %}
+{% set bypass_htaccess = edxapp_nginx_cms_bypass_htaccess_ip_whitelist | length > 0 %}
 upstream cms-backend {
   server edxapp-cms-{{ deployment_stamp }}:{{ edxapp_django_port }} fail_timeout=0;
 }
@@ -6,11 +8,19 @@ server {
   listen {{ edxapp_nginx_cms_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_cms_app;
+  }
+{% else %}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
-  {% endif %}
-
+{% endif %}
+{% endif %}
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P 'CP="Open edX does not have a P3P policy."';
 
@@ -31,6 +41,13 @@ server {
   }
 
   location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_cms_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 @basicauth;
+      return 401;
+    }
+{% endif %} 
+
     try_files $uri @proxy_to_cms_app;
   }
 

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -1,3 +1,5 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or edxapp_activate_http_basic_auth %}
+{% set bypass_htaccess = edxapp_nginx_lms_bypass_htaccess_ip_whitelist | length > 0 %}
 upstream lms-backend {
   server edxapp-lms-{{ deployment_stamp }}:{{ edxapp_django_port }} fail_timeout=0;
 }
@@ -6,10 +8,19 @@ server {
   listen {{ edxapp_nginx_lms_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_lms_app;
+  }
+{% else %}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
-  {% endif %}
+{% endif %}
+{% endif %}
 
   # Prevent invalid display courseware in IE 10+ with high privacy settings
   add_header P3P 'CP="Open edX does not have a P3P policy."';
@@ -31,6 +42,12 @@ server {
   }
 
   location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_lms_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 @basicauth;
+      return 401;
+    }
+{% endif %}    
     try_files $uri @proxy_to_lms_app;
   }
 

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -108,7 +108,9 @@ edxapp_nginx_healthcheck_port: 5000
 edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxapp_routing_timeout: "60s"
 edxapp_nginx_cms_admin_ip_withelist: []
+edxapp_nginx_cms_bypass_htaccess_ip_whitelist: []
 edxapp_nginx_lms_admin_ip_withelist: []
+edxapp_nginx_lms_bypass_htaccess_ip_whitelist: []
 edxapp_nginx_cms_static_cache_expires: "1M"
 edxapp_nginx_lms_media_cache_expires: "1y"
 edxapp_nginx_lms_profile_cache_expires: "1y"

--- a/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
@@ -1,3 +1,5 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or edxec_activate_http_basic_auth %}
+{% set bypass_htaccess = edxec_nginx_bypass_htaccess_ip_whitelist | length > 0 %}
 upstream edxec-backend {
   server edxec-app-{{ deployment_stamp }}:{{ edxec_django_port }} fail_timeout=0;
 }
@@ -6,10 +8,19 @@ server {
   listen {{ edxec_nginx_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth or edxec_activate_http_basic_auth -%}
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_edxec_app;
+  }
+{% else %}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
-  {% endif %}
+{% endif %}
+{% endif %}
 
   client_max_body_size 100M;
 
@@ -26,6 +37,13 @@ server {
   }
 
   location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ edxec_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 @basicauth;
+      return 401;
+    }
+{% endif %} 
+
     try_files $uri @proxy_to_edxec_app;
   }
 

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -22,6 +22,7 @@ edxec_nginx_htpasswd_secret_name: "edxec-htpasswd"
 edxec_nginx_healthcheck_port: 5000
 edxec_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxec_nginx_admin_ip_withelist: []
+edxec_nginx_bypass_htaccess_ip_whitelist: []
 edxec_nginx_static_cache_expires: "1M"
 edxec_nginx_media_cache_expires: "1M"
 

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -1,3 +1,5 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or marsha_activate_http_basic_auth %}
+{% set bypass_htaccess = marsha_nginx_bypass_htaccess_ip_whitelist | length > 0 %}
 upstream marsha-backend {
   server marsha-app-{{ deployment_stamp }}:{{ marsha_django_port }} fail_timeout=0;
 }
@@ -6,10 +8,19 @@ server {
   listen {{ marsha_nginx_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth or marsha_activate_http_basic_auth -%}
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_marsha_app;
+  }
+{% else %}
   auth_basic "{{ http_basic_auth_message }}";
   auth_basic_user_file {{ http_basic_auth_user_file }};
-  {% endif %}
+{% endif %}
+{% endif %}
 
   client_max_body_size 100M;
 
@@ -26,6 +37,13 @@ server {
   }
 
   location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 @basicauth;
+      return 401;
+    }
+{% endif %} 
+
     try_files $uri @proxy_to_marsha_app;
   }
 

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -12,6 +12,7 @@ marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 marsha_nginx_healthcheck_port: 5000
 marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
 marsha_nginx_admin_ip_withelist: []
+marsha_nginx_bypass_htaccess_ip_whitelist: []
 marsha_nginx_static_cache_expires: "1M"
 
 # -- postgresql

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -1,3 +1,5 @@
+{% set http_basic_auth_enabled = activate_http_basic_auth or richie_activate_http_basic_auth %}
+{% set bypass_htaccess = richie_nginx_bypass_htaccess_ip_whitelist | length > 0 %}
 upstream richie-backend {
   server richie-app-{{ deployment_stamp }}:{{ richie_django_port }} fail_timeout=0;
 }
@@ -6,17 +8,26 @@ server {
   listen {{ richie_nginx_port }};
   server_name localhost;
 
-  {% if activate_http_basic_auth or richie_activate_http_basic_auth -%}
-  auth_basic "{{ http_basic_auth_message }}";
-  auth_basic_user_file {{ http_basic_auth_user_file }};
-  {% endif %}
-
   client_max_body_size 100M;
 
   rewrite ^(.*)/favicon.ico$ /static/images/favicon.ico last;
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+
+{% if http_basic_auth_enabled %}
+{% if bypass_htaccess %}
+  location @basicauth {
+    auth_basic "{{ http_basic_auth_message }}";
+    auth_basic_user_file {{ http_basic_auth_user_file }};
+
+    try_files $uri @proxy_to_richie_app;
+  }
+{% else %}
+  auth_basic "{{ http_basic_auth_message }}";
+  auth_basic_user_file {{ http_basic_auth_user_file }};
+{% endif %}
+{% endif %}
 
   location @proxy_to_richie_app {
     proxy_set_header Host $http_host;
@@ -26,6 +37,13 @@ server {
   }
 
   location / {
+{% if http_basic_auth_enabled and bypass_htaccess %}
+    if ($http_x_forwarded_for !~ ^({{ richie_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+      error_page 401 @basicauth;
+      return 401;
+    }
+{% endif %}
+
     try_files $uri @proxy_to_richie_app;
   }
 

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -12,6 +12,7 @@ richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 richie_nginx_healthcheck_port: 5000
 richie_nginx_healthcheck_endpoint: "/__healthcheck__"
 richie_nginx_admin_ip_withelist: []
+richie_nginx_bypass_htaccess_ip_whitelist: []
 richie_nginx_static_cache_expires: "1M"
 richie_nginx_media_cache_expires: "1M"
 


### PR DESCRIPTION
## Purpose

When a user has a trusted IP we wan't to deactivate the htaccess
protection while still keeping it active for other users.

## Proposal

Bypass htaccess using a whitelist of ip addresses for the following apps:

- [x] `richie`
- [x] `marsha`
- [x] `edxec`
- [x] `edxapp`
