### PR TITLE
🐛(playbook) fix JSON config file generation from jinja2 template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - `edxapp`'s `nginx` service now uses a docker image with bundled CMS & LMS static files
 
+### Fixed
+
+- Error while generating JSON config file from jinja2 template
+
 ### Removed
 
 - `edxapp`'s static files collection jobs are no longer required

--- a/apps/hello/templates/services/app/configs/test.json.j2
+++ b/apps/hello/templates/services/app/configs/test.json.j2
@@ -1,0 +1,5 @@
+{
+  "stamp": "{{ deployment_stamp }}",
+  "project": "{{ project_name }}",
+  "key": "valu€"
+}

--- a/tasks/create_app_config.yml
+++ b/tasks/create_app_config.yml
@@ -36,7 +36,7 @@
       {%- for service in app_configmaps -%}
         {%- set _ = configmaps.update({ service.name: {} }) -%}
         {%- for cm_path in service.configs -%}
-          {%- set content = lookup('template', cm_path) -%}
+          {%- set content = lookup('template', cm_path, convert_data = False) -%}
           {%- set filename = cm_path | basename | regex_replace('.j2') -%}
           {%- set _ = configmaps.get(service.name).update({filename: content}) -%}
         {%- endfor -%}


### PR DESCRIPTION

## Purpose

As described in #450, the deploy playbook fails to generate a ConfigMap if it contains a JSON file generated from a Jinja2 template.

## Proposal

Prevent ansible from converting/interpreting files that will be stored in ConfigMaps.

**Do you see any side effects generated by this proposal ?**