### PR TITLE
Release ironwood

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Upgrade default `edxapp` image to `ironwood.2-oee-1.0.0`
+- Add `enable_sql_dump_loading` to `main.yml`
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [5.15.0] - 2020-09-16
+
+### Added
+
+- Upgrade default `edxapp` image to `ironwood.2-oee-1.0.0`
+
 ### Changed
 
 - Upgrade `ansible` to `2.9.13`

--- a/apps/edxapp/templates/services/mysql/job_00_load_sql_dump.yml.j2
+++ b/apps/edxapp/templates/services/mysql/job_00_load_sql_dump.yml.j2
@@ -1,4 +1,4 @@
-{% if env_type in trashable_env_types %}
+{% if env_type in trashable_env_types and enable_sql_dump_loading %}
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -7,7 +7,7 @@ edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "hawthorn.1-oee-3.3.0"
+edxapp_image_tag: "ironwood.2-oee-1.0.0"
 edxapp_django_port: 8000
 edxapp_lms_replicas: 1
 edxapp_cms_replicas: 1

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -46,6 +46,12 @@ trashable_env_types:
   - "development"
   - "feature"
 
+# To be use with edxapp_sql_dump_url in edxapp config
+# This is useful when migration become too long to execute. We can
+# provide a sql dump of the schema to then load it instead of waiting
+# for migrate to be done (works only with trashable env)
+enable_sql_dump_loading: false
+
 # Blue/Green deployment route prefixes
 blue_green_route_prefixes:
   - "previous"
@@ -105,7 +111,7 @@ force_route: false
 # In trashable environments these endpoints will not be used because everything will
 # run inside OpenShift pods. in Production and Pre-production environments you should consider using a dedicated cluster
 # for your databases.
-# Endpoint IPs are initialized at "null" (except for mongodb we initalize it with an empty list) by default 
+# Endpoint IPs are initialized at "null" (except for mongodb we initalize it with an empty list) by default
 # and you SHOULD overwrite them in the corresponding environment where you will use them.
 endpoint_mongodb_ips:     []
 endpoint_mysql_ip:       null


### PR DESCRIPTION
## Purpose

This PR intends to update the edxapp to the first release of ironwood (2-oee).
It also update a script to *not* use a dump of the base's schema. This was done before to save time as migrate were too long. Migrations have been squashed in ironwood so it should be faster now.
