### PR TITLE
Restore theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
-- `edxapp`'s `nginx` service now uses a docker image with bundled CMS & LMS static files
+- `edxapp`'s `nginx` service now uses a docker image with bundled CMS & LMS
+  static files (even for custom themes)
 - Upgrade `ansible` to 2.9.4
 - Upgrade `openshift` to 0.10.1
 

--- a/apps/edxapp/templates/services/cms/_bc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_bc_base.yml.j2
@@ -42,14 +42,10 @@ spec:
       FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
       USER 0
       {% if edxapp_theme_url is defined and edxapp_theme_url -%}
-      RUN apt-get update && \
-        ( which npm || apt-get install -y npm ) && \
-        rm -rf /var/lib/apt/lists/*
       COPY . /edx/app/edxapp/edx-platform/themes/custom-theme
 {% for lang in edxapp_i18n_languages %}
       RUN python manage.py {{ service_variant }} compilemessages -l {{ lang }} --settings=fun.docker_run
 {% endfor %}
-      RUN NO_PREREQ_INSTALL=1 paver update_assets --settings={{ edxapp_build_settings }} --skip-collect
       {% endif -%}
       {% if edxapp_extra_dependencies is defined and edxapp_extra_dependencies | length -%}
       RUN pip install {{ edxapp_extra_dependencies | join(" ") }}

--- a/apps/edxapp/templates/services/nginx/bc_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/nginx/bc_collectstatic.yml.j2
@@ -1,0 +1,58 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
+
+# Note that we use chained builds to override OpenShift's Docker multistage
+# build limitation (incompatible old docker release). This build is the first
+# step where we collect static files (including theme statics) given an edxapp
+# Docker image, and store this artefact in the /edx/app/edxapp/staticfiles
+# directory.
+#
+# The next build (bc_nginx) is triggered when this build successfully finishes.
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  name: "{{ image_name("collectstatic", edxapp_nginx_image_tag, edxapp_theme_tag) | replace(':', '-') }}"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "nginx"
+    version: "{{ edxapp_image_tag }}"
+    theme: "{{ edxapp_theme_tag | default("none") }}"
+spec:
+  strategy:
+    type: Docker
+  source:
+    {% if edxapp_theme_url is defined and edxapp_theme_url -%}
+    git:
+      uri: "{{ edxapp_theme_url }}"
+      ref: "{{ edxapp_theme_tag | default("master") }}"
+    {% if edxapp_theme_is_private -%}
+    sourceSecret:
+      name: "{{ edxapp_theme_git_private_key_secret_name }}"
+    {% endif -%}
+    {% endif -%}
+    dockerfile: |-
+      FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
+      USER 0
+      {% if edxapp_theme_url is defined and edxapp_theme_url -%}
+      RUN apt-get update && \
+        ( which npm || apt-get install -y npm ) && \
+        apt-get install -y rdfind && \
+        rm -rf /var/lib/apt/lists/*
+      COPY . /edx/app/edxapp/edx-platform/themes/custom-theme
+      {% if edxapp_should_update_i18n -%}
+      RUN python manage.py lms compilejsi18n && \
+          python manage.py cms compilejsi18n
+      {% endif -%}
+      # Note that we also collect statics here.
+      RUN NO_PREREQ_INSTALL=1 paver update_assets --settings={{ edxapp_build_settings }}
+      # Replace duplicated file by a symlink to decrease the overall size of the
+      # final image
+      RUN rdfind -makesymlinks true /edx/app/edxapp/staticfiles
+      {% endif -%}
+      USER 10000
+  triggers:
+    - type: "ConfigChange"
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "{{ image_name("collectstatic", edxapp_nginx_image_tag, edxapp_theme_tag) }}"

--- a/apps/edxapp/templates/services/nginx/bc_nginx.yml.j2
+++ b/apps/edxapp/templates/services/nginx/bc_nginx.yml.j2
@@ -1,0 +1,44 @@
+{%- from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name -%}
+
+# Note that we use chained builds to override OpenShift's Docker multistage
+# build limitation (incompatible old docker release). This build is triggered
+# by the first build (bc_collectstatic) where we collect static files
+# (including theme statics) given an edxapp Docker image.
+apiVersion: "v1"
+kind: "BuildConfig"
+metadata:
+  name: "{{ image_name("nginx", edxapp_nginx_image_tag, edxapp_theme_tag) | replace(':', '-') }}"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "nginx"
+    version: "{{ edxapp_nginx_image_tag }}"
+    theme: "{{ edxapp_theme_tag | default("none") }}"
+spec:
+  strategy:
+    type: Docker
+  source:
+    dockerfile: |-
+      FROM {{ edxapp_nginx_image_name }}:{{ edxapp_nginx_image_tag }}
+      USER 0
+      {% if edxapp_theme_url is defined and edxapp_theme_url -%}
+      COPY ./tmp/edxapp/staticfiles/* /edx/app/edxapp/staticfiles/
+      {% endif -%}
+      USER 10000
+    images:
+      - from:
+          kind: ImageStreamTag
+          name: "{{ image_name("collectstatic", edxapp_nginx_image_tag, edxapp_theme_tag) }}"
+        paths:
+          - sourcePath: /edx/app/edxapp/staticfiles
+            destinationDir: "./tmp/edxapp/staticfiles"
+  triggers:
+    - imageChange:
+        from:
+          kind: "ImageStreamTag"
+          name: "{{ image_name("collectstatic", edxapp_nginx_image_tag, edxapp_theme_tag) }}"
+      type: ImageChange
+  output:
+    to:
+      kind: "ImageStreamTag"
+      name: "{{ image_name("nginx", edxapp_nginx_image_tag, edxapp_theme_tag) }}"

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -73,7 +73,7 @@ server {
     access_log off;
     gzip on;
     gzip_comp_level 5;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/xml image/svg+xml;
     expires {{ edxapp_nginx_cms_static_cache_expires }};
     add_header Cache-Control public;
     root /edx/app/edxapp/staticfiles;

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -100,7 +100,7 @@ server {
     access_log off;
     gzip on;
     gzip_comp_level 5;
-    gzip_types text/plain text/css text/xml text/javascript application/x-javascript application/xml image/svg+xml;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/x-javascript application/xml image/svg+xml;
     expires {{ edxapp_nginx_lms_static_cache_expires }};
     add_header Cache-Control public;
     root /edx/app/edxapp/staticfiles;

--- a/apps/edxapp/templates/services/nginx/dc.yml.j2
+++ b/apps/edxapp/templates/services/nginx/dc.yml.j2
@@ -1,3 +1,5 @@
+{% from "apps/edxapp/templates/services/cms/macros/image.yml.j2" import image_name %}
+
 apiVersion: v1
 kind: DeploymentConfig
 metadata:
@@ -33,7 +35,7 @@ spec:
                   - "edxapp-nginx-{{ deployment_stamp }}"
               topologyKey: kubernetes.io/hostname
       containers:
-        - image: "{{ edxapp_nginx_image_name }}:{{ edxapp_nginx_image_tag }}"
+        - image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('nginx', edxapp_nginx_image_tag, edxapp_theme_tag) }}"
           name: nginx
           ports:
             - containerPort: 80

--- a/apps/edxapp/templates/services/nginx/is_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/nginx/is_collectstatic.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "edxapp-collectstatic"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "nginx"

--- a/apps/edxapp/templates/services/nginx/is_nginx.yml.j2
+++ b/apps/edxapp/templates/services/nginx/is_nginx.yml.j2
@@ -1,0 +1,8 @@
+apiVersion: "v1"
+kind: "ImageStream"
+metadata:
+  name: "edxapp-nginx"
+  namespace: "{{ project_name }}"
+  labels:
+    app: "edxapp"
+    service: "nginx"


### PR DESCRIPTION
## Purpose

Now that we serve static files from an nginx container, we also need to add theme static files when the theme support is activated.

## Proposal

- [x] Add `nginx` ImageStream and BuildConfig
- [x] Move theme static files build from `cms` or `lms` service to `nginx`
