### PR TITLE
🐛(edxapp) fix image pull policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - `elasticsearch-discovery` service is not a headless service anymore
 - Generate a valid YAML value from `elasticsearch_memory_lock` variable
-
+- Set `edxapp`'s jobs image pull policy to "Always"
 
 ## [5.0.0] - 2020-01-31
 

--- a/apps/edxapp/templates/services/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_dc_base.yml.j2
@@ -134,7 +134,7 @@ spec:
         # container. Please refer to the documentation to better understand our
         # settings generation mecanism.
         - name: init-create-config
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name(service_variant, edxapp_image_tag, edxapp_theme_tag) }}"
           imagePullPolicy: Always
           command:
             - "/bin/bash"

--- a/apps/edxapp/templates/services/cms/job_01_create_directories.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_01_create_directories.yml.j2
@@ -29,6 +29,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          imagePullPolicy: Always
           command:
             - "bash"
             - "-c"

--- a/apps/edxapp/templates/services/cms/job_02_internationalization.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_02_internationalization.yml.j2
@@ -29,6 +29,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run

--- a/apps/edxapp/templates/services/cms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_04_db_migrate.yml.j2
@@ -26,6 +26,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run
@@ -51,7 +52,7 @@ spec:
         # container. Please refer to the documentation to better understand our
         # settings generation mecanism.
         - name: init-create-config
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           imagePullPolicy: Always
           command:
             - "/bin/bash"

--- a/apps/edxapp/templates/services/cms/job_05_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_05_load_fixtures.yml.j2
@@ -27,6 +27,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
+          imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: cms.envs.fun.docker_run
@@ -64,7 +65,7 @@ spec:
         # container. Please refer to the documentation to better understand our
         # settings generation mecanism.
         - name: init-create-config
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           imagePullPolicy: Always
           command:
             - "/bin/bash"

--- a/apps/edxapp/templates/services/lms/job_03_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_03_db_migrate.yml.j2
@@ -26,6 +26,7 @@ spec:
           # We point to a local registry image build for this "live" image (see
           # ImageStream and BuildConfig templates)
           image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('lms', edxapp_image_tag, edxapp_theme_tag) }}"
+          imagePullPolicy: Always
           env:
             - name: DJANGO_SETTINGS_MODULE
               value: lms.envs.fun.docker_run
@@ -51,7 +52,7 @@ spec:
         # container. Please refer to the documentation to better understand our
         # settings generation mecanism.
         - name: init-create-config
-          image: "{{ edxapp_image_name }}:{{ edxapp_image_tag }}"
+          image: "{{ internal_docker_registry }}/{{ project_name }}/{{ image_name('cms', edxapp_image_tag, edxapp_theme_tag) }}"
           imagePullPolicy: Always
           command:
             - "/bin/bash"


### PR DESCRIPTION
## Purpose

Image pull policy was not set to Always so overriding an image with another one with the same name was not possible. 

We can't rely on existing images until we are able to ensure that 2 different image versions never have the same name.

## Proposal

- [x] Set image pull policy to Always
- [x] Use the same image name and tag for init containers so we don't pull 2 identical images
