### PR TITLE
✨(apps) add nginx status endpoint in arnold applications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - New `nextcloud` application
+- Add nginx status endpoint in `ashley`, `edxapp`, `edxec`, `flower`,
+  `learninglocker`, `marsha`, `nextcloud` and `richie`.
 
 ## [5.3.0] - 2020-03-31
 

--- a/apps/ashley/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/ashley/templates/services/nginx/configs/healthcheck.conf.j2
@@ -7,4 +7,8 @@ server {
     access_log off;
     return 200 "OK";
   }
+
+  location {{ ashley_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/ashley/vars/all/main.yml
+++ b/apps/ashley/vars/all/main.yml
@@ -11,6 +11,7 @@ ashley_nginx_replicas: 1
 ashley_nginx_htpasswd_secret_name: "ashley-htpasswd"
 ashley_nginx_healthcheck_port: 5000
 ashley_nginx_healthcheck_endpoint: "/__healthcheck__"
+ashley_nginx_status_endpoint: "/__status__"
 ashley_nginx_admin_ip_withelist: []
 ashley_nginx_bypass_htaccess_ip_whitelist: []
 ashley_nginx_static_cache_expires: "1M"

--- a/apps/edxapp/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,8 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ edxapp_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -106,6 +106,7 @@ edxapp_nginx_replicas: 1
 edxapp_nginx_htpasswd_secret_name: "edxapp-htpasswd"
 edxapp_nginx_healthcheck_port: 5000
 edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
+edxapp_nginx_status_endpoint: "/__status__"
 edxapp_routing_timeout: "60s"
 edxapp_nginx_cms_admin_ip_withelist: []
 edxapp_nginx_cms_bypass_htaccess_ip_whitelist: []

--- a/apps/edxec/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,8 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ edxec_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -21,6 +21,7 @@ edxec_nginx_replicas: 1
 edxec_nginx_htpasswd_secret_name: "edxec-htpasswd"
 edxec_nginx_healthcheck_port: 5000
 edxec_nginx_healthcheck_endpoint: "/__healthcheck__"
+edxec_nginx_status_endpoint: "/__status__"
 edxec_nginx_admin_ip_withelist: []
 edxec_nginx_bypass_htaccess_ip_whitelist: []
 edxec_nginx_static_cache_expires: "1M"

--- a/apps/flower/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/flower/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,8 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ flower_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/flower/vars/all/main.yml
+++ b/apps/flower/vars/all/main.yml
@@ -5,6 +5,7 @@ flower_nginx_image_name: "fundocker/openshift-nginx"
 flower_nginx_image_tag: "1.13"
 flower_nginx_healthcheck_port: 5000
 flower_nginx_healthcheck_endpoint: "/__healthcheck__"
+flower_nginx_status_endpoint: "/__status__"
 flower_nginx_app_port: 8091
 flower_nginx_app_ip_whitelist: []
 

--- a/apps/learninglocker/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/learninglocker/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,8 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ learninglocker_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -39,6 +39,7 @@ learninglocker_nginx_image_tag: "1.13"
 learninglocker_nginx_port: 8888
 learninglocker_nginx_healthcheck_port: 5000
 learninglocker_nginx_healthcheck_endpoint: "/__healthcheck__"
+learninglocker_nginx_status_endpoint: "/__status__"
 learninglocker_nginx_replicas: 1
 
 # -- volumes

--- a/apps/marsha/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,9 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ marsha_nginx_status_endpoint }} {
+     stub_status;
+  }
+
 }

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -11,6 +11,7 @@ marsha_nginx_replicas: 1
 marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 marsha_nginx_healthcheck_port: 5000
 marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
+marsha_nginx_status_endpoint: "/__status__"
 marsha_nginx_admin_ip_withelist: []
 marsha_nginx_bypass_htaccess_ip_whitelist: []
 marsha_nginx_static_cache_expires: "1M"

--- a/apps/nextcloud/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/nextcloud/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,8 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ nextcloud_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/nextcloud/vars/all/main.yml
+++ b/apps/nextcloud/vars/all/main.yml
@@ -11,6 +11,7 @@ nextcloud_nginx_replicas: 1
 nextcloud_nginx_htpasswd_secret_name: "nextcloud-htpasswd"
 nextcloud_nginx_healthcheck_port: 5000
 nextcloud_nginx_healthcheck_endpoint: "/__healthcheck__"
+nextcloud_nginx_status_endpoint: "/__status__"
 nextcloud_nginx_ip_withelist: []
 nextcloud_nginx_static_cache_expires: "1M"
 nextcloud_nginx_root: "/app"

--- a/apps/richie/templates/services/nginx/configs/healthcheck.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/healthcheck.conf.j2
@@ -6,4 +6,8 @@ server {
     add_header Content-Type text/plain;
     return 200 "OK";
   }
+
+  location {{ richie_nginx_status_endpoint }} {
+     stub_status;
+  }
 }

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -11,6 +11,7 @@ richie_nginx_replicas: 1
 richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 richie_nginx_healthcheck_port: 5000
 richie_nginx_healthcheck_endpoint: "/__healthcheck__"
+richie_nginx_status_endpoint: "/__status__"
 richie_nginx_admin_ip_withelist: []
 richie_nginx_bypass_htaccess_ip_whitelist: []
 richie_nginx_static_cache_expires: "1M"


### PR DESCRIPTION
## Purpose

We want to inpect nginx metrics on running applications.

## Proposal

Add a `/__status__` endpoint that use the [ngx_http_stub_status_module](https://nginx.org/libxslt/en/docs/http/ngx_http_stub_status_module.html) to display a simple status page.

This endpoint is only accessible on the healtcheck port of nginx.

The following arnold applications have been updated :
 - [x] ashley
 - [x] edxapp
 - [x] edxec
 - [x] flower
 - [x] learninglocker
 - [x] marsha
 - [x] nextcloud
 - [x] richie
