### PR TITLE
✨(cli) add an option to disable the use of K8S CA certificate

### DIFF
--- a/bin/arnold
+++ b/bin/arnold
@@ -111,11 +111,17 @@ export K8S_DOMAIN
 #    If you work on a specific k8s cluster, you need to create a serviceaccount with
 #    enough permissions to be able to run the Ansible playbook tasks, and adjust these
 #    variables to match your configuration.
+#
+#    By default, arnold will use the ca.crt stored in the Service Account secret to
+#    check the k8s API certificate. You might want to disable this if your k8s API
+#    certificate is signed by a public trusted CA, by setting the environment variable
+#    USE_K8S_SERVICE_ACCOUNT_CA_CERT to 0.
 
 declare K3D_CLUSTER_NAME=${K3D_CLUSTER_NAME:-arnold}
 declare K8S_CONTEXT="${K8S_CONTEXT:-"k3d-${K3D_CLUSTER_NAME}"}"
 declare K8S_SERVICE_ACCOUNT="${K8S_SERVICE_ACCOUNT:-"arnold"}"
 declare K8S_SERVICE_ACCOUNT_NAMESPACE="${K8S_SERVICE_ACCOUNT_NAMESPACE:-"default"}"
+declare -i USE_K8S_SERVICE_ACCOUNT_CA_CERT=${USE_K8S_SERVICE_ACCOUNT_CA_CERT:-1}
 
 # Flags
 declare -i DEV_MODE=0
@@ -376,9 +382,11 @@ function _set_k8s_env() {
       K8S_AUTH_API_KEY=$(${KUBECTL} --namespace "${K8S_SERVICE_ACCOUNT_NAMESPACE}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\\.io/service-account\\.name']=='${K8S_SERVICE_ACCOUNT}')].data.token}"|base64 --decode)
 
       # Get certificate authority data
-      K8S_AUTH_SSL_CA_CERT_B64=$(${KUBECTL} --namespace "${K8S_SERVICE_ACCOUNT_NAMESPACE}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\\.io/service-account\\.name']=='${K8S_SERVICE_ACCOUNT}')].data.ca\\.crt}")
-      if [[ -n "${K8S_AUTH_SSL_CA_CERT_B64}" ]] ; then
-        export K8S_AUTH_SSL_CA_CERT_B64
+      if [[ ${USE_K8S_SERVICE_ACCOUNT_CA_CERT} -eq 1 ]]; then
+        K8S_AUTH_SSL_CA_CERT_B64=$(${KUBECTL} --namespace "${K8S_SERVICE_ACCOUNT_NAMESPACE}" get secrets -o jsonpath="{.items[?(@.metadata.annotations['kubernetes\\.io/service-account\\.name']=='${K8S_SERVICE_ACCOUNT}')].data.ca\\.crt}")
+        if [[ -n "${K8S_AUTH_SSL_CA_CERT_B64}" ]] ; then
+          export K8S_AUTH_SSL_CA_CERT_B64
+        fi
       fi
 
       if [[ -z "${K8S_AUTH_API_KEY}" ]] ; then


### PR DESCRIPTION
## Purpose

When using ServiceAccount discovery to authenticate against k8s API,
the CA certificate of k8s is automatically transmitted to arnold
container via the `K8S_AUTH_SSL_CA_CERT_B64` environment variable.

And this CA certificate is then used by ansible to validate the
certificate of k8s' API. It is useful in situations where k8s API use
a self-signed certificate. But in other situations, the certificate
used by k8s API is signed by a public trusted CA. And we should not
verify it with k8s internal CA certificate.

## Proposal

A new flag has been introduced (`USE_K8S_SERVICE_ACCOUNT_CA_CERT`) to
disable the use of K8S CA certificate.
