### PR TITLE
🐛(elasticsearch) fix elasticsearch configuration template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fix syntax error in elasticsearch configuration file
+
 ## [5.1.0] - 2020-02-27
 
 ### Added

--- a/apps/elasticsearch/templates/services/app/configs/elasticsearch.yml.j2
+++ b/apps/elasticsearch/templates/services/app/configs/elasticsearch.yml.j2
@@ -4,9 +4,9 @@ cluster.name: {{ elasticsearch_cluster_name }}
 network.host: "0.0.0.0"
 
 {% if elasticsearch_image_tag is version('6.0', '<') %}
-bootstrap.mlockall: {{ elasticsearch_memory_lock | to_yaml }}
+bootstrap.mlockall: {{ elasticsearch_memory_lock | lower }}
 {% else %}
-bootstrap.memory_lock: {{ elasticsearch_memory_lock | to_yaml }}
+bootstrap.memory_lock: {{ elasticsearch_memory_lock | lower }}
 {% endif %}
 
 # Cluster discovery address, to get the peer list.


### PR DESCRIPTION
## Purpose

The commit e295e07f37b1e0d36f4d60cd4b12d1f09e03ad5d introduced a syntax error in elasticsearch configuration file, due to the usage of the `to_yaml` filter. As a result, the configuration directives are ignored by elasticsearch.

Here is an example of a faulty generated configuration file (see the `...` line added by the to_yaml filter after `bootstrap.mlockall: false`)

```
cluster.name: elasticsearch-cluster

# Bind address (listen to all interfaces)
network.host: "0.0.0.0"

bootstrap.mlockall: false
...


# Cluster discovery address, to get the peer list.
# This is a kubernetes service that target every ES running nodes, even if they
# are not ready yet.
discovery.zen.ping.unicast.hosts: elasticsearch-discovery.staging-fun.svc

discovery.zen.minimum_master_nodes: 2

# Security features are disabled by default on ES basic and trial licenses
xpack.security.enabled: false

# Monitoring is not supported in this arnold application yet
xpack.monitoring.enabled: false
```


## Proposal

Use ` | lower`  instead of `| to_yaml` to add lowercase boolean values to the configuration file.