### PR TITLE
✨(deploy) manage cronjob object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
   - `marsha`
   - `edxec`
   - `edxapp`
+- Handle `CronJob` object type
 
 ### Changed
 

--- a/apps/hello/templates/services/app/cronjob_hello.yml.j2
+++ b/apps/hello/templates/services/app/cronjob_hello.yml.j2
@@ -1,0 +1,33 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: "cronjob-hello-{{ deployment_stamp }}"
+  namespace: "{{ project_name }}"
+  labels:
+    app: hello
+    service: app
+    deployment_stamp: "{{ deployment_stamp }}"
+spec:
+  schedule: "*/3 * * * *"  
+  successfulJobsHistoryLimit: 2
+  failedJobsHistoryLimit: 1
+  concurrencyPolicy: Forbid
+  suspend: {{ suspend_cronjob | default(false) }}
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          name: "cronjob-hello-{{ deployment_stamp }}"
+          labels:
+            app: hello
+            service: app
+            deployment_stamp: "{{ deployment_stamp }}"
+        spec:
+          containers:
+            - name: hello-world
+              image: busybox:1.31.1
+              command:
+                - "sh"
+                - "-c"
+                - echo "Hello World!"
+          restartPolicy: Never

--- a/deploy.yml
+++ b/deploy.yml
@@ -37,6 +37,7 @@
 
     - include_tasks: tasks/run_tasks_for_apps.yml
       vars:
+        suspend_cronjob: true
         tasks:
           - tasks/get_objects_for_app
           - tasks/check_app_secrets

--- a/switch.yml
+++ b/switch.yml
@@ -24,6 +24,7 @@
         tasks:
           - get_objects_for_app
           - switch_routes
+          - switch_cronjobs
       tags:
         - route
         - switch

--- a/tasks/delete_app.yml
+++ b/tasks/delete_app.yml
@@ -6,15 +6,16 @@
 - name: Iterate over objects to delete with deployment_stamp {{ targeted_deployment_stamp }} for app {{ app.name }}
   include_tasks: tasks/delete_app_objects_kind.yml
   loop:
-    - DeploymentConfig
+    - { kind: "DeploymentConfig", api_version: "v1" }
     # Manually handle deletion cascade as the k8s module won't
     # https://github.com/ansible/ansible/issues/42302
-    - ReplicationController
-    - Pod
-    - Job
-    - Service
-    - Endpoints
-    - ConfigMap
+    - { kind:  "ReplicationController", api_version: "v1" }
+    - { kind:  "Pod", api_version: "v1" }
+    - { kind:  "Job", api_version: "v1" }
+    - { kind:  "CronJob", api_version: "v1beta1" }
+    - { kind:  "Service", api_version: "v1" }
+    - { kind:  "EndPoints", api_version: "v1" }
+    - { kind:  "ConfigMap", api_version: "v1" }
   loop_control:
-    loop_var: kind
+    loop_var: resource_to_delete
   tags: deploy

--- a/tasks/delete_app_objects_kind.yml
+++ b/tasks/delete_app_objects_kind.yml
@@ -1,30 +1,31 @@
 # Delete a kind of objects for the targeted deployment_stamp
-- name: Lookup {{ kind }} to delete with deployment_stamp {{ targeted_deployment_stamp }} for app {{ app.name }}
+- name: Lookup {{ resource_to_delete.kind }} to delete with deployment_stamp {{ targeted_deployment_stamp }} for app {{ app.name }}
   k8s_info:
-    api_version: "v1"
+    api_version: "{{ resource_to_delete.api_version }}"
     namespace: "{{ project_name }}"
-    kind: "{{ kind }}"
+    kind: "{{ resource_to_delete.kind }}"
     label_selectors:
       - app={{ app.name }}
       - deployment_stamp={{ targeted_deployment_stamp }}
   register: selected_objects
   tags: deploy
 
-- name: Delete {{ kind }} with deployment_stamp {{ targeted_deployment_stamp }} for app {{ app.name }}
+- name: Delete {{ resource_to_delete.kind }} with deployment_stamp {{ targeted_deployment_stamp }} for app {{ app.name }}
   k8s:
+    api_version: "{{ resource_to_delete.api_version }}"
     namespace: "{{ project_name }}"
-    kind: "{{ kind }}"
+    kind: "{{ resource_to_delete.kind }}"
     name: "{{ object.metadata.name }}"
     state: absent
   loop: "{{ selected_objects.resources }}"
   loop_control:
     loop_var: object
 
-- name: Wait for objects of kind {{ kind }} to be deleted
+- name: Wait for objects of kind {{ resource_to_delete.kind }} to be deleted
   k8s_info:
-    api_version: "v1"
+    api_version: "{{ resource_to_delete.api_version }}"
     namespace: "{{ project_name }}"
-    kind: "{{ kind }}"
+    kind: "{{ resource_to_delete.kind }}"
     label_selectors:
       - app={{ app.name }}
       - deployment_stamp={{ targeted_deployment_stamp }}

--- a/tasks/deploy_patch_cronjob.yml
+++ b/tasks/deploy_patch_cronjob.yml
@@ -1,0 +1,14 @@
+# Patch cronjob to change spec.suspend value to true 
+# for the current stack and false otherwise
+
+- name: Patch CronJobs with deployment_stamp {{ deployment_stamp }}
+  k8s:
+    definition: "{{ lookup('template', cronjob_template) | from_yaml }}"
+    state: present
+  loop: "{{ cronjobs }}"
+  loop_control:
+    loop_var: cronjob_template
+  when: cronjobs | length > 0 and app.settings.is_blue_green_compatible | default(True) == True
+  tags:
+    - switch
+    - cronjob

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -20,6 +20,7 @@
     services: "{{ templates | map('regex_search', '.*/svc.*\\.yml\\.j2$') | select('string') | list }}"
     streams: "{{ templates | map('regex_search', '.*/is.*\\.yml\\.j2$') | select('string') | list }}"
     jobs: "{{ templates | map('regex_search', '.*/job_.*\\.yml\\.j2$') | select('string') | list }}"
+    cronjobs: "{{ templates | map('regex_search', '.*/cronjob_.*\\.yml\\.j2$') | select('string') | list }}"
     routes: "{{ templates | map('regex_search', '.*/route.*\\.yml\\.j2$') | select('string') | list }}"
   tags:
     - deploy
@@ -84,6 +85,15 @@
   tags:
     - deploy
     - job
+
+- name: Display OpenShift's cronjobs for this app
+  debug:
+    var: cronjobs
+    verbosity: 2
+  when: cronjobs is defined
+  tags:
+    - deploy
+    - cronjob
 
 - name: Display OpenShift's routes for this app
   debug:

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -45,6 +45,15 @@
     - deploy
     - job
 
+- name: OpenShift cronjobs with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
+  k8s:
+    definition: "{{ lookup('template', item) | from_yaml }}"
+    state: "{{ deployment_state | default('present') }}"
+  with_items: "{{ cronjobs }}"
+  tags:
+    - deploy
+    - cronjob
+
 - name: OpenShift deployments with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
   k8s:
     definition: "{{ lookup('template', item) | from_yaml }}"

--- a/tasks/switch_cronjobs.yml
+++ b/tasks/switch_cronjobs.yml
@@ -1,0 +1,26 @@
+---
+# In a switch, cronjobs from the previous stack must be suspended
+# and those from  the current stack must be activated.
+# At this point routes are already switched, the next stack is empty and only
+# the current and previous are alive.
+
+- include_tasks: deploy_get_stamp_from_route.yml
+  vars:
+    prefix: "current"
+  tags: switch
+
+- include_tasks: deploy_get_stamp_from_route.yml
+  vars:
+    prefix: "previous"
+  tags: switch
+
+- include_tasks: deploy_patch_cronjob.yml
+  vars:
+    suspend_cronjob: true
+    deployment_stamp: "{{ previous_app_deployment_stamp }}"
+  when: previous_app_deployment_stamp | length > 0
+
+- include_tasks: deploy_patch_cronjob.yml
+  vars:
+    suspend_cronjob: false
+    deployment_stamp: "{{ current_app_deployment_stamp }}"


### PR DESCRIPTION
## Purpose

In some applications we would like to add cronjob objects. In order to
manage them we have a new regex mapping cronjob files (cronjob_*.yml.j2)
and then create them in the manage_app task. They are creating before
DeploymentConfig.

## Proposal

- [x] register cronjob templates in `get_objects_for_app` task.
- [x] create/delete cronjob object in `manage_app` task.
