### PR TITLE
♻️(ci) stop pulling images anonymously

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,9 @@ aliases:
   - &defaults
     docker:
       - image: circleci/python:3.6.5-stretch-node-browsers
+        auth:
+          username: $DOCKER_USER
+          password: $DOCKER_PASS
     working_directory: ~/fun
 
   # Activate Docker in Docker (aka dind)
@@ -64,6 +67,18 @@ aliases:
         echo "export K8S_AUTH_API_KEY=${K8S_AUTH_API_KEY}" >> $BASH_ENV
         source $BASH_ENV
 
+  - &docker_login
+    # Login to DockerHub
+    #
+    # Nota bene: you'll need to define the following secrets environment vars
+    # in CircleCI interface:
+    #
+    #   - DOCKER_USER
+    #   - DOCKER_PASS
+    run:
+      name: Login to DockerHub
+      command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
+
 version: 2
 jobs:
   # Build Arnold's docker image
@@ -78,6 +93,7 @@ jobs:
     steps:
       - checkout
       - *ci_env
+      - *docker_login
       - run:
           name: Build arnold production image
           command: |
@@ -754,18 +770,9 @@ jobs:
     steps:
       - checkout
       - *attach_workspace
+      - *docker_login
       - *docker_load
       - *ci_env
-      # Login to DockerHub to Publish new images
-      #
-      # Nota bene: you'll need to define the following secrets environment vars
-      # in CircleCI interface:
-      #
-      #   - DOCKER_USER
-      #   - DOCKER_PASS
-      - run:
-          name: Login to DockerHub
-          command: echo "$DOCKER_PASS" | docker login -u "$DOCKER_USER" --password-stdin
 
       # Tag docker images with the same pattern used in Git (Semantic Versioning)
       #


### PR DESCRIPTION
## Purpose

Docker will start a rate limit on pulling images on docker hub. This rate
limit is based on the IP used for anonymous users, this is the CircleCI IP
that will be used so the rate limit will be reached quickly. If the image pull
is made with a connected user, the rate limit becomes a per-user rate so we
should not reach it once connected.


## Proposal

- [x] stop pulling images anonymously