### PR TITLE
Release ironwood

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -370,7 +370,7 @@ jobs:
             bin/ci-ansible-playbook bootstrap.yml "edxapp,redis"
             # Test services deployed with the next route
             bin/ci-test-route "cms" "Welcome to Your Platform Studio" "/" "next" 20
-            bin/ci-test-route "lms" "It works! This is the default homepage for this Open edX instance." "/" "next" 20
+            bin/ci-test-route "lms" "It works!" "/" "next" 20
 
       - run:
           name: Test the "edxapp" application switch
@@ -379,7 +379,7 @@ jobs:
             bin/ci-ansible-playbook switch.yml "edxapp"
             # Test service switched to the current route
             bin/ci-test-route "cms" "Welcome to Your Platform Studio" "/" "current" 20
-            bin/ci-test-route "lms" "It works! This is the default homepage for this Open edX instance." "/" "current" 20
+            bin/ci-test-route "lms" "It works!" "/" "current" 20
 
   # Test the bootstrap playbook on the "edxec" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade `ansible` to `2.9.13`
+- Upgrade default `edxapp` version to `ironwood.2-1.0.1`
 
 ## [5.14.2] - 2020-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## [5.15.0] - 2020-09-22
+
 ### Changed
 
 - Upgrade `ansible` to `2.9.13`
-- Upgrade default `edxapp` version to `ironwood.2-1.0.1`
+- Upgrade `edxapp` version to `ironwood.2-1.0.1`
 
 ## [5.14.2] - 2020-09-03
 
@@ -833,7 +835,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Official Docker image is available at:
   https://hub.docker.com/r/fundocker/arnold/
 
-[unreleased]: https://github.com/openfun/arnold/compare/v5.14.2...master
+[unreleased]: https://github.com/openfun/arnold/compare/v5.15.0...master
+[5.14.3]: https://github.com/openfun/arnold/compare/v5.14.2...v5.15.0
 [5.14.2]: https://github.com/openfun/arnold/compare/v5.14.1...v5.14.2
 [5.14.1]: https://github.com/openfun/arnold/compare/v5.14.0...v5.14.1
 [5.14.0]: https://github.com/openfun/arnold/compare/v5.13.1...v5.14.0

--- a/apps/edxapp/tray.yml
+++ b/apps/edxapp/tray.yml
@@ -1,3 +1,3 @@
 metadata:
   name: edxapp
-  version: hawthorn.1-3.2.0
+  version: ironwood.2-1.0.1

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -7,7 +7,7 @@ edxapp_preview_host: "preview.{{ project_name}}.{{ domain_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"
-edxapp_image_tag: "hawthorn.1-oee-3.3.0"
+edxapp_image_tag: "ironwood.2-oee-1.0.1"
 edxapp_django_port: 8000
 edxapp_lms_replicas: 1
 edxapp_cms_replicas: 1

--- a/group_vars/all/fixtures.yml
+++ b/group_vars/all/fixtures.yml
@@ -1,7 +1,7 @@
 # Fixtures for the `development` and `feature` environments
 
 # edX demo course release (should be compatible with deployed edxapp release)
-demo_course_url: "https://github.com/edx/edx-demo-course/archive/open-release/hawthorn.1.tar.gz"
+demo_course_url: "https://github.com/edx/edx-demo-course/archive/open-release/ironwood.2.tar.gz"
 
 # Demo users
 demo_users:


### PR DESCRIPTION
## Purpose

This PR intends to update the edxapp to the first release of ironwood (2-oee).
It also update a script to not use a dump of the base's schema. This was done before to save time as migrate were too long. Migrations have been squashed in ironwood so it should be faster now.