### PR TITLE
✨(learninglocker) configure and use pm2 to run learninglocker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add nginx status endpoint in `ashley`, `edxapp`, `edxec`, `flower`,
   `learninglocker`, `marsha`, `nextcloud` and `richie`.
 
+### Changed
+
+- Run learninglocker using pm2 process manager
+
 ## [5.3.0] - 2020-03-31
 
 ### Added

--- a/apps/learninglocker/templates/services/app/_dc_base.yml.j2
+++ b/apps/learninglocker/templates/services/app/_dc_base.yml.j2
@@ -32,7 +32,7 @@ spec:
             - containerPort: "{{ learninglocker_port }}"
               protocol: TCP
 {% endif %}
-          command: ["node", "{{ learninglocker_command }}"]
+          command: ["pm2-runtime", "/usr/local/etc/pm2/config.d/ecosystem.config.js", "--only", "{{ learninglocker_pm2_app }}"]
           envFrom:
             - secretRef:
                 name: "{{ learninglocker_secret_name }}"
@@ -41,10 +41,26 @@ spec:
           env:
             - name: MONGODB_PATH
               value: "{{ mongodb_uri(env_type, trashable_env_types, learninglocker_mongodb_host, deployment_stamp, learninglocker_endpoint_mongodb_ips, learninglocker_mongodb_replicaset, learninglocker_mongodb_read_preference) }}"
+            # PM2 creates files and directories in the user's HOME. By default the user's HOME is `/`
+            # and obviously it's not possible for an unprivileged user to write to the `/` directory.
+            # PM2 will work as expected after changing the `HOME` environment variable to a
+            # directory the user can write to.
+            - name: HOME
+              value: /home/pm2_user
           volumeMounts:
             - name: learninglocker-v-storage
               mountPath: /app/storage
+            - name: learninglocker-configmap
+              mountPath: /usr/local/etc/pm2/config.d
+            - name: pm2-homedir
+              mountPath: /home/pm2_user
       volumes:
         - name: learninglocker-v-storage
           persistentVolumeClaim:
             claimName: learninglocker-pvc-storage
+        - name: learninglocker-configmap
+          configMap:
+            defaultMode: 420
+            name: learninglocker-app-{{ deployment_stamp }}
+        - name: pm2-homedir
+          emptyDir: {}  # volume that lives as long as the pod lives

--- a/apps/learninglocker/templates/services/app/_dc_base.yml.j2
+++ b/apps/learninglocker/templates/services/app/_dc_base.yml.j2
@@ -23,6 +23,19 @@ spec:
         version: "{{ learninglocker_image_tag }}"
         deploymentconfig: "{{ dc_name }}-{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: deploymentconfig
+                      operator: In
+                      values:
+                        - "{{ dc_name }}-{{ deployment_stamp }}"
+                topologyKey: kubernetes.io/hostname
       containers:
         - name: "{{ service_variant }}"
           image: "{{ learninglocker_image_name }}:{{ learninglocker_image_tag }}"

--- a/apps/learninglocker/templates/services/app/configs/ecosystem.config.js.j2
+++ b/apps/learninglocker/templates/services/app/configs/ecosystem.config.js.j2
@@ -1,0 +1,19 @@
+module.exports = [{
+  cwd: '/app',
+  exec_mode: 'cluster',
+  instances: {{ learninglocker_api_pm2_instances }},
+  name: 'api',
+  script: 'api/dist/server'
+}, {
+  cwd: '/app',
+  exec_mode: 'cluster',
+  instances: {{ learninglocker_ui_pm2_instances }},
+   name: 'ui',
+  script: 'ui/dist/server'
+}, {
+  cwd: '/app',
+  exec_mode: 'fork',
+  instances: {{ learninglocker_worker_pm2_instances }},
+  name: 'worker',
+  script: 'worker/dist/server'
+}];

--- a/apps/learninglocker/templates/services/app/dc_api.yml.j2
+++ b/apps/learninglocker/templates/services/app/dc_api.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "api" %}
-{% set learninglocker_command = "api/dist/server" %}
+{% set learninglocker_pm2_app = "api" %}
 {% set learninglocker_port = learninglocker_api_port %}
 {% set learninglocker_replicas = learninglocker_api_replicas %}
 

--- a/apps/learninglocker/templates/services/app/dc_ui.yml.j2
+++ b/apps/learninglocker/templates/services/app/dc_ui.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "ui" %}
-{% set learninglocker_command = "ui/dist/server" %}
+{% set learninglocker_pm2_app = "ui" %}
 {% set learninglocker_port = learninglocker_ui_port %}
 {% set learninglocker_replicas = learninglocker_ui_replicas %}
 

--- a/apps/learninglocker/templates/services/app/dc_worker.yml.j2
+++ b/apps/learninglocker/templates/services/app/dc_worker.yml.j2
@@ -1,5 +1,5 @@
 {% set service_variant = "worker" %}
-{% set learninglocker_command = "worker/dist/server" %}
+{% set learninglocker_pm2_app = "worker" %}
 {% set learninglocker_replicas = learninglocker_worker_replicas %}
 
 {% include "apps/learninglocker/templates/services/app/_dc_base.yml.j2" with context %}

--- a/apps/learninglocker/templates/services/xapi/configs/ecosystem.config.js.j2
+++ b/apps/learninglocker/templates/services/xapi/configs/ecosystem.config.js.j2
@@ -1,0 +1,7 @@
+module.exports = [{
+  cwd: '/app',
+  exec_mode: 'cluster',
+  instances: {{ learninglocker_xapi_pm2_instances }},
+  name: 'xapi',
+  script: 'dist/server.js'
+}]

--- a/apps/learninglocker/templates/services/xapi/dc.yml.j2
+++ b/apps/learninglocker/templates/services/xapi/dc.yml.j2
@@ -21,6 +21,19 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
         deploymentconfig: "learninglocker-xapi-{{ deployment_stamp }}"
     spec:
+      # Prefer running pods on different nodes for redundancy
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: deploymentconfig
+                      operator: In
+                      values:
+                        - "learninglocker-xapi-{{ deployment_stamp }}"
+                topologyKey: kubernetes.io/hostname
       containers:
         - image: "{{ learninglocker_xapi_image_name }}:{{ learninglocker_xapi_image_tag }}"
           imagePullPolicy: Always

--- a/apps/learninglocker/templates/services/xapi/dc.yml.j2
+++ b/apps/learninglocker/templates/services/xapi/dc.yml.j2
@@ -25,6 +25,7 @@ spec:
         - image: "{{ learninglocker_xapi_image_name }}:{{ learninglocker_xapi_image_tag }}"
           imagePullPolicy: Always
           name: nginx
+          command: ["pm2-runtime", "/usr/local/etc/pm2/config.d/ecosystem.config.js", "--only", "xapi"]
           ports:
             - containerPort: "{{ learninglocker_xapi_port }}"
               protocol: TCP
@@ -36,9 +37,25 @@ spec:
           env:
             - name: MONGO_URL
               value: "{{ mongodb_uri(env_type, trashable_env_types, learninglocker_mongodb_host, deployment_stamp, learninglocker_endpoint_mongodb_ips, learninglocker_mongodb_replicaset, learninglocker_mongodb_read_preference) }}"
+            # PM2 creates files and directories in the user's HOME. By default the user's HOME is `/`
+            # and obviously it's not possible for an unprivileged user to write to the `/` directory.
+            # PM2 will work as expected after changing the `HOME` environment variable to a
+            # directory the user can write to.
+            - name: HOME
+              value: /home/pm2_user
           volumeMounts:
+            - name: learninglocker-xapi-configmap
+              mountPath: /usr/local/etc/pm2/config.d
             - name: learninglocker-xapi-storage
               mountPath: /app/storage
+            - name: pm2-homedir
+              mountPath: /home/pm2_user
       volumes:
+        - name: learninglocker-xapi-configmap
+          configMap:
+            defaultMode: 420
+            name: learninglocker-xapi-{{ deployment_stamp }}
         - name: learninglocker-xapi-storage
           emptyDir: {}
+        - name: pm2-homedir
+          emptyDir: {}  # volume that lives as long as the pod lives

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -5,22 +5,26 @@ learninglocker_host: "learninglocker.{{ project_name}}.{{ domain_name }}"
 
 # -- learninglocker
 learninglocker_image_name: "fundocker/learninglocker"
-learninglocker_image_tag: "v5.2.2"
+learninglocker_image_tag: "v6.2.2"
 learninglocker_secret_name: "learninglocker-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 learninglocker_ui_port: 3000
 learninglocker_api_port: 8080
 learninglocker_api_replicas: 1
 learninglocker_worker_replicas: 1
 learninglocker_ui_replicas: 1
+learninglocker_api_pm2_instances: 2
+learninglocker_ui_pm2_instances: 2
+learninglocker_worker_pm2_instances: 2
 learninglocker_nginx_admin_ip_withelist: []
 
 
 # -- xapi
 learninglocker_xapi_image_name: "fundocker/xapi-service"
-learninglocker_xapi_image_tag: "v2.9.10"
+learninglocker_xapi_image_tag: "v3.6.1"
 learninglocker_xapi_port: 8081
 learninglocker_xapi_secret_name: "learninglocker-xapi-{{ learninglocker_vault_checksum | default('undefined_learninglocker_vault_checksum') }}"
 learninglocker_xapi_replicas: 1
+learninglocker_xapi_pm2_instances: 2
 
 # -- monogodb
 learninglocker_mongodb_version: "3.2"


### PR DESCRIPTION
## Purpose

Recent docker images of learninglocker have [PM2](https://pm2.keymetrics.io/) installed.

We want to use this process manager in Arnold. For each service we created a configuration file containing information on how to run each application.

Also PM2 writes files and directories to the user's HOME, but by default in OpenShift, the HOME environment variable is set to `/` which is obviously not writable for an un-privileged user.

We need to set this variable to a directory the user can write to.

## Proposal

- [x] create a configuration file for each service
- [x] change DC command to run `pm2-runtime`

