### PR TITLE
🔧(nextcloud) remove app skeleton in BuildConfig

### DIFF
--- a/apps/nextcloud/templates/services/app/bc.yml.j2
+++ b/apps/nextcloud/templates/services/app/bc.yml.j2
@@ -16,6 +16,10 @@ spec:
       FROM {{ nextcloud_image_name }}:{{ nextcloud_image_tag }}
       USER 0
 
+      # Remove skeleton content to create an empty directory
+      # when a user is created
+      RUN rm -rf /app/core/skeleton/*
+
       RUN chown -R {{ nextcloud_user_id }}:root /app && \
           chown {{ nextcloud_user_id }}:root /install.sh
         


### PR DESCRIPTION
## Purpose

The app contains a skeleton used when a new user is created. This
skeleton is used to create demonstration files and we don't want them.
Moreover removing them increase the performace when a user is created
from SAML provider.

## Proposal

- [x] remove skeleton in the BuildConfig