### PR TITLE
🐛(edxapp) force to create staticfiles directory in bc_collectstatic template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - `elasticsearch-discovery` service is not a headless service anymore
 - Generate a valid YAML value from `elasticsearch_memory_lock` variable
 - Set `edxapp`'s jobs image pull policy to "Always"
+- Force creation of `/edx/app/edxapp/staticfiles` directory in `bc_nginx` build config
 
 ## [5.0.0] - 2020-01-31
 

--- a/apps/edxapp/templates/services/nginx/bc_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/nginx/bc_collectstatic.yml.j2
@@ -33,6 +33,9 @@ spec:
     dockerfile: |-
       FROM {{ edxapp_image_name }}:{{ edxapp_image_tag }}
       USER 0
+      # This directory must be present. Without it the next BC bc_nginx
+      # will fail if no theme is used
+      RUN mkdir -p /edx/app/edxapp/staticfiles
       {% if edxapp_theme_url is defined and edxapp_theme_url -%}
       RUN apt-get update && \
         ( which npm || apt-get install -y npm ) && \


### PR DESCRIPTION
## Purpose

In bc_collectstatic, if no theme is used the pushed image does not have
the directory /edx/app/edxapp/staticfiles created. Without this
directory the `bc_nginx` build config will fail because it tries to
mount this directory.

## Proposal

- [x] create directory `/edx/app/edxapp/staticfiles` in bc_collectstatic template
