### PR TITLE
✨(richie) allow placing static files behind a CDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Add CORS headers for richie static files to allow placing them behind a CDN
+
 ### Changed
 
 - Upgrade `ansible` to `2.9.12`

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -84,5 +84,11 @@ server {
     add_header Cache-Control public;
     root /data/static;
     try_files /$file =404;
+
+    add_header Access-Control-Allow-Origin https://{{ richie_host }};
+    add_header Access-Control-Allow-Credentials false;
+    add_header Access-Control-Allow-Methods GET;
+    add_header Access-Control-Allow-Headers 'DNT,X-CustomHeader,Keep-Alive,User-Agent,X-Requested-With,If-Modified-Since,Cache-Control,Content-Type';
+
   }
 }


### PR DESCRIPTION
## Purpose

On richie sites, we can configure Django to serve static files behind a CDN like CloudFront on a domain other then the origin.
Some types of files like fonts required CORS access control allow origin headers to be set.

## Proposal

Add minimal CORS headers to requests on static files so they can be served from another domain name as long as the site origin url is our main domain.
