### PR TITLE
Fix CI's hub job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -729,6 +729,7 @@ jobs:
     steps:
       - checkout
       - *attach_workspace
+      - *ci_env
       - *docker_login
       - *docker_load
 


### PR DESCRIPTION
## Purpose

Without defining Arnold image name in the environment, the docker tag command fails as only a single parameter is passed.


## Proposal

- [x] load the CI environment
