### PR TITLE
🐛(elasticsearch) fix YAML syntax error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- YAML syntax errors in ES job template
+
 ## [5.18.0] - 2020-10-16
 
 ### Added

--- a/apps/elasticsearch/templates/services/app/job_03_create_admin_user.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_03_create_admin_user.yml.j2
@@ -31,10 +31,10 @@ spec:
             - curl -kfsSL
                 -X PUT "https://elasticsearch:9200/_security/user/${ADMIN_USERNAME}?pretty"
                 -u "${ELASTIC_USERNAME}:${ELASTIC_PASSWORD}"
-                -H "Content-Type: application/json"
+                -H "Content-Type:application/json"
                 -d "{
-                    \"password\" : \"${ADMIN_PASSWORD}\",
-                    \"roles\" : [ \"superuser\" ]
+                    \"password\":\"${ADMIN_PASSWORD}\",
+                    \"roles\":[ \"superuser\" ]
                 }"
           envFrom:
             - secretRef:


### PR DESCRIPTION
## Purpose

A recent update of Ansible's YAML parser considers the Elasticsearch app "create admin user" job template syntax as invalid.

## Proposal

- [x] remove spaces around colons in strings.