### PR TITLE
✨(core) allow to specify uid of running containers

### DIFF
--- a/apps/hello/templates/services/app/cronjob_hello.yml.j2
+++ b/apps/hello/templates/services/app/cronjob_hello.yml.j2
@@ -8,7 +8,7 @@ metadata:
     service: app
     deployment_stamp: "{{ deployment_stamp }}"
 spec:
-  schedule: "*/3 * * * *"  
+  schedule: "*/3 * * * *"
   successfulJobsHistoryLimit: 2
   failedJobsHistoryLimit: 1
   concurrencyPolicy: Forbid
@@ -36,3 +36,6 @@ spec:
                 - "-c"
                 - echo "Hello World!"
           restartPolicy: Never
+          securityContext:
+            runAsUser: {{ container_uid }}
+            runAsGroup: {{ container_gid }}

--- a/apps/hello/templates/services/app/deploy.yml.j2
+++ b/apps/hello/templates/services/app/deploy.yml.j2
@@ -49,3 +49,6 @@ spec:
           emptyDir: {}
       restartPolicy: Always
       dnsPolicy: ClusterFirst
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}

--- a/apps/hello/templates/services/app/job_writevolume.yml.j2
+++ b/apps/hello/templates/services/app/job_writevolume.yml.j2
@@ -19,8 +19,6 @@ spec:
         deployment_stamp: "{{ deployment_stamp }}"
         job_stamp: "{{ job_stamp }}"
     spec:
-      securityContext:
-        runAsUser: 4242
 {% set image_pull_secret_name = openshift_hello_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
 {% if image_pull_secret_name is not none %}
       imagePullSecrets:
@@ -43,3 +41,6 @@ spec:
           persistentVolumeClaim:
             claimName: hello-pvc
       restartPolicy: Never
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -163,3 +163,18 @@ network_policy_rule_ingress_controller:
       matchLabels:
         "app.kubernetes.io/component": controller
         "app.kubernetes.io/name": ingress-nginx
+
+
+# UID to use for running containers on k8s.
+#
+# It will be used in k8s templates to specify the SecurityContext.RunAsUser
+# field, to force pods to run with this specific UID.
+#
+# It prevents from running a container as root.
+#
+# We recommend that you specify a unique UID per customer/environment.
+container_uid: 10000
+
+# GID to use for running containers on k8s.
+# This value should be set to 0 (root).
+container_gid: 0

--- a/group_vars/customer/eugene/main.yml
+++ b/group_vars/customer/eugene/main.yml
@@ -21,3 +21,6 @@ elasticsearch_image_tag: "7.7.0"
 
 # Network policy
 network_policy_per_namespace_enabled: true
+
+# UID to use for running containers on k8s.
+container_uid: 10100


### PR DESCRIPTION
## Purpose

By default, kubernetes will run containers with the USER specified in
the docker image. And this USER can be root. We want to run containers
as non-root user, like Openshift was doing by default.

Kubernetes allow to specify a SecurityContext for resources that will
create containers (e.g. Pods, Deployments, Jobs...). SecurityContext
has a RunAsUser option which allows to run containers with the
specified UID.

## Proposal

A new ansible variable `container_uid` has been introduced to specify
the UID that will be used to run containers. We recommend to specify a
unique UID per namespace.

The `hello` app has been updated to use it. And this will have to be
generalized to all arnold apps.
