### PR TITLE
👷(circleci) remove nextcloud test requirement to publish on Docker Hub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1058,7 +1058,6 @@ workflows:
             - test-bootstrap-forum
             - test-bootstrap-learninglocker
             - test-bootstrap-ashley
-            - test-bootstrap-nextcloud
             - test-bootstrap-etherpad
             - test-bootstrap-kibana
             - test-redirect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- nextcloud tests have been removed from requirements to publish the arnold
+  docker image with CircleCI
+
 ## [5.22.0] - 2020-12-08
 
 ### Added


### PR DESCRIPTION
## Purpose

The CircleCI job test-bootstrap-nextcloud is always failing and
prevents from publishing new arnold releases to Docker Hub.

## Proposal

- [x] Remove the `test-bootstrap-nextcloud` requirement to execute the `hub` job
