### PR TITLE
🐛(core) trim templates before checking if we should ignore them

### DIFF
--- a/apps/forum/templates/services/mongodb/deploy.yml.j2
+++ b/apps/forum/templates/services/mongodb/deploy.yml.j2
@@ -45,4 +45,3 @@ spec:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
 {% endif %}
-

--- a/tasks/filter_empty_templates_for_app.yml
+++ b/tasks/filter_empty_templates_for_app.yml
@@ -12,7 +12,7 @@
     path: "{{ item }}"
   register: filtered_templates
   with_items: "{{ raw_templates }}"
-  when: lookup('template', item) | length > 1
+  when: lookup('template', item) | trim | length > 1
   tags: deploy
 
 - name: Update templates list for this app


### PR DESCRIPTION
## Purpose

We are unable to deploy the forum on non-trashable environment type.
This is due to the fact that the mongodb deployment template contains
an extra-line at the end of file, and is not ignored by the "Ignore
empty rendered templates" task. It results in a fatal error during
deployment. The ansible task has been fixed to trim files and avoid
this kind of error.

## Proposal
- [x] Fix the "Ignore empty rendered template" task
- [x] Remove the extra line in mongodb deployment template
