### PR TITLE
[Nextcloud] Change scripts path and create .ocdata file in data directory

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -543,7 +543,8 @@ jobs:
             sed -i -e "s/REPLACE_USER_ID/$USER_ID/g" group_vars/customer/eugene/ci/main.yml
             bin/build
 
-      # Once deployed, we need to manually run the upgrade command because some dependencies have to be updated.
+      # Once deployed, we need to turn off the maintenance mode in case it is still enabled once
+      # the upgrade command run in the entrypoint.
       - run:
           name: Test the "nextcloud" application bootstrapping
           command: |
@@ -552,7 +553,7 @@ jobs:
             bin/ci-ansible-playbook deploy.yml "redis,mailcatcher,nextcloud"
             oc project ci-eugene
             oc exec -it $(oc get pod -l 'app in (nextcloud),service in (nextcloud),!job_stamp' -o json | jq -r '.items[0].metadata.name') \
-              -- /bin/bash -c 'php /app/occ upgrade && php /app/occ maintenance:mode --off'
+              -- php /app/occ maintenance:mode --off
             bin/ci-test-route "nextcloud" "Nextcloud" "/login" "next" 20
 
       - run:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## Changed
+
+- Update `nextcloud` app scripts path to: `/usr/local/bin`
+
+## Fixed
+
+- Create `.ocdata` file in the `data` directory for the Nextcloud image
+
 ## [5.4.0] - 2020-04-03
 
 ### Added

--- a/apps/nextcloud/templates/services/app/bc.yml.j2
+++ b/apps/nextcloud/templates/services/app/bc.yml.j2
@@ -10,7 +10,9 @@ metadata:
     deployment_stamp: "{{ deployment_stamp }}"
 spec:
   strategy:
-    type: Docker
+    dockerStrategy:
+      noCache: true
+      forcePull: true
   source:
     dockerfile: |-
       FROM {{ nextcloud_image_name }}:{{ nextcloud_image_tag }}

--- a/apps/nextcloud/templates/services/app/bc.yml.j2
+++ b/apps/nextcloud/templates/services/app/bc.yml.j2
@@ -26,6 +26,9 @@ spec:
           chown {{ nextcloud_user_id }}:root /usr/local/bin/install.sh
 
       USER {{ nextcloud_user_id }}
+
+      # Nextcloud warn us if this file doesn't exists and the pod stays in CrashLoopBackOff
+      RUN touch {{ nextcloud_base_dir }}/data/.ocdata
   triggers:
     - type: "ConfigChange"
   output:

--- a/apps/nextcloud/templates/services/app/bc.yml.j2
+++ b/apps/nextcloud/templates/services/app/bc.yml.j2
@@ -20,9 +20,9 @@ spec:
       # when a user is created
       RUN rm -rf /app/core/skeleton/*
 
-      RUN chown -R {{ nextcloud_user_id }}:root /app && \
-          chown {{ nextcloud_user_id }}:root /install.sh
-        
+      RUN chown -R {{ nextcloud_user_id }}:root {{ nextcloud_base_dir }} && \
+          chown {{ nextcloud_user_id }}:root /usr/local/bin/install.sh
+
       USER {{ nextcloud_user_id }}
   triggers:
     - type: "ConfigChange"

--- a/apps/nextcloud/templates/services/app/job_01_install.yml.j2
+++ b/apps/nextcloud/templates/services/app/job_01_install.yml.j2
@@ -38,7 +38,7 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-            - /entrypoint.sh /install.sh
+            - entrypoint.sh install.sh
           volumeMounts:
             - name: nextcloud-v-install
               mountPath: /tmp/nextcloud  


### PR DESCRIPTION
## Purpose

We choose to change were scripts are leaving in our base image (`fundocker/nextcloud`) and copy them in `/usr/loca/bin`. This change must be reflected in Arnold
We also have a new bug, if the `.ocdata` file doesn't exist in the `data` directory, the application raises an exception and it's impossible to use it.
Also to be sure to still have a fresh image we choose to remove cache and force to pull image in the BuildConfig


## Proposal

- [x] change sctiprs path
- [x] create `.ocdata` file in `data` directory
- [x] disable cache and force to pull image in the `BuildConfig`