### PR TITLE
Fix/misc k8s fixes

### DIFF
--- a/apps/ashley/templates/services/nginx/ingress.yml.j2
+++ b/apps/ashley/templates/services/nginx/ingress.yml.j2
@@ -25,4 +25,4 @@ spec:
   tls:
   - hosts:
     - "{{ ashley_host | blue_green_host(prefix) }}"
-    secretName: ashley-app-tls
+    secretName: "ashley-app-tls-{{ prefix }}"

--- a/apps/ashley/templates/services/nginx/ingress.yml.j2
+++ b/apps/ashley/templates/services/nginx/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -19,9 +19,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "ashley-nginx-{{ prefix }}"
-          servicePort: {{ ashley_nginx_port }}
+          service:
+            name: "ashley-nginx-{{ prefix }}"
+            port:
+              number: {{ ashley_nginx_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ ashley_host | blue_green_host(prefix) }}"

--- a/apps/ashley/templates/services/nginx/ingress.yml.j2
+++ b/apps/ashley/templates/services/nginx/ingress.yml.j2
@@ -12,7 +12,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ ashley_host | blue_green_host(prefix) }}"

--- a/apps/ashley/templates/services/postgresql/deploy.yml.j2
+++ b/apps/ashley/templates/services/postgresql/deploy.yml.j2
@@ -44,7 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ ashley_database_secret_name }}"
-{% endif%}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
+{% endif%}

--- a/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
@@ -12,7 +12,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "cms"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
   rules:

--- a/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
@@ -26,4 +26,4 @@ spec:
   tls:
   - hosts:
     - "{{ edxapp_cms_host | blue_green_host(prefix) }}"
-    secretName: edxapp-cms-tls
+    secretName: "edxapp-cms-tls-{{ prefix }}"

--- a/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "edxapp-nginx-cms-{{ prefix }}"
@@ -20,9 +20,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "edxapp-nginx-{{ prefix }}"
-          servicePort: {{ edxapp_nginx_cms_port }}
+          service:
+            name: "edxapp-nginx-{{ prefix }}"
+            port:
+              number: {{ edxapp_nginx_cms_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ edxapp_cms_host | blue_green_host(prefix) }}"

--- a/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "edxapp-nginx-lms-{{ prefix }}"
@@ -20,9 +20,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "edxapp-nginx-{{ prefix }}"
-          servicePort: {{ edxapp_nginx_lms_port }}
+          service:
+            name: "edxapp-nginx-{{ prefix }}"
+            port:
+              number: {{ edxapp_nginx_lms_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ edxapp_lms_host | blue_green_host(prefix) }}"

--- a/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
@@ -26,4 +26,4 @@ spec:
   tls:
   - hosts:
     - "{{ edxapp_lms_host | blue_green_host(prefix) }}"
-    secretName: edxapp-lms-tls
+    secretName: "edxapp-lms-tls-{{ prefix }}"

--- a/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
@@ -12,7 +12,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "lms"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
   rules:

--- a/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
@@ -26,4 +26,4 @@ spec:
   tls:
   - hosts:
     - "{{ edxapp_preview_host | blue_green_host(prefix) }}"
-    secretName: edxapp-preview-tls
+    secretName: "edxapp-preview-tls-{{ prefix }}"

--- a/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "edxapp-nginx-preview-{{ prefix }}"
@@ -20,9 +20,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "edxapp-nginx-{{ prefix }}"
-          servicePort: {{ edxapp_nginx_lms_port }}
+          service:
+            name: "edxapp-nginx-{{ prefix }}"
+            port:
+              number: {{ edxapp_nginx_lms_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ edxapp_preview_host | blue_green_host(prefix) }}"

--- a/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
@@ -12,7 +12,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "lms"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
   rules:

--- a/apps/edxec/templates/services/nginx/ingress.yml.j2
+++ b/apps/edxec/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ edxec_host | blue_green_host(prefix) }}"

--- a/apps/edxec/templates/services/nginx/ingress.yml.j2
+++ b/apps/edxec/templates/services/nginx/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ edxec_host | blue_green_host(prefix) }}"
-    secretName: edxec-app-tls
+    secretName: "edxec-app-tls-{{ prefix }}"

--- a/apps/edxec/templates/services/nginx/ingress.yml.j2
+++ b/apps/edxec/templates/services/nginx/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "edxec-nginx-{{ prefix }}"
-          servicePort: {{ edxec_nginx_port }}
+          service:
+            name: "edxec-nginx-{{ prefix }}"
+            port:
+              number: {{ edxec_nginx_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ edxec_host | blue_green_host(prefix) }}"

--- a/apps/etherpad/templates/services/nginx/ingress.yml.j2
+++ b/apps/etherpad/templates/services/nginx/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ etherpad_host | blue_green_host(prefix) }}"
-    secretName: etherpad-app-tls
+    secretName: "etherpad-app-tls-{{ prefix }}"

--- a/apps/etherpad/templates/services/nginx/ingress.yml.j2
+++ b/apps/etherpad/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ etherpad_host | blue_green_host(prefix) }}"

--- a/apps/etherpad/templates/services/nginx/ingress.yml.j2
+++ b/apps/etherpad/templates/services/nginx/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "etherpad-nginx-{{ prefix }}"
-          servicePort: {{ etherpad_nginx_port }}
+          service:
+            name: "etherpad-nginx-{{ prefix }}"
+            port:
+              number: {{ etherpad_nginx_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ etherpad_host | blue_green_host(prefix) }}"

--- a/apps/flower/templates/services/nginx/ingress_flower.yml.j2
+++ b/apps/flower/templates/services/nginx/ingress_flower.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "flower-nginx"
-          servicePort: {{ flower_nginx_app_port }}
+          service:
+            name: "flower-nginx"
+            port:
+              number: {{ flower_nginx_app_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ flower_host }}"

--- a/apps/flower/templates/services/nginx/ingress_flower.yml.j2
+++ b/apps/flower/templates/services/nginx/ingress_flower.yml.j2
@@ -11,7 +11,7 @@ metadata:
     version: "{{ flower_nginx_image_tag }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ flower_host }}"

--- a/apps/forum/templates/services/app/ingress.yml.j2
+++ b/apps/forum/templates/services/app/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ forum_host | blue_green_host(prefix) }}"

--- a/apps/forum/templates/services/app/ingress.yml.j2
+++ b/apps/forum/templates/services/app/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "forum-app-{{ prefix }}"
-          servicePort: {{ forum_port }}
+          service:
+            name: "forum-app-{{ prefix }}"
+            port:
+              number: {{ forum_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ forum_host | blue_green_host(prefix) }}"

--- a/apps/forum/templates/services/app/ingress.yml.j2
+++ b/apps/forum/templates/services/app/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ forum_host | blue_green_host(prefix) }}"
-    secretName: forum-app-tls
+    secretName: "forum-app-tls-{{ prefix }}"

--- a/apps/hello/templates/services/app/ingress.yml.j2
+++ b/apps/hello/templates/services/app/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: "hello-app-{{ prefix }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "hello-app-{{ prefix }}"
-          servicePort: {{ hello_app_port }}
+          service:
+            name: "hello-app-{{ prefix }}"
+            port:
+              number: {{ hello_app_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ hello_host | blue_green_host(prefix) }}"

--- a/apps/hello/templates/services/app/ingress.yml.j2
+++ b/apps/hello/templates/services/app/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ hello_host | blue_green_host(prefix) }}"
-    secretName: hello-app-tls
+    secretName: "hello-app-tls-{{ prefix }}"

--- a/apps/hello/templates/services/app/ingress.yml.j2
+++ b/apps/hello/templates/services/app/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ hello_host | blue_green_host(prefix) }}"

--- a/apps/kibana/templates/services/nginx/ingress.yml.j2
+++ b/apps/kibana/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ kibana_host | blue_green_host(prefix) }}"

--- a/apps/kibana/templates/services/nginx/ingress.yml.j2
+++ b/apps/kibana/templates/services/nginx/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ kibana_host | blue_green_host(prefix) }}"
-    secretName: kibana-app-tls
+    secretName: "kibana-app-tls-{{ prefix }}"

--- a/apps/kibana/templates/services/nginx/ingress.yml.j2
+++ b/apps/kibana/templates/services/nginx/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "kibana-nginx-{{ prefix }}"
-          servicePort: {{ kibana_nginx_port }}
+          service:
+            name: "kibana-nginx-{{ prefix }}"
+            port:
+              number: {{ kibana_nginx_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ kibana_host | blue_green_host(prefix) }}"

--- a/apps/mailcatcher/templates/services/app/ingress.yml.j2
+++ b/apps/mailcatcher/templates/services/app/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "mailcatcher"
-          servicePort: {{ mailcatcher_reader_port }}
+          service:
+            name: "mailcatcher"
+            port:
+              number: {{ mailcatcher_reader_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ mailcatcher_host }}"

--- a/apps/mailcatcher/templates/services/app/ingress.yml.j2
+++ b/apps/mailcatcher/templates/services/app/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     version: "{{ mailcatcher_image_tag }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ mailcatcher_host }}"

--- a/apps/marsha/templates/services/nginx/ingress.yml.j2
+++ b/apps/marsha/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ marsha_host | blue_green_host(prefix) }}"

--- a/apps/marsha/templates/services/nginx/ingress.yml.j2
+++ b/apps/marsha/templates/services/nginx/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ marsha_host | blue_green_host(prefix) }}"
-    secretName: marsha-app-tls
+    secretName: "marsha-app-tls-{{ prefix }}"

--- a/apps/marsha/templates/services/nginx/ingress.yml.j2
+++ b/apps/marsha/templates/services/nginx/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "marsha-nginx-{{ prefix }}"
-          servicePort: {{ marsha_nginx_port }}
+          service:
+            name: "marsha-nginx-{{ prefix }}"
+            port:
+              number: {{ marsha_nginx_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ marsha_host | blue_green_host(prefix) }}"

--- a/apps/richie/templates/services/nginx/ingress.yml.j2
+++ b/apps/richie/templates/services/nginx/ingress.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   namespace: "{{ namespace_name }}"
@@ -18,9 +18,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: "richie-nginx-{{ prefix }}"
-          servicePort: {{ richie_nginx_port }}
+          service:
+            name: "richie-nginx-{{ prefix }}"
+            port:
+              number: {{ richie_nginx_port }}
         path: /
+        pathType: Prefix
   tls:
   - hosts:
     - "{{ richie_host | blue_green_host(prefix) }}"

--- a/apps/richie/templates/services/nginx/ingress.yml.j2
+++ b/apps/richie/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,7 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
-    cert-manager.io/cluster-issuer: "{{ acme_issuer_name }}"
+    cert-manager.io/issuer: "{{ acme_issuer_name }}"
 spec:
   rules:
   - host: "{{ richie_host | blue_green_host(prefix) }}"

--- a/apps/richie/templates/services/nginx/ingress.yml.j2
+++ b/apps/richie/templates/services/nginx/ingress.yml.j2
@@ -24,4 +24,4 @@ spec:
   tls:
   - hosts:
     - "{{ richie_host | blue_green_host(prefix) }}"
-    secretName: richie-app-tls
+    secretName: "richie-app-tls-{{ prefix }}"

--- a/apps/richie/templates/services/postgresql/deploy.yml.j2
+++ b/apps/richie/templates/services/postgresql/deploy.yml.j2
@@ -44,7 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ richie_database_secret_name }}"
-{% endif%}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
+{% endif%}


### PR DESCRIPTION
## Purpose

This PR is intended to fix 5 issues : 

1. The `postgresql` Deployment template in `Ashley` causes an error in non-trashable environment type.
2. There is a confict in the secret name used to store TLS certificates in blue/green applications
3. The annotation used to declare the cert-manager `Issuer` to use in invalid in all Ingresse templates
4. There is warning due to the usage of a deprecated `apiVersion` in Ingresses templates
5. The `postgresql` Deployment template in `Richie` causes an error in non-trashable environment type.

## Proposal

1. [x] Fix Deployment template for ashley/postgresql
2. [x] Use the prefix in the secret name to have a distinct secret per Ingress
3. [x] Use `cert-manager.io/issuer` annotation instead of `cert-manager.io/cluster-issuer`
4. Upgrade all Ingresses :
   - [x] Change apiVersion `extensions/v1beta1` :arrow_right:  `networking.k8s.io/v1`
   - [x] Add [pathType](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types) argument that is now required 
   - [x] Update the backend definition according to the new spec
5. [x] Fix Deployment template for richie/postgresql