### PR TITLE
👷(circle) enable nextcloud hub dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -959,8 +959,7 @@ workflows:
             - test-bootstrap-forum
             - test-bootstrap-learninglocker
             - test-bootstrap-ashley
-            # FIXME: this job is broken and prevent any release.
-            # - test-bootstrap-nextcloud
+            - test-bootstrap-nextcloud
             - test-bootstrap-etherpad
             - test-redirect
             - test-delete-app


### PR DESCRIPTION
## Purpose

The nextcloud job is working as expected, we can enable it in the hub
dependency

## Proposal

- [x] enable `nextcloud` job as `hub` dependency
