### PR TITLE
✅(scripts) add argument to ci-test-route to set the max retries

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -369,8 +369,8 @@ jobs:
             # Bootstrap app
             bin/ci-ansible-playbook bootstrap.yml "edxapp,redis"
             # Test services deployed with the next route
-            bin/ci-test-route "cms" "Welcome to Your Platform Studio" "/" "next"
-            bin/ci-test-route "lms" "It works! This is the default homepage for this Open edX instance." "/" "next"
+            bin/ci-test-route "cms" "Welcome to Your Platform Studio" "/" "next" 20
+            bin/ci-test-route "lms" "It works! This is the default homepage for this Open edX instance." "/" "next" 20
 
       - run:
           name: Test the "edxapp" application switch
@@ -378,8 +378,8 @@ jobs:
             # Switch next route to current
             bin/ci-ansible-playbook switch.yml "edxapp"
             # Test service switched to the current route
-            bin/ci-test-route "cms" "Welcome to Your Platform Studio"
-            bin/ci-test-route "lms" "It works! This is the default homepage for this Open edX instance."
+            bin/ci-test-route "cms" "Welcome to Your Platform Studio" "/" "current" 20
+            bin/ci-test-route "lms" "It works! This is the default homepage for this Open edX instance." "/" "current" 20
 
   # Test the bootstrap playbook on the "edxec" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Add argument to `ci-test-route` to configure the maximum number of retries
+
 ### Fixed
 
 - `elasticsearch-discovery` service is not a headless service anymore

--- a/bin/ci-test-route
+++ b/bin/ci-test-route
@@ -18,6 +18,9 @@ path="${3:-"/"}"
 # Fourth script argument is the prefix used in the url. It defaults to "current".
 prefix="${4:-"current"}"
 
+# Fifth script argument is the maximum number of retry to get the expected response
+max_retry="${5:-"5"}"
+
 # Current URL has by definition no prefix, while next and previous URLs are
 # sub-domains. Hence, we add the sub-domain dot for next and previous prefixes
 # and remove the current prefix for the current URL.
@@ -28,7 +31,7 @@ else
 fi
 
 # Wait for the application to respond
-for try in $(seq 5); do
+for try in $(seq "${max_retry}"); do
   echo "Testing ${service} application http response ($try)"
   curl -vLk --header "Accept: text/html" "https://${prefix}${service}.ci-eugene.${OPENSHIFT_DOMAIN}.nip.io${path}" 2> "/tmp/${service}.err" > "/tmp/${service}.out"
   if grep "HTTP/1.1 200 OK" "/tmp/${service}.err" && grep "${content}" "/tmp/${service}.out"; then


### PR DESCRIPTION
## Purpose

The `ci-test-route`  script has  a hardcoded value  (5) for  the maximum number of retries to get the  expected response from the server before failing. 

This  number  is   too  low  for  the  `test-bootstrap-edxapp` test suite and  generates a lot  of false negative  in the CI.  

## Proposal

- Add a new argument  to the  script to  specify the  maximum number  of retries.

- Increase max_retry to 20 for `test-bootstrap-edxapp` tests
