### PR TITLE
🐛(acme) fix priority type in CM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+## Fixed
+
+- Move `acme` ConfigMap annotation type to string
+
 ## [5.19.0] - 2020-10-21
 
 ### Added

--- a/core_apps/acme/templates/services/app/cm.yml.j2
+++ b/core_apps/acme/templates/services/app/cm.yml.j2
@@ -3,7 +3,7 @@ apiVersion: v1
 metadata:
   name: letsencrypt
   annotations:
-    "acme.openshift.io/priority": 100
+    "acme.openshift.io/priority": "100"
   labels:
     managed-by: "openshift-acme"
     type: "CertIssuer"


### PR DESCRIPTION
## Purpose

k8s schema validator refuses an integer as object annotation. Not sure if it is restricted to CMs.

## Proposal

- [x] switch `acme` CM priority annotation to a string