### PR TITLE
✨(core) add support for generic ConfigMap templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Implemented support for generic ConfigMap templates
+
 ### Changed
 
 - Upgrade `ansible` to `2.9.7`

--- a/tasks/create_app_config.yml
+++ b/tasks/create_app_config.yml
@@ -7,6 +7,15 @@
 # [1] https://docs.okd.io/latest/dev_guide/configmaps.html#configmaps-use-case-consuming-in-volumes
 # [2] https://docs.okd.io/latest/dev_guide/configmaps.html#configmaps-use-case-consuming-in-env-vars
 
+################# Generic ConfigMaps #######################
+- name: Create generic config maps
+  k8s:
+    definition: "{{ lookup('template', item) | from_yaml }}"
+    state: present
+  with_items: "{{ configmaps }}"
+  when: configmaps is defined
+  tags: configmap
+
 ################# ConfigMaps used in a volume #######################
 
 # Select services with ConfigMaps
@@ -31,21 +40,21 @@
 # }
 - name: Format configMaps
   set_fact:
-    configmaps: |
-      {%- set configmaps = {} -%}
+    configmaps_from_files: |
+      {%- set configmaps_from_files = {} -%}
       {%- for service in app_configmaps -%}
-        {%- set _ = configmaps.update({ service.name: {} }) -%}
+        {%- set _ = configmaps_from_files.update({ service.name: {} }) -%}
         {%- for cm_path in service.configs -%}
           {%- set content = lookup('template', cm_path, convert_data = False) -%}
           {%- set filename = cm_path | basename | regex_replace('.j2') -%}
-          {%- set _ = configmaps.get(service.name).update({filename: content}) -%}
+          {%- set _ = configmaps_from_files.get(service.name).update({filename: content}) -%}
         {%- endfor -%}
       {%- endfor -%}
-      {{ configmaps }}
+      {{ configmaps_from_files }}
 
 - name: Display config maps
   debug:
-    var: configmaps
+    var: configmaps_from_files
     verbosity: 3
 
 - name: Create the config maps in OpenShift
@@ -62,7 +71,7 @@
           service: "{{ item.key }}"
           deployment_stamp: "{{ deployment_stamp | default('N/A') }}"
       data: "{{ item.value }}"
-  with_dict: "{{ configmaps }}"
+  with_dict: "{{ configmaps_from_files }}"
 
 ################# ConfigMaps used to populate environment variables #######################
 

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -15,6 +15,7 @@
 - name: Set OpenShift objects to manage
   set_fact:
     builds: "{{ templates | map('regex_search', '.*/bc.*\\.yml\\.j2$') | select('string') | list }}"
+    configmaps: "{{ templates | map('regex_search', '.*/cm.*\\.yml\\.j2$') | select('string') | list }}"
     deployments: "{{ templates | map('regex_search', '.*/dc.*\\.yml\\.j2$') | select('string') | list }}"
     endpoints: "{{ templates | map('regex_search', '.*/ep.*\\.yml\\.j2$') | select('string') | list }}"
     services: "{{ templates | map('regex_search', '.*/svc.*\\.yml\\.j2$') | select('string') | list }}"
@@ -23,14 +24,15 @@
     cronjobs: "{{ templates | map('regex_search', '.*/cronjob_.*\\.yml\\.j2$') | select('string') | list }}"
     routes: "{{ templates | map('regex_search', '.*/route.*\\.yml\\.j2$') | select('string') | list }}"
   tags:
-    - deploy
     - build
+    - configmap
+    - deploy
     - deployment
     - endpoint
-    - service
-    - stream
     - job
     - route
+    - service
+    - stream
 
 - name: Display OpenShift's builds for this app
   debug:
@@ -40,6 +42,15 @@
   tags:
     - deploy
     - build
+
+- name: Display OpenShift's configmaps for this app
+  debug:
+    var: configmaps
+    verbosity: 2
+  when: configmaps is defined
+  tags:
+    - deploy
+    - configmap
 
 - name: Display OpenShift's deployments for this app
   debug:


### PR DESCRIPTION
## Purpose

Automagic ConfigMap generation is a useful feature to ease their creation from files that will be used mounted as volumes, but we need more flexibility by also allowing the creation of generic ConfigMap objects.

## Proposal

- [x] add support for ConfigMap creation from `cm*` service templates
