### PR TITLE
🐛(edxapp) pin transifex-client version in edx i18n job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Pin transifex-client version in edx i18n job
+
 ## [5.14.0] - 2020-08-21
 
 ### Added

--- a/apps/edxapp/templates/services/cms/job_02_internationalization.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_02_internationalization.yml.j2
@@ -53,7 +53,7 @@ spec:
           command:
             - "bash"
             - "-c"
-            - pip install -I --prefix /tmp transifex-client &&
+            - pip install -I --prefix /tmp transifex-client==0.13.9 &&
               cp -R .tx /tmp &&
 {% for lang in edxapp_i18n_languages %}
               HOME="/tmp" PYTHONPATH=/tmp/lib/python2.7/site-packages/ /tmp/bin/tx --root /tmp pull --mode=reviewed -l {{ lang }} &&


### PR DESCRIPTION
## Purpose

We must pin transifex-client to version 0.13.9, version after use git
and git client is not installed in the edxapp image.

## Proposal

- [x] pin transifex-client version in edx i18n job
