### PR TITLE
🐛(nextcloud) use nextcloud image built by our BC in the Nginx InitContainer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Create `.ocdata` file in the `data` directory for the Nextcloud image
 - Restore `edxapp` custom theme support (front-end translations in `nginx`
   collectstatic BC)
+- Use nextcloud image built by our BC in the Nginx InitContainer
 
 ## [5.4.0] - 2020-04-03
 

--- a/apps/nextcloud/templates/services/nginx/dc.yml.j2
+++ b/apps/nextcloud/templates/services/nginx/dc.yml.j2
@@ -64,7 +64,7 @@ spec:
             periodSeconds: 5
 
       initContainers:
-        - image: "{{ nextcloud_image_name }}:{{ nextcloud_image_tag }}"
+        - image: "{{ internal_docker_registry }}/{{ project_name }}/nextcloud:{{ nextcloud_image_tag }}"
           name: init-copy-src
           imagePullPolicy: Always
           command:


### PR DESCRIPTION
## Purpose

Nextcloud apps can be added in our BC, we have to use this image in
order to copy all assets needed by the application.

## Proposal

- [x] use nextcloud image built by our BC in the Nginx InitContainer
