### PR TITLE
✨(marsha) allow to set unlimited secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Allow to set unlimited secrets in marsha
+
 ## [5.8.0] - 2020-04-28
 
 ### Changed

--- a/apps/marsha/templates/services/app/secret.yml.j2
+++ b/apps/marsha/templates/services/app/secret.yml.j2
@@ -26,3 +26,8 @@ data:
 {% if MARSHA_VAULT.DJANGO_LRS_URL is defined %}
   DJANGO_LRS_URL: "{{ MARSHA_VAULT.DJANGO_LRS_URL | b64encode }}"
 {% endif %}
+{% if MARSHA_VAULT.SECRETS is defined %}
+{% for k, v in MARSHA_VAULT.SECRETS.items() %}
+  {{ k }}: {{ v | default('') | b64encode }}
+{% endfor %}
+{% endif %}


### PR DESCRIPTION
## Purpose

We want to add more secrets in marsha than one already defined in the
secret template. To do this we use an already known pattern used in
arnold. If the key `SECRETS` is defined in the vault, all the items are
added in the secret.

## Proposal

- [x] allow to set unlimited secrets
