### PR TITLE
🐛(edxapp) fix type error endpoint templates

### DIFF
--- a/apps/edxapp/templates/services/mongodb/ep.yml.j2
+++ b/apps/edxapp/templates/services/mongodb/ep.yml.j2
@@ -16,8 +16,8 @@ subsets:
       - 
         ip: "{{ ip }}"
     ports:
-      - 
-        port: "{{ edxapp_mongodb_port }}"
+      -
+        port: {{ edxapp_mongodb_port }}
         name: "mongodb-{{ ip | regex_replace("\.", "-") }}-tcp"
 {% endfor -%}
 {% endif %}

--- a/apps/edxapp/templates/services/mysql/ep.yml.j2
+++ b/apps/edxapp/templates/services/mysql/ep.yml.j2
@@ -13,6 +13,6 @@ subsets:
   - addresses:
     - ip: "{{ endpoint_mysql_ip }}"
     ports:
-    - port: "{{ edxapp_mysql_port }}"
+    - port: {{ edxapp_mysql_port }}
       name: "{{ edxapp_mysql_port }}-tcp"
 {% endif %}


### PR DESCRIPTION
## Purpose

The Endpoint templates in edxapp declare target port as strings, when
it should be an integers. This causes a fatal error when we try to
deploy edxapp in a non-trashable environment type.

## Proposal

- [x] Fix endpoint templates
