### PR TITLE
🐛(cli) autodetect if we are in a terminal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Use `kubectl` instead of `oc` in `arnold` CLI
 - Authentication in `arnold` CLI must be done with a service account
 - Replace `oc cluster` with k3d for local development
+- CLI: autodetect if we are within a terminal
 
 ### Removed
 

--- a/bin/arnold
+++ b/bin/arnold
@@ -604,8 +604,15 @@ function _docker_run() {
       fi
     fi
 
+    if tty > /dev/null ; then
+      # If we are in a terminal, add the `-t` option to docker run
+      DOCKER_TERM_OPTIONS="-ti"
+    else
+      DOCKER_TERM_OPTIONS="-i"
+    fi
+
     # shellcheck disable=SC2086
-    docker run --rm -ti \
+    docker run --rm "${DOCKER_TERM_OPTIONS}" \
         -u "${DOCKER_USER}" \
         --env K8S_AUTH_API_KEY \
         --env K8S_AUTH_HOST \


### PR DESCRIPTION
## Purpose

We want to use arnold CLI on CI environements that don't run
necessarily inside a terminal. In these case, the docker run command
fail with the following error: `the input device is not a TTY`,
because of the `-t` option.

## Proposal

Autodetect if we are within a terminal and add the `-t` option to docker run only in this case.
