### PR TITLE
👷(circle) trigger the hub job on branch migration-to-k8s

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -983,6 +983,8 @@ workflows:
             - test-prevent-switch-to-nothing
           filters:
             branches:
-              only: master
+              only:
+                - master
+                - migration-to-k8s
             tags:
               only: /^v.*/


### PR DESCRIPTION
## Purpose

We want to publish a docker image containing the latest changes of the
kubernetes edition of arnold. It's a solution that is intended to be
temporary, but it will allow us to use arnold on real environments
easily.

## Proposal

Update the CircleCI configuration to trigger the `hub` job on branch `migration-to-k8s`
