### PR TITLE
✨(nginx) allow extending nginx configs on all apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Allow extending nginx configuration templates on all sites
+
 ## [5.15.0] - 2020-09-22
 
 ### Changed

--- a/apps/ashley/templates/services/nginx/configs/ashley.conf.j2
+++ b/apps/ashley/templates/services/nginx/configs/ashley.conf.j2
@@ -14,6 +14,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
 {% if http_basic_auth_enabled %}
 {% if bypass_htaccess %}

--- a/apps/edxapp/templates/services/cms/_dc_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_dc_base.yml.j2
@@ -50,6 +50,10 @@ spec:
   # We want to deploy every target DC even if replicas has been set to zero to
   # be able to scale up/down worker for a deployed stack.
   replicas: {{ replicas | default(1) }} # number of pods we want
+  strategy:
+    rollingParams:
+      timeoutSeconds: 1200
+    type: Rolling
   template:
     metadata:
       labels:

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -30,6 +30,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
   location @proxy_to_cms_app {
     proxy_set_header Host $http_host;

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -31,6 +31,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
   location @proxy_to_lms_app {
     proxy_set_header Host $http_host;

--- a/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
@@ -28,6 +28,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
   location @proxy_to_edxec_app {
     proxy_set_header Host $http_host;

--- a/apps/etherpad/templates/services/nginx/configs/etherpad.conf.j2
+++ b/apps/etherpad/templates/services/nginx/configs/etherpad.conf.j2
@@ -14,6 +14,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
 {% if http_basic_auth_enabled %}
 {% if bypass_htaccess %}

--- a/apps/flower/templates/services/nginx/configs/flower.conf.j2
+++ b/apps/flower/templates/services/nginx/configs/flower.conf.j2
@@ -6,6 +6,7 @@ server {
   listen {{ flower_nginx_app_port }};
   server_name localhost;
   charset utf-8;
+  {% block server_extra %}{% endblock %}
 
   location @proxy_to_flower {
     proxy_pass http://flower;

--- a/apps/kibana/templates/services/nginx/configs/kibana.conf.j2
+++ b/apps/kibana/templates/services/nginx/configs/kibana.conf.j2
@@ -10,6 +10,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
 {% if http_basic_auth_enabled %}
 {% if bypass_htaccess %}

--- a/apps/learninglocker/templates/services/nginx/configs/default.conf.j2
+++ b/apps/learninglocker/templates/services/nginx/configs/default.conf.j2
@@ -18,6 +18,7 @@ server {
   # Max request size
   client_max_body_size 20M;
   large_client_header_buffers 4 256k;
+  {% block server_extra %}{% endblock %}
 
   # xAPI endpoints
   location ~* ^/data/xAPI(.*)$ {

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -32,6 +32,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
   location @proxy_to_marsha_app {
     proxy_set_header Host $http_host;

--- a/apps/nextcloud/templates/services/nginx/configs/nextcloud.conf.j2
+++ b/apps/nextcloud/templates/services/nginx/configs/nextcloud.conf.j2
@@ -29,6 +29,7 @@ server {
 
     # Path to the root of your installation
     root {{ nextcloud_nginx_root }};
+    {% block server_extra %}{% endblock %}
 
     location = /robots.txt {
         allow all;

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -14,6 +14,7 @@ server {
 
   # Disables server version feedback on pages and in headers
   server_tokens off;
+  {% block server_extra %}{% endblock %}
 
 {% if http_basic_auth_enabled %}
 {% if bypass_htaccess %}


### PR DESCRIPTION
## Purpose

We very often need to add a rule to the nginx configuration of an app. Today, we override the whole template but this makes maintenance much harder and some improvements of the base nginx configuration may not be taken into account on sites that have overriden it...

## Proposal

Add a template block "server_extra" in all apps nginx configuration templates.
