### PR TITLE
🐛(edxapp) fix nginx collectstatic BC theme support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Fixed
 
 - Create `.ocdata` file in the `data` directory for the Nextcloud image
+- Restore `edxapp` custom theme support (front-end translations in `nginx`
+  collectstatic BC)
 
 ## [5.4.0] - 2020-04-03
 

--- a/apps/edxapp/templates/services/nginx/bc_collectstatic.yml.j2
+++ b/apps/edxapp/templates/services/nginx/bc_collectstatic.yml.j2
@@ -43,8 +43,8 @@ spec:
         rm -rf /var/lib/apt/lists/*
       COPY . /edx/app/edxapp/edx-platform/themes/custom-theme
       {% if edxapp_should_update_i18n -%}
-      RUN python manage.py lms compilejsi18n && \
-          python manage.py cms compilejsi18n
+      RUN python manage.py lms compilejsi18n --settings={{ edxapp_build_settings }} && \
+          python manage.py cms compilejsi18n --settings={{ edxapp_build_settings }}
       {% endif -%}
       # Note that we also collect statics here.
       RUN NO_PREREQ_INSTALL=1 paver update_assets --settings={{ edxapp_build_settings }}


### PR DESCRIPTION
## Purpose

The `edxapp` `nginx` collecstatic BC is broken while activating a custom theme.

## Proposal

When invoking a Django management command in a BuildConfig, one need to explictly specify the `--settings` option to override edxapp default ones (aws).
