### PR TITLE
🔧(learninglocker) improve pm2 logs configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Upgrade `openshift` to `0.11.0`
 
+### Fixed
+
+- Improve pm2 logs configuration for the `learninglocker` application
+
 ## [5.5.0] - 2020-04-09
 
 ## Added

--- a/apps/learninglocker/templates/services/app/configs/ecosystem.config.js.j2
+++ b/apps/learninglocker/templates/services/app/configs/ecosystem.config.js.j2
@@ -3,17 +3,29 @@ module.exports = [{
   exec_mode: 'cluster',
   instances: {{ learninglocker_api_pm2_instances }},
   name: 'api',
-  script: 'api/dist/server'
+  script: 'api/dist/server',
+  log_date_format: 'YYYY-MM-DD HH:mm Z',
+  combine_logs: true,
+  error_file: '/dev/stderr',
+  out_file: '/dev/stderr'
 }, {
   cwd: '/app',
   exec_mode: 'cluster',
   instances: {{ learninglocker_ui_pm2_instances }},
-   name: 'ui',
-  script: 'ui/dist/server'
+  name: 'ui',
+  script: 'ui/dist/server',
+  log_date_format: 'YYYY-MM-DD HH:mm Z',
+  combine_logs: true,
+  error_file: '/dev/stderr',
+  out_file: '/dev/stderr'
 }, {
   cwd: '/app',
   exec_mode: 'fork',
   instances: {{ learninglocker_worker_pm2_instances }},
   name: 'worker',
-  script: 'worker/dist/server'
+  script: 'worker/dist/server',
+  log_date_format: 'YYYY-MM-DD HH:mm Z',
+  combine_logs: true,
+  error_file: '/dev/stderr',
+  out_file: '/dev/stderr'
 }];

--- a/apps/learninglocker/templates/services/xapi/configs/ecosystem.config.js.j2
+++ b/apps/learninglocker/templates/services/xapi/configs/ecosystem.config.js.j2
@@ -3,5 +3,9 @@ module.exports = [{
   exec_mode: 'cluster',
   instances: {{ learninglocker_xapi_pm2_instances }},
   name: 'xapi',
-  script: 'dist/server.js'
+  script: 'dist/server.js',
+  log_date_format: 'YYYY-MM-DD HH:mm Z',
+  combine_logs: true,
+  error_file: '/dev/stderr',
+  out_file: '/dev/stderr'
 }]


### PR DESCRIPTION
## Purpose

Until now, only error messages were displayed in running container logs and standard logs were redirected to flat files in pm2 user's home directory.  Moreover, error logs had no date/time associated. Hence we decided to merge error and output logs and redirect them to `stderr` with an associated standard log date format.

## Proposal

We decided to merge error and output logs and redirect them to `stderr` with an associated standard log date format.

- [x] fix pm2 log configuration for all learning locker services
