### PR TITLE
♻️(richie) inject configmap environment in all jobs to allow defining required settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Changed
 
+- Inject configmap env in all jobs to allow defining settings that are required
 - Upgrade `ansible` to `2.9.12`
 - Create only required `openshift-acme` CM given the project environment
 

--- a/apps/richie/templates/services/app/job_01_db_migrate.yml.j2
+++ b/apps/richie/templates/services/app/job_01_db_migrate.yml.j2
@@ -44,6 +44,8 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ richie_secret_name }}"
+            - configMapRef:
+                name: "richie-app-dotenv-{{ deployment_stamp }}"
           command:
             - "bash"
             - "-c"

--- a/apps/richie/templates/services/app/job_02_richie_init.yml.j2
+++ b/apps/richie/templates/services/app/job_02_richie_init.yml.j2
@@ -44,6 +44,8 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ richie_secret_name }}"
+            - configMapRef:
+                name: "richie-app-dotenv-{{ deployment_stamp }}"
           command:
             - "bash"
             - "-c"

--- a/apps/richie/templates/services/app/job_03_bootstrap_elasticsearch.yml.j2
+++ b/apps/richie/templates/services/app/job_03_bootstrap_elasticsearch.yml.j2
@@ -47,6 +47,8 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ richie_secret_name }}"
+            - configMapRef:
+                name: "richie-app-dotenv-{{ deployment_stamp }}"
           command:
             - "bash"
             - "-c"


### PR DESCRIPTION
## Purpose

We want to add an environment variable to our configmap for a setting that is required. Our jobs are breaking because the configmap env is not injected.

## Proposal

Modify the template definition for all jobs to inject the configmap env.
