### PR TITLE
🔧(redis-sentinel) update redis-sentinel to be compatible with k8s

### DIFF
--- a/apps/redis-sentinel/templates/services/app/svc.yml.j2
+++ b/apps/redis-sentinel/templates/services/app/svc.yml.j2
@@ -36,9 +36,8 @@ spec:
 {% endfor %}
 {% endif %}
     securityContext:
-      runAsUser: {{ redis_sentinel_user_id }}
-      runAsGroup: {{ redis_sentinel_group_id }}
-      fsGroup: {{ redis_sentinel_fsgroup_id }}
+      runAsUser: {{ container_uid }}
+      runAsGroup: {{ container_gid }}
   redis:
     replicas: {{ redis_sentinel_redis_replicas }}
     affinity:
@@ -75,8 +74,8 @@ spec:
           resources:
             requests:
               storage: {{ redis_sentinel_redis_data_volume_size }}
+          storageClassName: "{{ default_storage_class_rwo }}"
 {% endif %}
     securityContext:
-      runAsUser: {{ redis_sentinel_user_id }}
-      runAsGroup: {{ redis_sentinel_group_id }}
-      fsGroup: {{ redis_sentinel_fsgroup_id }}
+      runAsUser: {{ container_uid }}
+      runAsGroup: {{ container_gid }}

--- a/apps/redis-sentinel/vars/all/main.yml
+++ b/apps/redis-sentinel/vars/all/main.yml
@@ -1,17 +1,10 @@
-# The following settings can be found in the project's annotation.
-# To retrieve them run the following command:
-#   $ oc get project $(oc project -q) -o yaml
-# then copy values of the `openshift.io/sa.scc.supplemental-groups` annotation
-redis_sentinel_user_id: null
-redis_sentinel_group_id: null
-redis_sentinel_fsgroup_id: null
 
 ## Service configuration
 # name used by the service. This name will be prefixed by `rfs-` in the final service
 redis_sentinel_service_name: redis-sentinel
 
 ## Sentinel configuration
-# Number of sentinel replicas 
+# Number of sentinel replicas
 redis_sentinel_sentinel_replicas: 3
 # If you need custom sentinel configuration you should add
 # them in this list with one configuration per item, e.g.:


### PR DESCRIPTION
## Purpose

We want to deploy the redis-sentinel app on a kubernetes cluster.

## Proposal

Since all the work is done by the redis-operator, the application
could have been deployed on kubernetes as-is. But a few improvements
were made : 

- [x] use `container_uid` and `container_gid` in the securityContext to be consistent with the rest of the apps
- [x] Remove the ansible variables `redis_sentinel_user_id`, `redis_sentinel_group_id` and `redis_sentinel_fsgroup_id`
- [x] Set the storage class to use when persistence is enabled
