### PR TITLE
🐛(project) fix Makefile's automated help

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,6 +114,6 @@ test: ## run plugins tests
 
 # -- Misc
 help:
-	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 .PHONY: help
 


### PR DESCRIPTION
## Purpose

Since we include environment files in the Makefile, the `make help` output no longer displays rule names in the first column:

```
Makefile        build Arnold's image (production)
Makefile        build Arnold's image (development)
Makefile        start a local k8s cluster for development
```

## Proposal

- [x] hard-code the Makefile file name that holds documented targets
