### PR TITLE
Fixes for the redirect core_app

### DIFF
--- a/core_apps/redirect/templates/services/nginx/deploy.yml.j2
+++ b/core_apps/redirect/templates/services/nginx/deploy.yml.j2
@@ -4,9 +4,7 @@ metadata:
   labels:
     app: redirect
     service: nginx
-    version: "{{ redirect_nginx_image_tag }}"
     deployment: redirect-nginx
-    deployment_stamp: "{{ deployment_stamp }}"
   name: redirect-nginx
   namespace: "{{ namespace_name }}"
 spec:
@@ -15,17 +13,13 @@ spec:
     matchLabels:
       app: redirect
       service: nginx
-      version: "{{ redirect_nginx_image_tag }}"
       deployment: redirect-nginx
-      deployment_stamp: "{{ deployment_stamp }}"
   template:
     metadata:
       labels:
         app: redirect
         service: nginx
-        version: "{{ redirect_nginx_image_tag }}"
         deployment: redirect-nginx
-        deployment_stamp: "{{ deployment_stamp }}"
     spec:
       # Prefer running pods on different nodes for redundancy
       affinity:

--- a/core_apps/redirect/templates/services/nginx/deploy.yml.j2
+++ b/core_apps/redirect/templates/services/nginx/deploy.yml.j2
@@ -56,6 +56,9 @@ spec:
             - mountPath: /etc/nginx/conf.d
               name: redirect-v-nginx
               readOnly: true
+      securityContext:
+        runAsUser: {{ container_uid }}
+        runAsGroup: {{ container_gid }}
       volumes:
         - name: redirect-v-nginx
           configMap:


### PR DESCRIPTION
## Purpose

1. We have a fatal error if we try to re-deploy the `redirect` core app: the `redirect-nginx` Deployment cannot to be updated. This is due to the fact that the `.spec.selector.matchLabels` field is Immutable in a Deployment and that we try to patch it with different values.

2. The securityContext is missing in `redirect-nginx` Deployment.

## Proposal

1. [x] Remove the dynamic labels from `redirect-nginx` Deployment
2. [x] Add `securityContext`
