### PR TITLE
💬(core) replace occurences of Openshift with k8s in tasks and templates

### DIFF
--- a/apps/ashley/templates/services/postgresql/svc.yml.j2
+++ b/apps/ashley/templates/services/postgresql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
       targetPort: {{ ashley_database_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: ashley

--- a/apps/edxapp/templates/services/mongodb/svc.yml.j2
+++ b/apps/edxapp/templates/services/mongodb/svc.yml.j2
@@ -18,8 +18,7 @@ spec:
     targetPort: {{ edxapp_mongodb_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a mongodb cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a mongodb cluster outside of k8s.
   selector:
     app: edxapp
     deployment: "{{ edxapp_mongodb_host }}-{{ deployment_stamp }}"

--- a/apps/edxapp/templates/services/mysql/svc.yml.j2
+++ b/apps/edxapp/templates/services/mysql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
     targetPort: {{ edxapp_mysql_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: edxapp

--- a/apps/edxec/templates/services/mysql/svc.yml.j2
+++ b/apps/edxec/templates/services/mysql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
     targetPort: {{ edxec_mysql_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a MySQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a MySQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: edxec

--- a/apps/etherpad/templates/services/postgresql/svc.yml.j2
+++ b/apps/etherpad/templates/services/postgresql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
       targetPort: {{ etherpad_database_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: etherpad

--- a/apps/forum/templates/services/mongodb/svc.yml.j2
+++ b/apps/forum/templates/services/mongodb/svc.yml.j2
@@ -18,8 +18,7 @@ spec:
     targetPort: {{ forum_mongodb_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a mongodb cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a mongodb cluster outside of k8s.
   selector:
     app: forum
     deployment: "{{ forum_mongodb_host }}-{{ deployment_stamp }}"

--- a/apps/learninglocker/templates/services/mongodb/svc.yml.j2
+++ b/apps/learninglocker/templates/services/mongodb/svc.yml.j2
@@ -18,8 +18,7 @@ spec:
     targetPort: {{ learninglocker_mongodb_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a mongodb cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a mongodb cluster outside of k8s.
   selector:
     app: learninglocker
     deploymentconfig: "learninglocker-mongodb-{{ deployment_stamp }}"

--- a/apps/marsha/templates/services/postgresql/svc.yml.j2
+++ b/apps/marsha/templates/services/postgresql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
       targetPort: {{ marsha_postgresql_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: marsha

--- a/apps/moodlenet/templates/services/postgresql/svc.yml.j2
+++ b/apps/moodlenet/templates/services/postgresql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
       targetPort: {{ moodlenet_postgresql_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: moodlenet

--- a/apps/nextcloud/templates/services/postgresql/svc.yml.j2
+++ b/apps/nextcloud/templates/services/postgresql/svc.yml.j2
@@ -17,8 +17,7 @@ spec:
       targetPort: {{ nextcloud_database_port }}
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
-# not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# not trashable. In this case, we use a PostgreSQL cluster outside of k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: nextcloud

--- a/apps/redis-sentinel/templates/services/app/svc.yml.j2
+++ b/apps/redis-sentinel/templates/services/app/svc.yml.j2
@@ -1,7 +1,7 @@
-{# 
-  Disclaimer: This template is not relative to an OpenShift Service object but to a RedisFailover object.
+{#
+  Disclaimer: This template is not relative to a k8s Service object but to a RedisFailover object.
   RedisFailover is part of the redis-operator (https://github.com/spotahome/redis-operator) and must be
-  deploy at the same time of other OpenShift Service, this is why we decided to created in this file.
+  deploy at the same time of other k8s Service, this is why we decided to created in this file.
 #}
 apiVersion: databases.spotahome.com/v1
 kind: RedisFailover

--- a/apps/redis/templates/services/app/deploy.yml.j2
+++ b/apps/redis/templates/services/app/deploy.yml.j2
@@ -9,7 +9,7 @@ metadata:
   namespace: "{{ namespace_name }}"
 spec:
   replicas: 1  # number of pods we want
-  # When upgrading, we don't want OpenShift to run several pods mounted on the same volume
+  # When upgrading, we don't want k8s to run several pods mounted on the same volume
   # because Redis does not support that. Instead we need to make sure that the existing pod
   # is switched off before the new one starts.
   strategy:

--- a/apps/richie/templates/services/postgresql/svc.yml.j2
+++ b/apps/richie/templates/services/postgresql/svc.yml.j2
@@ -18,7 +18,7 @@ spec:
 # As commented in the ad hoc endpoint, the endpoint name points to this service
 # so that it does not rely on a deployment configuration when the "env_type" is
 # not trashable. In this case, we use a PostgreSQL cluster outside of
-# OpenShift.
+# k8s.
 {% if env_type in trashable_env_types %}
   selector:
     app: richie

--- a/create_object.yml
+++ b/create_object.yml
@@ -1,5 +1,5 @@
 ---
-# This playbook pushes an OpenShift definition file for a project.
+# This playbook pushes a k8s definition file for a project.
 #
 # A definition file is generated and pushed for a template given the
 # `object_template` path.

--- a/create_redirect.yml
+++ b/create_redirect.yml
@@ -48,7 +48,7 @@
         loop_var: deployment
 
     # Check if the nginx service already exists and recreate it only if not
-    # (parts of an OpenShift Service definition are immutable).
+    # (parts of an k8s Service definition are immutable).
     - name: Check if the redirect nginx service already exists
       k8s_info:
         api_version: "v1"

--- a/tasks/create_app_config.yml
+++ b/tasks/create_app_config.yml
@@ -57,7 +57,7 @@
     var: configmaps_from_files
     verbosity: 3
 
-- name: Create the config maps in OpenShift
+- name: Create the config maps in k8s
   k8s:
     state: present
     name: "{{ app.name }}-{{ item.key }}{{ deployment_stamp is none | ternary('', '-') }}{{ deployment_stamp }}"

--- a/tasks/create_app_secrets.yml
+++ b/tasks/create_app_secrets.yml
@@ -17,7 +17,7 @@
     secrets: "{{ templates | map('regex_search', '.*/secret.*\\.yml\\.j2$') | select('string') | list }}"
   tags: secret
 
-- name: Display OpenShift's secrets for this app
+- name: Display k8s's secrets for this app
   debug:
     var: secrets
     verbosity: 2
@@ -25,7 +25,7 @@
   tags: secret
 
 # Create all secrets for the current application
-- name: Actually create the secrets in OpenShift
+- name: Actually create the secrets in k8s
   k8s:
     state: present
     definition: "{{ lookup('template', item) | from_yaml }}"

--- a/tasks/deploy_get_stamp_from_static_service.yml
+++ b/tasks/deploy_get_stamp_from_static_service.yml
@@ -14,7 +14,6 @@
       - type=static-service
       - app={{ app.name }}
       - service_prefix={{ prefix }}
-      - "!acme.openshift.io/temporary"
   register: app_service
   when: static_services | length > 0 and app.settings.is_blue_green_compatible | default(True)
 

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -12,7 +12,7 @@
 
 - include_tasks: tasks/filter_empty_templates_for_app.yml
 
-- name: Set OpenShift objects to manage
+- name: Set k8s objects to manage
   set_fact:
     configmaps: "{{ templates | map('regex_search', '.*/cm.*\\.yml\\.j2$') | select('string') | list }}"
     deployments: "{{ templates | map('regex_search', '.*/deploy.*\\.yml\\.j2$') | select('string') | list }}"
@@ -33,7 +33,7 @@
     - service
     - statefulset
 
-- name: Display OpenShift's configmaps for this app
+- name: Display k8s's configmaps for this app
   debug:
     var: configmaps
     verbosity: 2
@@ -42,7 +42,7 @@
     - deploy
     - configmap
 
-- name: Display OpenShift's deployments for this app
+- name: Display k8s's deployments for this app
   debug:
     var: deployments
     verbosity: 2
@@ -51,7 +51,7 @@
     - deploy
     - deployment
 
-- name: Display OpenShift's statefulsets for this app
+- name: Display k8s's statefulsets for this app
   debug:
     var: statefulsets
     verbosity: 2
@@ -60,7 +60,7 @@
     - deploy
     - statefulset
 
-- name: Display OpenShift's endpoints for this app
+- name: Display k8s's endpoints for this app
   debug:
     var: endpoints
     verbosity: 2
@@ -69,7 +69,7 @@
     - deploy
     - endpoint
 
-- name: Display OpenShift's services for this app
+- name: Display k8s's services for this app
   debug:
     var: services
     verbosity: 2
@@ -78,7 +78,7 @@
     - deploy
     - service
 
-- name: Display OpenShift's jobs for this app
+- name: Display k8s's jobs for this app
   debug:
     var: jobs
     verbosity: 2
@@ -87,7 +87,7 @@
     - deploy
     - job
 
-- name: Display OpenShift's cronjobs for this app
+- name: Display k8s's cronjobs for this app
   debug:
     var: cronjobs
     verbosity: 2

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -6,7 +6,7 @@
 #     - "absent":  all objects are deleted
 #   deployment_stamp: the stamp of the object we are going to create or delete
 
-- name: OpenShift objects with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
+- name: k8s objects with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
   k8s:
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: "{{ deployment_state | default('present') }}"
@@ -45,7 +45,7 @@
     - deploy
     - job
 
-- name: OpenShift cronjobs with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
+- name: k8s cronjobs with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
   k8s:
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: "{{ deployment_state | default('present') }}"
@@ -54,7 +54,7 @@
     - deploy
     - cronjob
 
-- name: OpenShift deployments with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
+- name: k8s deployments with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
   k8s:
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: "{{ deployment_state | default('present') }}"
@@ -63,7 +63,7 @@
     - deploy
     - deployment
 
-- name: OpenShift StatefulSets with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
+- name: k8s StatefulSets with deployment_stamp[{{ deployment_stamp }}] must be {{ deployment_state | default('present') }}
   k8s:
     definition: "{{ lookup('template', item) | from_yaml }}"
     state: "{{ deployment_state | default('present') }}"


### PR DESCRIPTION
## Purpose

There are still occurrences of Openshift in comments or in the names
of ansible tasks. 

## Proposal

- [x] Replace Openshift by k8s in ansible tasks and templates
