### PR TITLE
Fixes for elasticsearch app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -478,29 +478,6 @@ jobs:
             # Test service switched to the current route
             bin/ci-test-route "learninglocker" "OK" "/api"
 
-  # Test the bootstrap playbook on the "elasticsearch" application.
-  test-bootstrap-elasticsearch:
-    machine:
-      docker_layer_caching: false
-
-    working_directory: ~/fun
-
-    steps:
-      - checkout
-      - *attach_workspace
-      - *docker_load
-      - *ci_env
-      - *install_openshift_cluster
-      - *configure_openshift_cluster
-      - *run_openshift_cluster
-
-      - run:
-          name: Test the "elasticsearch" application bootstrapping
-          command: |
-            bin/ci-ansible-playbook bootstrap.yml "elasticsearch"
-            oc project ci-eugene
-            bin/ci-test-service elasticsearch 9200 "green" /_cluster/health
-
   # Test the delete_app tasks for blue-green applications
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-delete-app:
@@ -798,15 +775,6 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - test-bootstrap-elasticsearch:
-          requires:
-            - lint-bash
-            - lint-docker
-            - lint-ansible
-            - lint-plugins
-          filters:
-            tags:
-              only: /.*/
       - test-delete-app:
           requires:
             - test-bootstrap-richie
@@ -844,7 +812,6 @@ workflows:
             - test-bootstrap-marsha
             - test-bootstrap-forum
             - test-bootstrap-learninglocker
-            - test-bootstrap-elasticsearch
             - test-redirect
             - test-delete-app
             - test-prevent-switch-to-nothing

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - `elasticsearch-discovery` service is not a headless service anymore
+- Generate a valid YAML value from `elasticsearch_memory_lock` variable
 
 
 ## [5.0.0] - 2020-01-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- `elasticsearch-discovery` service is not a headless service anymore
+
+
 ## [5.0.0] - 2020-01-31
 
 ### Added

--- a/apps/elasticsearch/templates/services/app/configs/elasticsearch.yml.j2
+++ b/apps/elasticsearch/templates/services/app/configs/elasticsearch.yml.j2
@@ -4,9 +4,9 @@ cluster.name: {{ elasticsearch_cluster_name }}
 network.host: "0.0.0.0"
 
 {% if elasticsearch_image_tag is version('6.0', '<') %}
-bootstrap.mlockall: {{ elasticsearch_memory_lock }}
+bootstrap.mlockall: {{ elasticsearch_memory_lock | to_yaml }}
 {% else %}
-bootstrap.memory_lock: {{ elasticsearch_memory_lock }}
+bootstrap.memory_lock: {{ elasticsearch_memory_lock | to_yaml }}
 {% endif %}
 
 # Cluster discovery address, to get the peer list.

--- a/apps/elasticsearch/templates/services/app/svc-discovery.yml.j2
+++ b/apps/elasticsearch/templates/services/app/svc-discovery.yml.j2
@@ -12,7 +12,6 @@ metadata:
     # Needed to be compatible with openshift < 3.11
     service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
 spec:
-  clusterIP: None
   # Required for peer discovery.
   # It allows ES nodes to join the cluster and start data synchronization before being declared ready.
   publishNotReadyAddresses: true


### PR DESCRIPTION
## Purpose

3 issues fixed in this PR :

1. Too many false negative in circleCI
2. The `elasticsearch_memory_lock` variable is always considered true by elasticsearch
3. Unable to discover peers on some environments because of DNS caching

## Proposal

1. Remove `test-bootstrap-elasticsearch` test from CircleCI
2. Use lowercase boolean values in `elasticsearch.yml`
3. Use a classic `ClusterIP` kubernetes service instead of a headless service

