### PR TITLE
⚡️(etherpad) implement reliable health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade `openshift` to `0.11.0`
+- Use lightship-based health checks for the `etherpad` application (requires a
+  recent `fundocker/etherpad` docker image; at least `1.8.0-education-1.2.0`).
 
 ### Fixed
 

--- a/apps/etherpad/templates/services/app/_env.yml.j2
+++ b/apps/etherpad/templates/services/app/_env.yml.j2
@@ -1,13 +1,15 @@
-TITLE: {{ etherpad_title }}
-FAVICON: {{ etherpad_favicon }}
-SKIN_NAME: {{ etherpad_skin_name }}
-IP: "0.0.0.0"
-PORT: "{{ etherpad_application_port }}"
-DB_TYPE: {{ etherpad_database_engine }}
-DB_HOST: etherpad-postgresql-{{ deployment_stamp }}
-DB_PORT: "{{ etherpad_database_port }}"
-DB_NAME: {{ etherpad_database_name }}
-TRUST_PROXY: "true"
-LOGLEVEL: {{ etherpad_loglevel }}
 APIKEY: "{{ etherpad_private_directory_path }}/APIKEY.txt"
+DB_HOST: etherpad-postgresql-{{ deployment_stamp }}
+DB_NAME: {{ etherpad_database_name }}
+DB_PORT: "{{ etherpad_database_port }}"
+DB_TYPE: {{ etherpad_database_engine }}
+EP_LIGHTSHIP_DETECT_KUBERNETES: "true"
+EP_LIGHTSHIP_PORT: "{{ etherpad_app_healthcheck_port }}"
+FAVICON: {{ etherpad_favicon }}
+IP: "0.0.0.0"
+LOGLEVEL: {{ etherpad_loglevel }}
+PORT: "{{ etherpad_application_port }}"
 SESSIONKEY: "{{ etherpad_private_directory_path }}/SESSIONKEY.txt"
+SKIN_NAME: {{ etherpad_skin_name }}
+TITLE: {{ etherpad_title }}
+TRUST_PROXY: "true"

--- a/apps/etherpad/templates/services/app/dc.yml.j2
+++ b/apps/etherpad/templates/services/app/dc.yml.j2
@@ -45,16 +45,26 @@ spec:
                 --apikey "{{ etherpad_private_directory_path }}/APIKEY.txt"
           livenessProbe:
             httpGet:
-              path: /
-              port: {{ etherpad_application_port }}
-            initialDelaySeconds: 30
-            periodSeconds: 10
+              path: {{ etherpad_app_healthcheck_live_endpoint }}
+              port: {{ etherpad_app_healthcheck_port }}
+            failureThreshold: 3
+            initialDelaySeconds: 10
+            # Allow sufficient amount of time (90 seconds = periodSeconds * failureThreshold)
+            # for the registered shutdown handlers to run to completion.
+            periodSeconds: 30
+            successThreshold: 1
+            # Setting a very low timeout value (e.g. 1 second) can cause false-positive
+            # checks and service interruption.
+            timeoutSeconds: 5
           readinessProbe:
             httpGet:
-              path: /
-              port: {{ etherpad_application_port }}
+              path: {{ etherpad_app_healthcheck_ready_endpoint }}
+              port: {{ etherpad_app_healthcheck_port }}
+            failureThreshold: 3
             initialDelaySeconds: 5
             periodSeconds: 5
+            successThreshold: 1
+            timeoutSeconds: 5
           envFrom:
             - secretRef:
                 name: "{{ etherpad_env_secret_name }}"

--- a/apps/etherpad/vars/all/main.yml
+++ b/apps/etherpad/vars/all/main.yml
@@ -35,6 +35,9 @@ etherpad_file_secret_name: "etherpad-file-{{ etherpad_vault_checksum | default('
 etherpad_activate_http_basic_auth: false
 etherpad_configs_directory_path: "/app/configs"
 etherpad_private_directory_path: "/app/private"
+etherpad_app_healthcheck_port: 9002
+etherpad_app_healthcheck_live_endpoint: "/live"
+etherpad_app_healthcheck_ready_endpoint: "/ready"
 
 # Configuration
 #


### PR DESCRIPTION
## Purpose

Now that lightship has been integrated in our Docker image [1], liveness and readyness probes could be implemented consequently.

[1] https://github.com/openfun/etherpad-docker/commit/697b2e368b1cd9ea6921e2ea9c4140d481cd1e80

## Proposal

- [x] use lightship endpoints as health check probes

Fix #489 