### PR TITLE
💥(apps) fix typos in setting names: `withelist` vs `whitelist`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Fix typos in setting names: `withelist` vs `whitelist` (BC)
+
 ## [5.23.0] - 2021-01-05
 
 ### Added

--- a/apps/ashley/templates/services/nginx/configs/ashley.conf.j2
+++ b/apps/ashley/templates/services/nginx/configs/ashley.conf.j2
@@ -48,7 +48,7 @@ server {
     try_files $uri @proxy_to_ashley_app;
   }
 
-{% if ashley_nginx_admin_ip_withelist | length > 0 %}
+{% if ashley_nginx_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#
       We want to limit access to a list of whitelisted IP addresses.
@@ -58,7 +58,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ ashley_nginx_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ ashley_nginx_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 

--- a/apps/ashley/vars/all/main.yml
+++ b/apps/ashley/vars/all/main.yml
@@ -12,7 +12,7 @@ ashley_nginx_htpasswd_secret_name: "ashley-htpasswd"
 ashley_nginx_healthcheck_port: 5000
 ashley_nginx_healthcheck_endpoint: "/__healthcheck__"
 ashley_nginx_status_endpoint: "/__status__"
-ashley_nginx_admin_ip_withelist: []
+ashley_nginx_admin_ip_whitelist: []
 ashley_nginx_bypass_htaccess_ip_whitelist: []
 ashley_nginx_static_cache_expires: "1M"
 ashley_nginx_media_cache_expires: "1d"

--- a/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/cms.conf.j2
@@ -52,7 +52,7 @@ server {
     try_files $uri @proxy_to_cms_app;
   }
 
-{% if edxapp_nginx_cms_admin_ip_withelist | length > 0 %}
+{% if edxapp_nginx_cms_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#
       We want to limit access to a list of whitelisted IP addresses.
@@ -62,7 +62,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_cms_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_cms_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -69,7 +69,7 @@ server {
     try_files $uri @proxy_to_lms_app;
   }
 
-{% if edxapp_nginx_lms_admin_ip_withelist | length > 0 %}
+{% if edxapp_nginx_lms_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#
       We want to limit access to a list of whitelisted IP addresses.
@@ -79,7 +79,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_lms_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ edxapp_nginx_lms_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -62,9 +62,9 @@ edxapp_nginx_healthcheck_port: 5000
 edxapp_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxapp_nginx_status_endpoint: "/__status__"
 edxapp_routing_timeout: "60s"
-edxapp_nginx_cms_admin_ip_withelist: []
+edxapp_nginx_cms_admin_ip_whitelist: []
 edxapp_nginx_cms_bypass_htaccess_ip_whitelist: []
-edxapp_nginx_lms_admin_ip_withelist: []
+edxapp_nginx_lms_admin_ip_whitelist: []
 edxapp_nginx_lms_bypass_htaccess_ip_whitelist: []
 edxapp_nginx_cms_static_cache_expires: "1d"
 edxapp_nginx_lms_media_cache_expires: "1y"

--- a/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
@@ -48,7 +48,7 @@ server {
     try_files $uri @proxy_to_edxec_app;
   }
 
-{% if edxec_nginx_admin_ip_withelist | length > 0 %}
+{% if edxec_nginx_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#
       We want to limit access to a list of whitelisted IP addresses.
@@ -58,7 +58,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ edxec_nginx_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ edxec_nginx_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -22,7 +22,7 @@ edxec_nginx_htpasswd_secret_name: "edxec-htpasswd"
 edxec_nginx_healthcheck_port: 5000
 edxec_nginx_healthcheck_endpoint: "/__healthcheck__"
 edxec_nginx_status_endpoint: "/__status__"
-edxec_nginx_admin_ip_withelist: []
+edxec_nginx_admin_ip_whitelist: []
 edxec_nginx_bypass_htaccess_ip_whitelist: []
 edxec_nginx_static_cache_expires: "1M"
 edxec_nginx_media_cache_expires: "1M"

--- a/apps/learninglocker/templates/services/nginx/configs/default.conf.j2
+++ b/apps/learninglocker/templates/services/nginx/configs/default.conf.j2
@@ -43,7 +43,7 @@ server {
 
   # All other traffic directed to statics or Node server
   location / {
-{% if learninglocker_nginx_admin_ip_withelist | length > 0 %}
+{% if learninglocker_nginx_admin_ip_whitelist | length > 0 %}
     {# 
       We want to limit access to a list of whitelisted IP addresses.
 
@@ -52,7 +52,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ learninglocker_nginx_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ learninglocker_nginx_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 {% endif %}

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -15,7 +15,7 @@ learninglocker_ui_replicas: 1
 learninglocker_api_pm2_instances: 2
 learninglocker_ui_pm2_instances: 2
 learninglocker_worker_pm2_instances: 2
-learninglocker_nginx_admin_ip_withelist: []
+learninglocker_nginx_admin_ip_whitelist: []
 
 
 # -- xapi

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -70,7 +70,7 @@ server {
     try_files $uri @proxy_to_marsha_xapi;
   }
 
-{% if marsha_nginx_admin_ip_withelist | length > 0 %}
+{% if marsha_nginx_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#
       We want to limit access to a list of whitelisted IP addresses.
@@ -80,7 +80,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ marsha_nginx_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -12,7 +12,7 @@ marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"
 marsha_nginx_healthcheck_port: 5000
 marsha_nginx_healthcheck_endpoint: "/__healthcheck__"
 marsha_nginx_status_endpoint: "/__status__"
-marsha_nginx_admin_ip_withelist: []
+marsha_nginx_admin_ip_whitelist: []
 marsha_nginx_bypass_htaccess_ip_whitelist: []
 marsha_nginx_static_cache_expires: "1M"
 

--- a/apps/moodlenet/vars/all/main.yml
+++ b/apps/moodlenet/vars/all/main.yml
@@ -13,7 +13,7 @@ moodlenet_nginx_htpasswd_secret_name: "moodlenet-htpasswd"
 moodlenet_nginx_healthcheck_port: 5000
 moodlenet_nginx_healthcheck_endpoint: "/__healthcheck__"
 moodlenet_nginx_status_endpoint: "/__status__"
-moodlenet_nginx_admin_ip_withelist: []
+moodlenet_nginx_admin_ip_whitelist: []
 moodlenet_nginx_bypass_htaccess_ip_whitelist: []
 
 # -- postgresql

--- a/apps/nextcloud/templates/services/nginx/configs/nextcloud.conf.j2
+++ b/apps/nextcloud/templates/services/nginx/configs/nextcloud.conf.j2
@@ -81,7 +81,7 @@ server {
     }
 
     location ~ ^\/(?:index|remote|public|cron|core\/ajax\/update|status|ocs\/v[12]|updater\/.+|oc[ms]-provider\/.+)\.php(?:$|\/) {
-{% if nextcloud_nginx_ip_withelist | length > 0 %}
+{% if nextcloud_nginx_ip_whitelist | length > 0 %}
         {#
         We want to limit access to a list of whitelisted IP addresses.
 
@@ -90,7 +90,7 @@ server {
         which is of interest (other ones have been added by subsequent proxies),
         hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
         #}
-        if ($http_x_forwarded_for !~ ^({{ nextcloud_nginx_ip_withelist | join("|") }})) {
+        if ($http_x_forwarded_for !~ ^({{ nextcloud_nginx_ip_whitelist | join("|") }})) {
             return 403;
         }
 {% endif %}

--- a/apps/nextcloud/vars/all/main.yml
+++ b/apps/nextcloud/vars/all/main.yml
@@ -12,7 +12,7 @@ nextcloud_nginx_htpasswd_secret_name: "nextcloud-htpasswd"
 nextcloud_nginx_healthcheck_port: 5000
 nextcloud_nginx_healthcheck_endpoint: "/__healthcheck__"
 nextcloud_nginx_status_endpoint: "/__status__"
-nextcloud_nginx_ip_withelist: []
+nextcloud_nginx_ip_whitelist: []
 nextcloud_nginx_static_cache_expires: "1M"
 nextcloud_nginx_root: "/app"
 nextcloud_nginx_max_body_size: 512M

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -48,7 +48,7 @@ server {
     try_files $uri @proxy_to_richie_app;
   }
 
-{% if richie_nginx_admin_ip_withelist | length > 0 %}
+{% if richie_nginx_admin_ip_whitelist | length > 0 %}
   location /admin {
     {#
       We want to limit access to a list of whitelisted IP addresses.
@@ -58,7 +58,7 @@ server {
       which is of interest (other ones have been added by subsequent proxies),
       hence we restrict our comparison with the beginning of this list (this is why our regex starts with a ^).
     #}
-    if ($http_x_forwarded_for !~ ^({{ richie_nginx_admin_ip_withelist | join("|") }})) {
+    if ($http_x_forwarded_for !~ ^({{ richie_nginx_admin_ip_whitelist | join("|") }})) {
       return 403;
     }
 

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -12,7 +12,7 @@ richie_nginx_htpasswd_secret_name: "richie-htpasswd"
 richie_nginx_healthcheck_port: 5000
 richie_nginx_healthcheck_endpoint: "/__healthcheck__"
 richie_nginx_status_endpoint: "/__status__"
-richie_nginx_admin_ip_withelist: []
+richie_nginx_admin_ip_whitelist: []
 richie_nginx_bypass_htaccess_ip_whitelist: []
 richie_nginx_static_cache_expires: "1M"
 richie_nginx_media_cache_expires: "1M"


### PR DESCRIPTION
## Purpose

Some settings had a typo: `{app}_nginx_admin_ip_withelist` instead of `{app}_nginx_admin_ip_whitelist`.

The typo was overlooked and was propagated to many apps.

## Proposal

Correct typo and mark fix as Breaking Change in the Changelog.