### PR TITLE
Fix CLI volume info and apps management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Fixed
 
 - Fix typos in setting names: `withelist` vs `whitelist` (BC)
+- Fix apps management when only a single app is available
 
 ## [5.23.0] - 2021-01-05
 

--- a/bin/arnold
+++ b/bin/arnold
@@ -1068,7 +1068,7 @@ Parameters:
   log level   : ${COLOR_BLUE}$(_get_log_level_name)${COLOR_RESET}
   CLI release : ${COLOR_BLUE}${ARNOLD_IMAGE_TAG}${COLOR_RESET}
   image       : ${COLOR_BLUE}${ARNOLD_IMAGE}${COLOR_RESET}
-  extra volume: ${COLOR_BLUE}${volume}${COLOR_RESET}
+  extra volume: ${COLOR_BLUE}${ARNOLD_EXTRA_VOLUMES[*]}${COLOR_RESET}
 "
 
 LATEST_RELEASE=$(_get_latest_release)

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -91,9 +91,9 @@
 
 - name: Add meta-data to available applications
   set_fact:
-    _app: '{{ available_apps | json_query("[?name==`" + item.name + "`]") | first | merge_with_app(item) }}'
+    _app: '{{ [ available_apps ] | flatten | json_query("[?name==`" + item.name + "`]") | first | merge_with_app(item) }}'
   register: merged_apps
-  with_items: "{{ apps | default(available_apps) }}"
+  with_items: "{{ apps | default([ available_apps ] | flatten) }}"
 
 - name: Set applications for this project
   set_fact:


### PR DESCRIPTION
## Purpose

This PR addresses two bugs:

1. the extra-volume option is not displayed in the CLI header when provided
2. When only one application is available (in the `apps` directory), the `available_apps` variable is a dict type and not a list, breaking filtering and enrichment.

## Proposal

- [x] fix extra-volume parameter in the header
- [x] fix apps management when a single app is available
