### PR TITLE
✨(redis-sentinel) allow to disable persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Allow to set unlimited secrets in Marsha
 - Create custom settings module in Marsha
 
+### Changed
+
+- Allow to disable persistence in redis-sentinel
+
 ## [5.8.0] - 2020-04-28
 
 ### Changed

--- a/apps/redis-sentinel/templates/services/app/svc.yml.j2
+++ b/apps/redis-sentinel/templates/services/app/svc.yml.j2
@@ -12,7 +12,7 @@ metadata:
     version: RedisFailover
   # Nota bene: the name of the service should be the host name in edxapp configuration,
   # prefixed by "rfs-", e.g. "rfs-redis-sentinel"
-  name: redis-sentinel
+  name: {{ redis_sentinel_service_name }}
   namespace: "{{ project_name }}"
 spec:
   sentinel:
@@ -59,6 +59,7 @@ spec:
       - "{{ config }}"
 {% endfor %}
 {% endif %}
+{% if redis_sentinel_redis_persistence_enabled %}
     storage:
       keepAfterDeletion: true
       persistentVolumeClaim:
@@ -74,6 +75,7 @@ spec:
           resources:
             requests:
               storage: {{ redis_sentinel_redis_data_volume_size }}
+{% endif %}
     securityContext:
       runAsUser: {{ redis_sentinel_user_id }}
       runAsGroup: {{ redis_sentinel_group_id }}

--- a/apps/redis-sentinel/vars/all/main.yml
+++ b/apps/redis-sentinel/vars/all/main.yml
@@ -6,6 +6,10 @@ redis_sentinel_user_id: null
 redis_sentinel_group_id: null
 redis_sentinel_fsgroup_id: null
 
+## Service configuration
+# name used by the service. This name will be prefixed by `rfs-` in the final service
+redis_sentinel_service_name: redis-sentinel
+
 ## Sentinel configuration
 # Number of sentinel replicas 
 redis_sentinel_sentinel_replicas: 3
@@ -18,6 +22,8 @@ redis_sentinel_sentinel_custom_config: []
 ## Redis configuration
 # Number of redis replicas
 redis_sentinel_redis_replicas: 3
+# Enable disk persistence
+redis_sentinel_redis_persistence_enabled: false
 redis_sentinel_redis_data_volume_size: 2Gi
 # If you need custom redis configuration you should add
 # them in this list. One configuration is a new entry


### PR DESCRIPTION
## Purpose

Persistence in redis-sentinel is now optional and the variable
redis_sentinel_redis_persistence_enabled is here to enable it or not. By
default this variable is set to false.

## Proposal

- [x] allow to disable persistence
