### PR TITLE
✨(core) define a default storage class with ansible variable

### DIFF
--- a/apps/ashley/templates/volumes/media.yml.j2
+++ b/apps/ashley/templates/volumes/media.yml.j2
@@ -14,4 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ ashley_media_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
 {% endif %}

--- a/apps/ashley/templates/volumes/static.yml.j2
+++ b/apps/ashley/templates/volumes/static.yml.j2
@@ -14,4 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ ashley_static_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
 {% endif %}

--- a/apps/edxapp/templates/volumes/data.yml.j2
+++ b/apps/edxapp/templates/volumes/data.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ edxapp_data_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/edxapp/templates/volumes/export.yml.j2
+++ b/apps/edxapp/templates/volumes/export.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ edxapp_export_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/edxapp/templates/volumes/locale.yml.j2
+++ b/apps/edxapp/templates/volumes/locale.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ edxapp_locale_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/edxapp/templates/volumes/media.yml.j2
+++ b/apps/edxapp/templates/volumes/media.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ edxapp_media_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/edxec/templates/volumes/media.yml.j2
+++ b/apps/edxec/templates/volumes/media.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ edxec_media_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/edxec/templates/volumes/static.yml.j2
+++ b/apps/edxec/templates/volumes/static.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ edxec_static_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/elasticsearch/templates/volumes/bootstrap.yml.j2
+++ b/apps/elasticsearch/templates/volumes/bootstrap.yml.j2
@@ -14,4 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ elasticsearch_bootstrap_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
 {% endif %}

--- a/apps/hello/templates/volumes/hello.yml.j2
+++ b/apps/hello/templates/volumes/hello.yml.j2
@@ -12,3 +12,4 @@ spec:
   resources:
     requests:
       storage: 1Mi
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/learninglocker/templates/volumes/storage.yml.j2
+++ b/apps/learninglocker/templates/volumes/storage.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ learninglocker_storage_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/marsha/templates/volumes/media.yml.j2
+++ b/apps/marsha/templates/volumes/media.yml.j2
@@ -14,4 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ marsha_media_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
 {% endif %}

--- a/apps/marsha/templates/volumes/static.yml.j2
+++ b/apps/marsha/templates/volumes/static.yml.j2
@@ -14,4 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ marsha_static_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
 {% endif %}

--- a/apps/moodlenet/templates/volumes/uploads.yml.j2
+++ b/apps/moodlenet/templates/volumes/uploads.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ moodlenet_upload_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/nextcloud/templates/volumes/install.yml.j2
+++ b/apps/nextcloud/templates/volumes/install.yml.j2
@@ -13,3 +13,4 @@ spec:
   resources:
     requests:
       storage: {{ nextcloud_install_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/redis/templates/volumes/data.yml.j2
+++ b/apps/redis/templates/volumes/data.yml.j2
@@ -12,3 +12,4 @@ spec:
   resources:
     requests:
       storage: {{ redis_data_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"

--- a/apps/richie/templates/volumes/media.yml.j2
+++ b/apps/richie/templates/volumes/media.yml.j2
@@ -14,4 +14,5 @@ spec:
   resources:
     requests:
       storage: {{ richie_media_volume_size }}
+  storageClassName: "{{ default_storage_class_rwx }}"
 {% endif %}

--- a/bin/init-cluster
+++ b/bin/init-cluster
@@ -75,7 +75,7 @@ echo "K3d cluster configuration exported to ${KUBECONFIG}"
 
 # Count the number of PVs with RWX accessMode and with the status Available
 AVAILABLE_PV_COUNT=$(kubectl --kubeconfig="${KUBECONFIG}" get pv \
-  -l type=arnold-rwx \
+  -l type=arnold-rwx,storageclass=manual \
   -o jsonpath='{range .items[?(@.status.phase=="Available")]}{.metadata.name}{"\n"}{end}' \
   | wc -l)
 
@@ -101,8 +101,9 @@ metadata:
   name: arnold-${PV_ID}
   labels:
     type: arnold-rwx
+    storageclass: manual
 spec:
-  storageClassName: local-path
+  storageClassName: manual
   capacity:
     storage: 1000Gi
   accessModes:

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -178,3 +178,13 @@ container_uid: 10000
 # GID to use for running containers on k8s.
 # This value should be set to 0 (root).
 container_gid: 0
+
+
+# Storage class
+# A default storage class is not necessarily defined in a k8s cluster. The following
+# variables defines the storage class to use for our PVC, depending on the accessMode
+# we are requesting (RWO = ReadWriteOnce, RWX = ReadWriteMany).
+# If an arnold app requires a specific storageClass, it should be handled in the app
+# directly.
+default_storage_class_rwx: "manual"
+default_storage_class_rwo: "local-path"


### PR DESCRIPTION
## Purpose

A default `StorageClass` is not necessarily defined on a k8s cluster.
When this is the case, the `PersistentVolumeClaim` created by arnold are
stuck in the _Pending_ state.

(This PR depends on #622) 

## Proposal

- [x] Introduce new ansible variables `default_storage_class_rwx` and `default_storage_class_rwo` to define the Storage Class to use by default
- [x] Update apps volume templates to use these
- [x] Change the storage class name of the RWX PersistentVolumes that we pre-provision in the `bin/init-cluster` script, so they are not related to the default storage class anymore. This will allow the CI to validate that everything is working well.
