### PR TITLE
Fix redis configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix syntax error in elasticsearch configuration file
+- Configure the `redis` container to listen to all network interfaces
 
 ## [5.1.0] - 2020-02-27
 

--- a/apps/redis/templates/services/app/configs/app.conf.j2
+++ b/apps/redis/templates/services/app/configs/app.conf.j2
@@ -66,7 +66,9 @@
 # IF YOU ARE SURE YOU WANT YOUR INSTANCE TO LISTEN TO ALL THE INTERFACES
 # JUST COMMENT THE FOLLOWING LINE.
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-bind 127.0.0.1
+# Since we are running redis in a container orchestrated in a k8s context, we
+# need to listen to all network interfaces.
+bind *
 
 # Protected mode is a layer of security protection, in order to avoid that
 # Redis instances left open on the internet are accessed and exploited.

--- a/apps/redis/templates/services/app/dc.yml.j2
+++ b/apps/redis/templates/services/app/dc.yml.j2
@@ -28,6 +28,9 @@ spec:
           command:
             - "redis-server"
             - "/config/redis/app.conf"
+          ports:
+            - containerPort: 6379
+              protocol: TCP
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
## Purpose

We recently had a configuration file for `redis` but we didn't test it extensively... Current configuration only listen to `localhost` and the service could not be joined from another service.

## Proposal

- [x] configure `redis` to listen to all interfaces
- [x] explicitly declare `redis` container port
