### PR TITLE
🐛(core) exclude acme routes when looking for app routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Exclude `openshift-acme` routes when looking for app routes
+
 ## [5.13.0] - 2020-07-22
 
 ### Added

--- a/tasks/deploy_get_stamp_from_route.yml
+++ b/tasks/deploy_get_stamp_from_route.yml
@@ -14,6 +14,7 @@
     label_selectors:
       - app={{ app.name }}
       - route_prefix={{ prefix }}
+      - "!acme.openshift.io/temporary"
   register: app_route
   when: routes | length > 0 and app.settings.is_blue_green_compatible | default(True)
 


### PR DESCRIPTION
## Purpose

When using acmev2 challenge routes contains the label included by the
targeted route. We have to exclude acme route to have only the next,
current or previous route returned by k8s.

## Proposal

- [x] exclude acme routes when looking for app routes