### PR TITLE
🐛(moodlenet) multiple fixes for moodlenet

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -485,7 +485,7 @@ jobs:
             # Bootstrap app
             bin/ci-ansible-playbook bootstrap.yml "moodlenet"
             # Test services deployed with the next route
-            bin/ci-test-route "moodlenet" "schema" "/.well-known/nodeinfo" "next" 10 "application/json"
+            bin/ci-test-route "api" "schema" "/.well-known/nodeinfo" "next" 10 "application/json"
 
       - run:
           name: Test the "moodlenet" application switch
@@ -493,7 +493,7 @@ jobs:
             # Switch next route to current
             bin/ci-ansible-playbook switch.yml "moodlenet"
             # Test service switched to the current route
-            bin/ci-test-route "moodlenet" "schema" "/.well-known/nodeinfo" "current" 10 "application/json"
+            bin/ci-test-route "api" "schema" "/.well-known/nodeinfo" "current" 10 "application/json"
 
 
   # Test the bootstrap playbook on the "learninglocker" application.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - new variable `acme_enabled_route_prefix` allowing to activate acme
   based on route prefix
 
+## Fixes
+
+- Add missing FRONTEND_BASE_URL variable in moodlenet
+
 ## [5.20.0] - 2020-11-05
 
 ## Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ## Fixes
 
 - Add missing FRONTEND_BASE_URL variable in moodlenet
+- Fix moodlenet-pvc-uploads PVC declaration in moodlenet
 
 ## [5.20.0] - 2020-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Add missing FRONTEND_BASE_URL variable in moodlenet
 - Fix moodlenet-pvc-uploads PVC declaration in moodlenet
 - Fix basic auth in moodlenet nginx configuration
+- Move moodlenet email credentials to vault and secret files
 
 ## [5.20.0] - 2020-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fix moodlenet-pvc-uploads PVC declaration in moodlenet
 - Fix basic auth in moodlenet nginx configuration
 - Move moodlenet email credentials to vault and secret files
+- Add missing location in moodlnet nginx configuration
 
 ## [5.20.0] - 2020-11-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Add missing FRONTEND_BASE_URL variable in moodlenet
 - Fix moodlenet-pvc-uploads PVC declaration in moodlenet
+- Fix basic auth in moodlenet nginx configuration
 
 ## [5.20.0] - 2020-11-05
 

--- a/apps/moodlenet/templates/services/backend/_env.yml.j2
+++ b/apps/moodlenet/templates/services/backend/_env.yml.j2
@@ -5,6 +5,9 @@ HOSTNAME: "{{ moodlenet_host }}"
 # (if it isn't the default for protocol like 80 or 443):
 BASE_URL: "https://{{ moodlenet_host }}"
 
+# full client app URL, where users will browse the site
+FRONTEND_BASE_URL: "{{ moodlenet_frontend_base_url }}"
+
 # cc public activities to the mothership for indexing
 CONNECT_WITH_MOTHERSHIP: "{{ moodlenet_mothership_connect }}"
 

--- a/apps/moodlenet/templates/services/backend/_env.yml.j2
+++ b/apps/moodlenet/templates/services/backend/_env.yml.j2
@@ -51,10 +51,4 @@ MAIL_BACKEND: "{{ moodlenet_email_backend }}"
 # -- smtp backend specific
 {% if moodlenet_email_backend == "smtp" %}
 MAIL_SERVER: "{{ moodlenet_email_smtp_host }}"
-MAIL_USER: "{{ moodlenet_email_smtp_user }}"
-MAIL_PASSWORD: "{{ moodlenet_email_smtp_password }}"
-{% endif %}
-# -- mailgun backend specific
-{% if moodlenet_email_backend == "mailgun" %}
-MAIL_KEY: "{{ moodlenet_email_mailgun_key }}"
 {% endif %}

--- a/apps/moodlenet/templates/services/backend/secret.yml.j2
+++ b/apps/moodlenet/templates/services/backend/secret.yml.j2
@@ -10,3 +10,10 @@ data:
   DATABASE_USER: "{{ MOODLENET_VAULT.POSTGRESQL_USER | default('moodlenet_user') | b64encode }}"
   DATABASE_PASS: "{{ MOODLENET_VAULT.POSTGRESQL_PASSWORD | default('password') | b64encode }}"
   SECRET_KEY_BASE: "{{ MOODLENET_VAULT.SECRET_KEY_BASE | default('secret') | b64encode }}"
+{% if moodlenet_email_backend == "smtp" %}
+  MAIL_USER: "{{ MOODLENET_VAULT.MOODLENET_SMTP_USER | default('smtp_user') | b64encode }}"
+  MAIL_PASSWORD: "{{ MOODLENET_VAULT.MOODLENET_SMTP_PASSWORD | default('smtp_password') | b64encode }}"
+{% endif %}
+{% if moodlenet_email_backend == "mailgun" %}
+  MAIL_KEY: "{{ MOODLENET_VAULT.MOODLENET_MAILGUN_KEY | default('mailgun_key') | b64encode }}"
+{% endif %}

--- a/apps/moodlenet/templates/services/nginx/configs/moodlenet.conf.j2
+++ b/apps/moodlenet/templates/services/nginx/configs/moodlenet.conf.j2
@@ -52,19 +52,45 @@ server {
   }
 
   location /api {
+    {% if http_basic_auth_enabled and bypass_htaccess %}
+        if ($http_x_forwarded_for !~ ^({{ moodlenet_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+          error_page 401 = @basicauth;
+          return 401;
+        }
+    {% endif %}
+
     client_max_body_size {{ moodlenet_upload_limit }};
     try_files $uri @proxy_to_backend;
   }
 
   location /pub {
+    {% if http_basic_auth_enabled and bypass_htaccess %}
+        if ($http_x_forwarded_for !~ ^({{ moodlenet_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+          error_page 401 = @basicauth;
+          return 401;
+        }
+    {% endif %}
+
     try_files $uri @proxy_to_backend;
   }
 
   location /oauth {
+    {% if http_basic_auth_enabled and bypass_htaccess %}
+        if ($http_x_forwarded_for !~ ^({{ moodlenet_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+          error_page 401 = @basicauth;
+          return 401;
+        }
+    {% endif %}
     try_files $uri @proxy_to_backend;
   }
 
   location /.well-known {
+    {% if http_basic_auth_enabled and bypass_htaccess %}
+        if ($http_x_forwarded_for !~ ^({{ moodlenet_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+          error_page 401 = @basicauth;
+          return 401;
+        }
+    {% endif %}
     try_files $uri @proxy_to_backend;
   }
 

--- a/apps/moodlenet/templates/services/nginx/configs/moodlenet.conf.j2
+++ b/apps/moodlenet/templates/services/nginx/configs/moodlenet.conf.j2
@@ -38,6 +38,18 @@ server {
     return 404;
   }
 
+  # uploaded resources
+  location /uploads {
+    {% if http_basic_auth_enabled and bypass_htaccess %}
+        if ($http_x_forwarded_for !~ ^({{ moodlenet_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {
+          error_page 401 = @basicauth;
+          return 401;
+        }
+    {% endif %}
+
+    try_files $uri =404;
+  }
+
   ## Backend routes
   location @proxy_to_backend {
     proxy_set_header X-Forwarded-Proto $scheme;

--- a/apps/moodlenet/templates/volumes/uploads.yml.j2
+++ b/apps/moodlenet/templates/volumes/uploads.yml.j2
@@ -1,4 +1,3 @@
-{% if env_type in trashable_env_types %}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -14,4 +13,3 @@ spec:
   resources:
     requests:
       storage: {{ moodlenet_upload_volume_size }}
-{% endif %}

--- a/apps/moodlenet/vars/all/main.yml
+++ b/apps/moodlenet/vars/all/main.yml
@@ -39,9 +39,6 @@ moodlenet_email_domain: "example.com"
 moodlenet_email_from: "contact@example.com"
 moodlenet_email_backend: "smtp"
 moodlenet_email_smtp_host: "localhost"
-moodlenet_email_smtp_user: ""
-moodlenet_email_smtp_password: ""
-moodlenet_email_mailgun_key: ""
 
 moodlenet_instance_description: "An instance of MoodleNet, a federated network for educators."
 moodlenet_invite_only: true

--- a/apps/moodlenet/vars/all/main.yml
+++ b/apps/moodlenet/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
-moodlenet_host: "moodlenet.{{ project_name}}.{{ domain_name }}"
+# -- route / urls
+moodlenet_host: "api.{{ project_name}}.{{ domain_name }}"
+moodlenet_frontend_base_url: "app.{{ project_name}}.{{ domain_name }}"
 
 # -- nginx
 moodlenet_nginx_image_name: "fundocker/openshift-nginx"


### PR DESCRIPTION
## Purpose

Fix 4 issues with moodlenet : 

- Unable to define a specific frontend URL in moodlenet configuration
- The PVC to store uploaded resources is not created in non trashable environment
- Basic auth configuration in nginx is incomplete
- Moodlenet email credentials are stored in ConfigMaps insead of secrets


## Proposal

- [x] Add missing FRONTEND_BASE_URL variable in moodlenet
- [x] Fix moodlenet-pvc-uploads PVC declaration in moodlenet
- [x] Fix basic auth in moodlenet nginx configuration
- [x] Move moodlenet email credentials to vault and secret files
