### PR TITLE
🔧(redis) update redis to be compatible with k8s

### DIFF
--- a/apps/redis/templates/services/app/deploy.yml.j2
+++ b/apps/redis/templates/services/app/deploy.yml.j2
@@ -56,7 +56,6 @@ spec:
                 - "/bin/bash"
                 - "-c"
                 - "redis-cli ping && touch /data/healthcheck"
-            initialDelaySeconds: 60
             periodSeconds: 10
           volumeMounts:
             - mountPath: /data

--- a/apps/redis/templates/services/app/deploy.yml.j2
+++ b/apps/redis/templates/services/app/deploy.yml.j2
@@ -1,5 +1,5 @@
 apiVersion: v1
-kind: DeploymentConfig
+kind: Deployment
 metadata:
   labels:
     app: redis
@@ -14,13 +14,19 @@ spec:
   # is switched off before the new one starts.
   strategy:
     type: Recreate
+  selector:
+    matchLabels:
+      app: redis
+      service: app
+      version: "{{ redis_app_image_tag }}"
+      deployment: redis-app
   template:
     metadata:
       labels:
         app: redis
         service: app
         version: "{{ redis_app_image_tag }}"
-        deploymentconfig: redis-app
+        deployment: redis-app
     spec:
 {% set image_pull_secret_name = redis_app_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
 {% if image_pull_secret_name is not none %}
@@ -57,6 +63,9 @@ spec:
               name: redis-v-data
             - mountPath: /config/redis
               name: redis-v-config
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
       volumes:
         - name: redis-v-data
           persistentVolumeClaim:

--- a/apps/redis/templates/services/app/svc.yml.j2
+++ b/apps/redis/templates/services/app/svc.yml.j2
@@ -16,5 +16,5 @@ spec:
     targetPort: {{ redis_app_port }}
   selector:
     app: redis
-    deploymentconfig: "redis-app"
+    deployment: "redis-app"
   type: ClusterIP


### PR DESCRIPTION
## Purpose

We want to deploy redis on a k8s cluster instead of Openshift.

## Proposal


- [x] Update templates
- [x] Remove `initialDelaySeconds` in readinessProbe to speedup startup time
