### PR TITLE
✨(apps) allow defining resources requests for all pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -463,6 +463,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Fix npm installation in Eucalyptus flavors
 - The forum API key generated a syntax error when its last character was a ":"
 
+### Added
+
+- Add resources requests to all applications to improve pod scheduling.
+
 ## [4.3.0] - 2019-12-13
 
 ### Added

--- a/apps/ashley/templates/services/app/cronjob_update_index.yml.j2
+++ b/apps/ashley/templates/services/app/cronjob_update_index.yml.j2
@@ -43,4 +43,5 @@ spec:
                     name: "{{ ashley_secret_name }}"
                 - configMapRef:
                     name: "ashley-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ ashley_app_cronjob_update_index_resources }}
           restartPolicy: Never

--- a/apps/ashley/templates/services/app/deploy.yml.j2
+++ b/apps/ashley/templates/services/app/deploy.yml.j2
@@ -71,6 +71,7 @@ spec:
                 name: "{{ ashley_secret_name }}"
             - configMapRef:
                 name: "ashley-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ ashley_app_resources }}
           volumeMounts:
 {% if ashley_should_activate_media_volume %}
             - name: ashley-v-media

--- a/apps/ashley/templates/services/app/job_01_collectstatic.yml.j2
+++ b/apps/ashley/templates/services/app/job_01_collectstatic.yml.j2
@@ -45,6 +45,7 @@ spec:
           volumeMounts:
             - mountPath: /data/static
               name: ashley-v-static
+          resources: {{ ashley_app_job_collectstatic_resources }}
       volumes:
         - name: ashley-v-static
           persistentVolumeClaim:

--- a/apps/ashley/templates/services/app/job_02_db_migrate.yml.j2
+++ b/apps/ashley/templates/services/app/job_02_db_migrate.yml.j2
@@ -38,6 +38,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py migrate
+          resources: {{ ashley_app_job_db_migrate_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/ashley/templates/services/nginx/deploy.yml.j2
+++ b/apps/ashley/templates/services/nginx/deploy.yml.j2
@@ -68,7 +68,6 @@ spec:
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: ashley-htpasswd
 {% endif %}
-
           livenessProbe:
             httpGet:
               path: "{{ ashley_nginx_healthcheck_endpoint }}"
@@ -81,6 +80,7 @@ spec:
               port: {{ ashley_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ ashley_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/ashley/templates/services/postgresql/deploy.yml.j2
+++ b/apps/ashley/templates/services/postgresql/deploy.yml.j2
@@ -44,6 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ ashley_database_secret_name }}"
+          resources: {{ ashley_postgresql_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/ashley/vars/all/main.yml
+++ b/apps/ashley/vars/all/main.yml
@@ -53,3 +53,27 @@ ashley_media_volume_size: 2Gi
 ashley_static_volume_size: 1Gi
 ashley_should_activate_media_volume: true
 ashley_should_activate_static_volume: true
+
+# -- resources requests
+{% set app_resources = {
+  "requests": {
+    "cpu": "10m",
+    "memory": "250Mi"
+  }
+} %}
+
+ashley_app_resources: "{{ app_resources }}"
+
+ashley_app_job_collectstatic_resources: "{{ app_resources }}"
+ashley_app_job_db_migrate_resources: "{{ app_resources }}"
+ashley_app_cronjob_update_index_resources: "{{ app_resources }}"
+
+ashley_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 20Mi
+
+ashley_postgresql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/apps/edxapp/templates/services/cms/_deploy_base.yml.j2
+++ b/apps/edxapp/templates/services/cms/_deploy_base.yml.j2
@@ -117,6 +117,7 @@ spec:
           initialDelaySeconds: 60
           periodSeconds: 10
 {% endif %}
+        resources: {{ resources }}
         volumeMounts:
         - mountPath: /config
           name: edxapp-config

--- a/apps/edxapp/templates/services/cms/deploy.yml.j2
+++ b/apps/edxapp/templates/services/cms/deploy.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "wsgi" %}
 {% set replicas = edxapp_cms_replicas %}
+{% set resources = edxapp_cms_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/cms/deploy_queue_default_priority.yml.j2
+++ b/apps/edxapp/templates/services/cms/deploy_queue_default_priority.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_cms_default_priority_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/cms/deploy_queue_high_priority.yml.j2
+++ b/apps/edxapp/templates/services/cms/deploy_queue_high_priority.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_cms_high_priority_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/cms/deploy_queue_low_priority.yml.j2
+++ b/apps/edxapp/templates/services/cms/deploy_queue_low_priority.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "cms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_cms_low_priority_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/cms/job_01_create_directories.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_01_create_directories.yml.j2
@@ -47,6 +47,7 @@ spec:
             - mountPath: /edx/app/edxapp/edx-platform/conf/locale
               name: edxapp-v-locale
 {% endif %}
+          resources: {{ edxapp_cms_job_create_directories_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/edxapp/templates/services/cms/job_02_internationalization.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_02_internationalization.yml.j2
@@ -65,6 +65,7 @@ spec:
 {% endfor %}
               echo "translations:" &&
               ls -l conf/locale/*/LC_MESSAGES/
+          resources: {{ edxapp_cms_job_internationalization_resources }}
           volumeMounts:
             - mountPath: /edx/app/edxapp/edx-platform/conf/locale
               name: edxapp-v-locale

--- a/apps/edxapp/templates/services/cms/job_04_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_04_db_migrate.yml.j2
@@ -36,6 +36,7 @@ spec:
             - "/bin/bash"
             - "-c"
             - DJANGO_SETTINGS_MODULE=cms.envs.fun.docker_run python manage.py cms migrate
+          resources: {{ edxapp_cms_job_db_migrate_resources }}
           volumeMounts:
             - mountPath: /config
               name: edxapp-config

--- a/apps/edxapp/templates/services/cms/job_05_load_fixtures.yml.j2
+++ b/apps/edxapp/templates/services/cms/job_05_load_fixtures.yml.j2
@@ -44,7 +44,7 @@ spec:
               cd - &&
               python manage.py cms import /edx/app/edxapp/data /tmp/edx-demo-course* &&
               python manage.py cms shell < /tmp/configmap-fixtures/create_demo_users.py
-
+          resources: {{ edxapp_cms_job_load_fixtures_resources }}
           volumeMounts:
             - mountPath: /tmp/configmap-fixtures
               name: edxapp-configmap-fixtures

--- a/apps/edxapp/templates/services/lms/deploy.yml.j2
+++ b/apps/edxapp/templates/services/lms/deploy.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "wsgi" %}
 {% set replicas = edxapp_lms_replicas %}
+{% set resources = edxapp_lms_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/lms/deploy_queue_default_priority.yml.j2
+++ b/apps/edxapp/templates/services/lms/deploy_queue_default_priority.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_lms_default_priority_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/lms/deploy_queue_high_mem.yml.j2
+++ b/apps/edxapp/templates/services/lms/deploy_queue_high_mem.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_lms_high_mem_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/lms/deploy_queue_high_priority.yml.j2
+++ b/apps/edxapp/templates/services/lms/deploy_queue_high_priority.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_lms_high_priority_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/lms/deploy_queue_low_priority.yml.j2
+++ b/apps/edxapp/templates/services/lms/deploy_queue_low_priority.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "lms" %}
 {% set worker_type = "queue" %}
 {% set celery_worker = edxapp_celery_lms_low_priority_worker %}
+{% set resources = edxapp_queue_resources %}
 
 {% include "apps/edxapp/templates/services/cms/_deploy_base.yml.j2" with context %}

--- a/apps/edxapp/templates/services/lms/job_03_db_migrate.yml.j2
+++ b/apps/edxapp/templates/services/lms/job_03_db_migrate.yml.j2
@@ -36,6 +36,7 @@ spec:
             - "/bin/bash"
             - "-c"
             - DJANGO_SETTINGS_MODULE=lms.envs.fun.docker_run python manage.py lms migrate
+          resources: {{ edxapp_lms_job_db_migrate_resources }}
           volumeMounts:
             - mountPath: /config
               name: edxapp-config

--- a/apps/edxapp/templates/services/mongodb/deploy.yml.j2
+++ b/apps/edxapp/templates/services/mongodb/deploy.yml.j2
@@ -41,6 +41,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ edxapp_mongodb_secret_name }}"
+          resources: {{ edxapp_mongodb_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/edxapp/templates/services/mysql/deploy.yml.j2
+++ b/apps/edxapp/templates/services/mysql/deploy.yml.j2
@@ -41,6 +41,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ edxapp_mysql_secret_name }}"
+          resources: {{ edxapp_mysql_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/edxapp/templates/services/mysql/job_00_load_sql_dump.yml.j2
+++ b/apps/edxapp/templates/services/mysql/job_00_load_sql_dump.yml.j2
@@ -42,6 +42,7 @@ spec:
               -h "edxapp-mysql-{{ deployment_stamp }}"
               --password=${MYSQL_PASSWORD}
               ${MYSQL_DATABASE} < edx-database.sql
+          resources: {{ edxapp_mysql_job_load_sql_dump_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/edxapp/templates/services/nginx/deploy.yml.j2
+++ b/apps/edxapp/templates/services/nginx/deploy.yml.j2
@@ -60,11 +60,10 @@ spec:
             - mountPath: /data/export
               name: edxapp-v-export
               readOnly: true
-            {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
+{% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: edxapp-htpasswd
-            {% endif %}
-
+{% endif %}
           livenessProbe:
             httpGet:
               path: "{{ edxapp_nginx_healthcheck_endpoint }}"
@@ -77,6 +76,7 @@ spec:
               port: {{ edxapp_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ edxapp_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -139,3 +139,55 @@ queue: ""
 # these variables are required
 redis_app_port: 6379
 mailcatcher_sender_port: 1025
+
+# -- resources requests
+{% set cms_app_resources = {
+  "requests": {
+    "cpu": "10m",
+    "memory": "800Mi"
+  }
+} %}
+
+edxapp_cms_resources: "{{ cms_app_resources }}"
+edxapp_cms_job_internationalization_resources: "{{ cms_app_resources }}"
+edxapp_cms_job_db_migrate_resources: "{{ cms_app_resources }}"
+edxapp_cms_job_load_fixtures_resources: "{{ cms_app_resources }}"
+edxapp_cms_job_create_directories_resources:
+  requests:
+    cpu: 10m
+    memory: 20Mi
+
+{% set lms_app_resources = {
+  "requests": {
+    "cpu": "100m",
+    "memory": "1Gi"
+  }
+} %}
+
+edxapp_lms_resources: "{{ lms_app_resources }}"
+edxapp_lms_job_db_migrate_resources: "{{ lms_app_resources }}"
+
+edxapp_queue_resources:
+  requests:
+    cpu: 10m
+    memory: 400Mi
+
+edxapp_mongodb_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi
+
+edxapp_mysql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi
+
+edxapp_mysql_job_load_sql_dump_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi
+
+edxapp_nginx_resources:
+  requests:
+    cpu: 10m
+    memory: 20Mi

--- a/apps/edxec/templates/services/app/deploy.yml.j2
+++ b/apps/edxec/templates/services/app/deploy.yml.j2
@@ -54,6 +54,7 @@ spec:
               value: /usr/local/etc/ecommerce/local.yml
             - name: DJANGO_SETTINGS_MODULE
               value: ecommerce.settings.production
+          resources: {{ edxec_app_resources }}
           volumeMounts:
             - name: edxec-local
               mountPath: /usr/local/etc/ecommerce

--- a/apps/edxec/templates/services/app/job_00_collectstatic.yml.j2
+++ b/apps/edxec/templates/services/app/job_00_collectstatic.yml.j2
@@ -41,6 +41,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py collectstatic --noinput && python manage.py compress
+          resources: {{ edxec_app_job_collectstatic_resources }}
           volumeMounts:
             - name: edxec-local
               mountPath: /usr/local/etc/ecommerce
@@ -56,6 +57,7 @@ spec:
             - "/bin/sh"
             - "-c"
             - "yq m /tmp/config/local.yml /tmp/secret/local.yml > /usr/local/etc/ecommerce/local.yml"
+          resources: {{ edxec_app_job_collectstatic_resources }}
           volumeMounts:
             - name: edxec-local
               mountPath: /usr/local/etc/ecommerce

--- a/apps/edxec/templates/services/app/job_01_db_migrate.yml.j2
+++ b/apps/edxec/templates/services/app/job_01_db_migrate.yml.j2
@@ -39,6 +39,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py migrate
+          resources: {{ edxec_app_job_db_migrate_resources }}
           volumeMounts:
             - name: edxec-local
               mountPath: /usr/local/etc/ecommerce
@@ -52,6 +53,7 @@ spec:
             - "/bin/sh"
             - "-c"
             - "yq m /tmp/config/local.yml /tmp/secret/local.yml > /usr/local/etc/ecommerce/local.yml"
+          resources: {{ edxec_app_job_db_migrate_resources }}
           volumeMounts:
             - name: edxec-local
               mountPath: /usr/local/etc/ecommerce

--- a/apps/edxec/templates/services/mysql/deploy.yml.j2
+++ b/apps/edxec/templates/services/mysql/deploy.yml.j2
@@ -41,6 +41,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ edxec_mysql_secret_name }}"
+          resources: {{ edxec_mysql_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/edxec/templates/services/nginx/deploy.yml.j2
+++ b/apps/edxec/templates/services/nginx/deploy.yml.j2
@@ -77,6 +77,7 @@ spec:
               port: {{ edxec_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ edxec_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -37,3 +37,25 @@ edxec_mysql_secret_name: "edxec-mysql-{{ edxec_vault_checksum | default('undefin
 # -- volumes size
 edxec_static_volume_size: 2Gi
 edxec_media_volume_size: 2Gi
+
+# -- resources requests
+{% set app_resources = {
+  "requests": {
+    "cpu": "10m",
+    "memory": "300Mi"
+  }
+} %}
+
+edxec_app_resources: "{{ app_resources }}"
+edxec_app_job_collectstatic_resources: "{{ app_resources }}"
+edxec_app_job_db_migrate_resources: "{{ app_resources }}"
+
+edxec_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 20Mi
+
+edxec_mysql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/apps/elasticsearch/templates/services/app/job_01_set_index_template.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_01_set_index_template.yml.j2
@@ -35,6 +35,7 @@ spec:
             - secretRef:
                 name: "{{ elasticsearch_credentials_secret_name }}"
 {% endif %}
+          resources: {{ elasticsearch_app_job_set_index_template_resources }}
           volumeMounts:
             - name: set-index-template
               mountPath: /usr/local/bin/set-index-template.sh

--- a/apps/elasticsearch/templates/services/app/job_02_set_passwords.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_02_set_passwords.yml.j2
@@ -40,6 +40,7 @@ spec:
               subPath: set-passwords.sh
             - name: elasticsearch-v-bootstrap
               mountPath: /usr/share/elasticsearch/bootstrap
+          resources: {{ elasticsearch_app_job_set_passwords_resources }}
       restartPolicy: Never
       volumes:
         - name: set-passwords

--- a/apps/elasticsearch/templates/services/app/job_03_create_admin_user.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_03_create_admin_user.yml.j2
@@ -44,6 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ elasticsearch_credentials_secret_name }}"
+          resources: {{ elasticsearch_app_job_create_admin_user_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/elasticsearch/templates/services/app/sts.yml.j2
+++ b/apps/elasticsearch/templates/services/app/sts.yml.j2
@@ -138,6 +138,7 @@ spec:
 {% endif %}
             initialDelaySeconds: 30
             periodSeconds: 30
+          resources: {{ elasticsearch_app_resources }}
       volumes:
         - name: elasticsearch-config-file
           configMap:

--- a/apps/elasticsearch/vars/all/main.yml
+++ b/apps/elasticsearch/vars/all/main.yml
@@ -7,6 +7,8 @@ elasticsearch_image_tag: "6.6.2"
 
 # JVM options
 # (-Xms and -Xmx must have the same value or elasticsearch will fail to boot)
+# If you change these values, please also adjust the resources requests
+# (see elasticsearch_app_resources)
 elasticsearch_java_opts:
   - "-Xms512m"
   - "-Xmx512m"
@@ -61,3 +63,16 @@ elasticsearch_ssl_certificates_name: elastic-certificates.p12
 elasticsearch_ca_secret_name: "elasticsearch-ca-{{ elasticsearch_vault_checksum | default('unset-yet') }}"
 elasticsearch_certificates_passwords_secret_name: "elasticsearch-certificates-passwords-{{ elasticsearch_vault_checksum | default('unset-yet') }}"
 elasticsearch_credentials_secret_name: "elasticsearch-credentials-{{ elasticsearch_vault_checksum | default('unset-yet') }}"
+
+# -- resources requests
+elasticsearch_app_resources:
+  requests:
+    cpu: 10m
+    memory: 512Mi
+
+elasticsearch_app_job_set_index_template_resources:
+  requests:
+    cpu: 10m
+    memory: 20Mi
+elasticsearch_app_job_set_passwords_resources: {{ elasticsearch_app_job_set_index_template_resources }}
+elasticsearch_app_job_create_admin_user_resources: {{ elasticsearch_app_job_set_index_template_resources }}

--- a/apps/etherpad/templates/services/app/deploy.yml.j2
+++ b/apps/etherpad/templates/services/app/deploy.yml.j2
@@ -82,6 +82,7 @@ spec:
                 name: "{{ etherpad_env_secret_name }}"
             - configMapRef:
                 name: "etherpad-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ etherpad_app_resources }}
           volumeMounts:
             - name: etherpad-v-configs
               mountPath: {{ etherpad_configs_directory_path }}

--- a/apps/etherpad/templates/services/nginx/deploy.yml.j2
+++ b/apps/etherpad/templates/services/nginx/deploy.yml.j2
@@ -71,6 +71,7 @@ spec:
               port: {{ etherpad_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ etherpad_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/etherpad/templates/services/postgresql/deploy.yml.j2
+++ b/apps/etherpad/templates/services/postgresql/deploy.yml.j2
@@ -44,6 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ etherpad_database_secret_name }}"
+          resources: {{ etherpad_postgresql_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/etherpad/vars/all/main.yml
+++ b/apps/etherpad/vars/all/main.yml
@@ -49,3 +49,20 @@ etherpad_loglevel: "INFO"
 etherpad_skin_name: "colibris"
 # The name of the instance
 etherpad_title: "{{ namespace_name }} etherpad"
+
+
+# -- resources requests
+etherpad_app_resources:
+  requests:
+    cpu: 5m
+    memory: 128Mi
+
+etherpad_postgresql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi
+
+etherpad_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 100Mi

--- a/apps/flower/templates/services/app/deploy.yml.j2
+++ b/apps/flower/templates/services/app/deploy.yml.j2
@@ -41,6 +41,7 @@ spec:
           envFrom:
             - configMapRef:
                 name: "flower-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ flower_app_resources }}
           volumeMounts:
             - mountPath: /app
               name: flower-configmap

--- a/apps/flower/templates/services/nginx/deploy.yml.j2
+++ b/apps/flower/templates/services/nginx/deploy.yml.j2
@@ -49,6 +49,7 @@ spec:
               port: {{ flower_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ flower_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/flower/vars/all/main.yml
+++ b/apps/flower/vars/all/main.yml
@@ -15,3 +15,14 @@ flower_image_name: "fundocker/flower"
 flower_image_tag: "0.9.3-py2"
 flower_address: "0.0.0.0"
 flower_port: 5555
+
+# -- resources requests
+flower_app_resources:
+  requests:
+    cpu: 10m
+    memory: 128Mi
+
+flower_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 20Mi

--- a/apps/forum/templates/services/app/deploy.yml.j2
+++ b/apps/forum/templates/services/app/deploy.yml.j2
@@ -67,6 +67,7 @@ spec:
                   value: "{{ forum_host }}"
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ forum_app_resources }}
           ports:
             - containerPort: {{ forum_port }}
               protocol: TCP

--- a/apps/forum/templates/services/app/job_01_init_index.yml.j2
+++ b/apps/forum/templates/services/app/job_01_init_index.yml.j2
@@ -41,6 +41,7 @@ spec:
             - "/bin/bash"
             - "-c"
             - bin/rake search:initialize
+          resources: {{ forum_app_job_init_index_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/forum/templates/services/elasticsearch/deploy.yml.j2
+++ b/apps/forum/templates/services/elasticsearch/deploy.yml.j2
@@ -37,6 +37,7 @@ spec:
           ports:
             - containerPort: {{ forum_elasticsearch_port }}
               protocol: TCP
+          resources: {{ forum_elasticsearch_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/forum/templates/services/mongodb/deploy.yml.j2
+++ b/apps/forum/templates/services/mongodb/deploy.yml.j2
@@ -41,6 +41,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ forum_mongodb_secret_name }}"
+          resources: {{ forum_mongodb_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/forum/vars/all/main.yml
+++ b/apps/forum/vars/all/main.yml
@@ -26,3 +26,21 @@ forum_mongodb_replicaset: ""
 forum_mongodb_read_preference: ""
 forum_mongodb_secret_name: "forum-mongo-{{ forum_vault_checksum | default('undefined_forum_vault_checksum') }}"
 forum_endpoint_mongodb_ips: "{{ endpoint_mongodb_ips }}"
+
+# -- resources requests
+{% set app_resources = {
+  "requests": {
+    "cpu": "10m",
+    "memory": "250Mi"
+  }
+} %}
+forum_app_resources: "{{ app_resources }}"
+forum_app_job_init_index_resources: "{{ app_resources }}"
+forum_elasticsearch_resources:
+  requests:
+    cpu: 10m
+    memory: 1Gi
+forum_mongodb_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/apps/hello/templates/services/app/cronjob_hello.yml.j2
+++ b/apps/hello/templates/services/app/cronjob_hello.yml.j2
@@ -35,6 +35,7 @@ spec:
                 - "sh"
                 - "-c"
                 - echo "Hello World!"
+              resources: {{ hello_app_cronjob_resources }}
           restartPolicy: Never
           securityContext:
             runAsUser: {{ container_uid }}

--- a/apps/hello/templates/services/app/deploy.yml.j2
+++ b/apps/hello/templates/services/app/deploy.yml.j2
@@ -34,7 +34,7 @@ spec:
           env:
             - name: RESPONSE
               value: "{{ hello_app_msg }} - {{ deployment_stamp }}"
-          resources: {}
+          resources: {{ hello_app_resources }}
           volumeMounts:
             - name: tmp
               mountPath: "/tmp"

--- a/apps/hello/templates/services/app/job_writevolume.yml.j2
+++ b/apps/hello/templates/services/app/job_writevolume.yml.j2
@@ -33,6 +33,7 @@ spec:
             - |
               id
               echo test > /data/volume/test
+          resources: {{ hello_app_job_writevolume_resources }}
           volumeMounts:
             - mountPath: /data/volume
               name: hello-volume

--- a/apps/hello/vars/all/main.yml
+++ b/apps/hello/vars/all/main.yml
@@ -6,3 +6,14 @@ hello_host: "hello.{{ namespace_name }}.{{ domain_name }}"
 # -- misc
 hello_app_port: "8080"
 hello_app_msg: "Hello Kubernetes! by Arnold"
+
+# -- resources
+{% set app_resources = {
+  "requests": {
+    "cpu": "1m",
+    "memory": "50Mi"
+  }
+} %}
+hello_app_resources: "{{ app_resources }}"
+hello_app_job_writevolume_resources: "{{ app_resources }}"
+hello_app_cronjob_resources: "{{ app_resources }}"

--- a/apps/kibana/templates/services/app/deploy.yml.j2
+++ b/apps/kibana/templates/services/app/deploy.yml.j2
@@ -64,6 +64,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ kibana_secret_name }}"
+          resources: {{ kibana_app_resources }}
           volumeMounts:
             - name: kibana-config-file
               mountPath: "{{ kibana_config_path }}/kibana.yml"

--- a/apps/kibana/templates/services/nginx/deploy.yml.j2
+++ b/apps/kibana/templates/services/nginx/deploy.yml.j2
@@ -71,6 +71,7 @@ spec:
               port: {{ kibana_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ kibana_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/kibana/vars/all/main.yml
+++ b/apps/kibana/vars/all/main.yml
@@ -26,3 +26,14 @@ kibana_ca_secret_name: "kibana-ca-{{ kibana_vault_checksum | default('undefined_
 kibana_secret_name: "kibana-{{ kibana_vault_checksum | default('undefined_kibana_vault_checksum') }}"
 kibana_activate_http_basic_auth: false
 kibana_security_enabled: false
+
+# -- resources requests
+kibana_app_resources:
+  requests:
+    cpu: 15m
+    memory: 512Mi
+
+kibana_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 20Mi

--- a/apps/learninglocker/templates/services/app/_dc_base.yml.j2
+++ b/apps/learninglocker/templates/services/app/_dc_base.yml.j2
@@ -65,6 +65,7 @@ spec:
             # directory the user can write to.
             - name: HOME
               value: /home/pm2_user
+          resources: {{ resources }}
           volumeMounts:
             - name: learninglocker-v-storage
               mountPath: /app/storage

--- a/apps/learninglocker/templates/services/app/dc_api.yml.j2
+++ b/apps/learninglocker/templates/services/app/dc_api.yml.j2
@@ -2,5 +2,6 @@
 {% set learninglocker_pm2_app = "api" %}
 {% set learninglocker_port = learninglocker_api_port %}
 {% set learninglocker_replicas = learninglocker_api_replicas %}
+{% set resources = learninglocker_app_api_resources %}
 
 {% include "apps/learninglocker/templates/services/app/_dc_base.yml.j2" with context %}

--- a/apps/learninglocker/templates/services/app/dc_ui.yml.j2
+++ b/apps/learninglocker/templates/services/app/dc_ui.yml.j2
@@ -2,5 +2,6 @@
 {% set learninglocker_pm2_app = "ui" %}
 {% set learninglocker_port = learninglocker_ui_port %}
 {% set learninglocker_replicas = learninglocker_ui_replicas %}
+{% set resources = learninglocker_app_ui_resources %}
 
 {% include "apps/learninglocker/templates/services/app/_dc_base.yml.j2" with context %}

--- a/apps/learninglocker/templates/services/app/dc_worker.yml.j2
+++ b/apps/learninglocker/templates/services/app/dc_worker.yml.j2
@@ -1,5 +1,6 @@
 {% set service_variant = "worker" %}
 {% set learninglocker_pm2_app = "worker" %}
 {% set learninglocker_replicas = learninglocker_worker_replicas %}
+{% set resources = learninglocker_app_worker_resources %}
 
 {% include "apps/learninglocker/templates/services/app/_dc_base.yml.j2" with context %}

--- a/apps/learninglocker/templates/services/app/job_storage.yml.j2
+++ b/apps/learninglocker/templates/services/app/job_storage.yml.j2
@@ -29,6 +29,7 @@ spec:
       - name: learninglocker-job-storage
         image: "busybox:1.30"
         command: ["mkdir", "-p", "/data/tmp", "/data/downloads", "/data/logos", "/data/storage", "/data/tests"]
+        resources: {{ learninglocker_app_job_storage_resources }}
         volumeMounts:
         - name: learninglocker-v-storage
           mountPath: /data

--- a/apps/learninglocker/templates/services/mongodb/dc.yml.j2
+++ b/apps/learninglocker/templates/services/mongodb/dc.yml.j2
@@ -35,4 +35,5 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ learninglocker_mongodb_secret_name }}"
+          resources: {{ learninglocker_mongodb_resources }}"
 {% endif %}

--- a/apps/learninglocker/templates/services/nginx/dc.yml.j2
+++ b/apps/learninglocker/templates/services/nginx/dc.yml.j2
@@ -43,6 +43,7 @@ spec:
               port: {{ learninglocker_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ learninglocker_nginx_resources }}
           volumeMounts:
             - mountPath: /etc/nginx/conf.d
               name: learninglocker-v-nginx

--- a/apps/learninglocker/templates/services/xapi/dc.yml.j2
+++ b/apps/learninglocker/templates/services/xapi/dc.yml.j2
@@ -33,7 +33,7 @@ spec:
                       operator: In
                       values:
                         - "learninglocker-xapi-{{ deployment_stamp }}"
-                topologyKey: kubernetes.io/hostname  
+                topologyKey: kubernetes.io/hostname
 {% set image_pull_secret_name = learninglocker_xapi_image_pull_secret_name | default(none) or default_image_pull_secret_name %}
 {% if image_pull_secret_name is not none %}
       imagePullSecrets:
@@ -68,6 +68,7 @@ spec:
               mountPath: /app/storage
             - name: pm2-homedir
               mountPath: /home/pm2_user
+          resources: {{ learninglocker_xapi_resources }}
       volumes:
         - name: learninglocker-xapi-configmap
           configMap:

--- a/apps/learninglocker/vars/all/main.yml
+++ b/apps/learninglocker/vars/all/main.yml
@@ -60,3 +60,25 @@ learninglocker_port: ""
 # these variables are required
 redis_app_port: 6379
 mailcatcher_sender_port: 1025
+
+# -- resources
+learninglocker_app_api_resources:
+  requests:
+    cpu: 10m
+    memory: 250Mi
+learninglocker_app_ui_resources: {{ learninglocker_app_api_resources }}
+learninglocker_app_worker_resources: {{ learninglocker_app_api_resources }}
+learninglocker_app_job_storage_resources: {{ learninglocker_app_api_resources }}
+
+learninglocker_mongodb_resources:
+  requests:
+    cpu: 10m
+    memory: 250Mi
+learninglocker_nginx_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi
+learninglocker_xapi_resources:
+  requests:
+    cpu: 10m
+    memory: 250Mi

--- a/apps/mailcatcher/templates/services/app/deploy.yml.j2
+++ b/apps/mailcatcher/templates/services/app/deploy.yml.j2
@@ -34,6 +34,7 @@ spec:
           protocol: TCP
         - containerPort: 1080
           protocol: TCP
+        resources: {{ mailcatcher_app_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/mailcatcher/vars/all/main.yml
+++ b/apps/mailcatcher/vars/all/main.yml
@@ -8,3 +8,9 @@ mailcatcher_image_name: "sj26/mailcatcher"
 mailcatcher_image_tag: "latest"
 mailcatcher_sender_port: 1025
 mailcatcher_reader_port: 1080
+
+# -- resources requests
+mailcatcher_app_resources:
+  requests:
+    cpu: 1m
+    memory: 50Mi

--- a/apps/marsha/templates/services/app/_deploy_base.yml.j2
+++ b/apps/marsha/templates/services/app/_deploy_base.yml.j2
@@ -88,6 +88,7 @@ spec:
                 name: "{{ marsha_secret_name }}"
             - configMapRef:
                 name: "marsha-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ marsha_app_resources }}
           volumeMounts:
             - name: marsha-configmap
               mountPath: /app/src/backend/marsha/configs

--- a/apps/marsha/templates/services/app/cronjob_check_harvested.yml.j2
+++ b/apps/marsha/templates/services/app/cronjob_check_harvested.yml.j2
@@ -58,6 +58,7 @@ spec:
                     name: "{{ marsha_secret_name }}"
                 - configMapRef:
                     name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_check_harvested_resources }}
               volumeMounts:
                 - name: marsha-configmap
                   mountPath: /app/src/backend/marsha/configs

--- a/apps/marsha/templates/services/app/cronjob_check_live_idle.yml.j2
+++ b/apps/marsha/templates/services/app/cronjob_check_live_idle.yml.j2
@@ -58,6 +58,7 @@ spec:
                     name: "{{ marsha_secret_name }}"
                 - configMapRef:
                     name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_check_live_idle_resources }}
               volumeMounts:
                 - name: marsha-configmap
                   mountPath: /app/src/backend/marsha/configs

--- a/apps/marsha/templates/services/app/cronjob_check_live_state.yml.j2
+++ b/apps/marsha/templates/services/app/cronjob_check_live_state.yml.j2
@@ -58,6 +58,7 @@ spec:
                     name: "{{ marsha_secret_name }}"
                 - configMapRef:
                     name: "marsha-app-dotenv-{{ deployment_stamp }}"
+              resources: {{ marsha_app_cronjob_check_live_state_resources }}
               volumeMounts:
                 - name: marsha-configmap
                   mountPath: /app/src/backend/marsha/configs

--- a/apps/marsha/templates/services/app/job_db_migrate.yml.j2
+++ b/apps/marsha/templates/services/app/job_db_migrate.yml.j2
@@ -46,6 +46,7 @@ spec:
             - secretRef:
                 name: "{{ marsha_secret_name }}"
           command: ["python", "manage.py", "migrate"]
+          resources: {{ marsha_app_job_db_migrate_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/marsha/templates/services/nginx/deploy.yml.j2
+++ b/apps/marsha/templates/services/nginx/deploy.yml.j2
@@ -79,6 +79,7 @@ spec:
               port: {{ marsha_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ marsha_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/marsha/templates/services/postgresql/deploy.yml.j2
+++ b/apps/marsha/templates/services/postgresql/deploy.yml.j2
@@ -44,6 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ marsha_postgresql_secret_name }}"
+          resources: {{ marsha_postgresql_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -46,3 +46,27 @@ marsha_check_idle_state_cronjob_schedule: "0 4 * * *"
 # -- volumes
 marsha_media_volume_size: 2Gi
 marsha_static_volume_size: 2Gi
+
+# -- resources
+{% set app_resources = {
+  "requests": {
+    "cpu": "80m",
+    "memory": "400Mi"
+  }
+} %}
+
+marsha_app_resources: "{{ app_resources }}"
+marsha_app_job_db_migrate_resources: "{{ app_resources }}"
+marsha_app_cronjob_check_harvested_resources: "{{ app_resources }}"
+marsha_app_cronjob_check_live_idle_resources: "{{ app_resources }}"
+marsha_app_cronjob_check_live_state_resources: "{{ app_resources }}"
+
+marsha_nginx_resources:
+  requests:
+    cpu: 10m
+    memory: 5Mi
+
+marsha_postgresql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/apps/redis-sentinel/templates/services/app/svc.yml.j2
+++ b/apps/redis-sentinel/templates/services/app/svc.yml.j2
@@ -58,6 +58,7 @@ spec:
       - "{{ config }}"
 {% endfor %}
 {% endif %}
+    resources: {{ redis_sentinel_resources }}
 {% if redis_sentinel_redis_persistence_enabled %}
     storage:
       keepAfterDeletion: true

--- a/apps/redis-sentinel/vars/all/main.yml
+++ b/apps/redis-sentinel/vars/all/main.yml
@@ -23,3 +23,9 @@ redis_sentinel_redis_data_volume_size: 2Gi
 # eg:
 #   - "stop-writes-on-bgsave-error no"
 redis_sentinel_redis_custom_config: []
+
+# -- resources requests
+redis_sentinel_resources:
+  requests:
+    cpu: 20m
+    memory: 100Mi

--- a/apps/redis/templates/services/app/deploy.yml.j2
+++ b/apps/redis/templates/services/app/deploy.yml.j2
@@ -57,6 +57,7 @@ spec:
                 - "-c"
                 - "redis-cli ping && touch /data/healthcheck"
             periodSeconds: 10
+          resources: {{ redis_app_resources }}
           volumeMounts:
             - mountPath: /data
               name: redis-v-data

--- a/apps/redis/vars/all/main.yml
+++ b/apps/redis/vars/all/main.yml
@@ -6,3 +6,9 @@ redis_app_port: 6379
 
 # -- volume size
 redis_data_volume_size: 2Gi
+
+# -- resources requests
+redis_app_resources:
+  requests:
+    cpu: 10m
+    memory: 500Mi

--- a/apps/richie/templates/services/app/deploy.yml.j2
+++ b/apps/richie/templates/services/app/deploy.yml.j2
@@ -88,6 +88,7 @@ spec:
                 name: "{{ richie_secret_name }}"
             - configMapRef:
                 name: "richie-app-dotenv-{{ deployment_stamp }}"
+          resources: {{ richie_app_resources }}
 {% if richie_should_activate_media_volume %}
           volumeMounts:
             - name: richie-v-media

--- a/apps/richie/templates/services/app/job_01_db_migrate.yml.j2
+++ b/apps/richie/templates/services/app/job_01_db_migrate.yml.j2
@@ -51,6 +51,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py migrate
+          resources: {{ richie_app_job_db_migrate_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/richie/templates/services/app/job_02_richie_init.yml.j2
+++ b/apps/richie/templates/services/app/job_02_richie_init.yml.j2
@@ -51,6 +51,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py richie_init
+          resources: {{ richie_app_job_richie_init_resources }}
       restartPolicy: Never
       securityContext:
         runAsUser: {{ container_uid }}

--- a/apps/richie/templates/services/app/job_03_bootstrap_elasticsearch.yml.j2
+++ b/apps/richie/templates/services/app/job_03_bootstrap_elasticsearch.yml.j2
@@ -54,6 +54,7 @@ spec:
             - "bash"
             - "-c"
             - python manage.py bootstrap_elasticsearch
+          resources: {{ richie_app_job_bootstrap_elasticsearch_resources }}
 {% if richie_should_activate_media_volume %}
           volumeMounts:
             - name: richie-v-media

--- a/apps/richie/templates/services/elasticsearch/deploy.yml.j2
+++ b/apps/richie/templates/services/elasticsearch/deploy.yml.j2
@@ -37,6 +37,7 @@ spec:
           ports:
             - containerPort: {{ richie_elasticsearch_port }}
               protocol: TCP
+          resources: {{ richie_elasticsearch_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/richie/templates/services/nginx/deploy.yml.j2
+++ b/apps/richie/templates/services/nginx/deploy.yml.j2
@@ -63,7 +63,6 @@ spec:
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: richie-htpasswd
 {% endif %}
-
           livenessProbe:
             httpGet:
               path: "{{ richie_nginx_healthcheck_endpoint }}"
@@ -76,6 +75,7 @@ spec:
               port: {{ richie_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ richie_nginx_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/richie/templates/services/postgresql/deploy.yml.j2
+++ b/apps/richie/templates/services/postgresql/deploy.yml.j2
@@ -44,6 +44,7 @@ spec:
           envFrom:
             - secretRef:
                 name: "{{ richie_database_secret_name }}"
+          resources: {{ richie_postgresql_resources }}
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -50,3 +50,29 @@ richie_activate_http_basic_auth: false
 # volume sizes with power of 2 suffices (Ki, Mi, Gi, Ti...) e.g 2Gi and 0 for no volume.
 richie_media_volume_size: 2Gi
 richie_should_activate_media_volume: true
+
+# -- resources requests
+{% set app_resources = {
+  "requests": {
+    "cpu": "5m",
+    "memory": "512Mi"
+  }
+} %}
+
+richie_app_resources: "{{ app_resources }}"
+richie_app_job_db_migrate_resources: "{{ app_resources }}"
+richie_app_job_richie_init_resources: "{{ app_resources }}"
+richie_app_job_bootstrap_elasticsearch_resources: "{{ app_resources }}"
+
+richie_elasticsearch_resources:
+  requests:
+    cpu: 10m
+    memory: 2Gi
+richie_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 20Mi
+richie_postgresql_resources:
+  requests:
+    cpu: 10m
+    memory: 100Mi

--- a/group_vars/customer/eugene/main.yml
+++ b/group_vars/customer/eugene/main.yml
@@ -13,6 +13,10 @@ nextcloud_database_name: nextcloud
 elasticsearch_java_opts:
   - "-Xms128m"
   - "-Xmx128m"
+elasticsearch_app_resources:
+  requests:
+    cpu: 100m
+    memory: 128Mi
 elasticsearch_image_name: "elasticsearch"
 elasticsearch_image_tag: "7.7.0"
 

--- a/tasks/load_app_defaults.yml
+++ b/tasks/load_app_defaults.yml
@@ -1,9 +1,8 @@
 # Load application default variables if not already defined
 
 - name: Load default variables from {{ file }}
-  include_vars:
-    file: "{{ file }}"
-    name: defaults
+  set_fact:
+    defaults: "{{ lookup('template', file) | from_yaml }}"
 
 - name: Print loaded variables from {{ file }}
   debug:


### PR DESCRIPTION
## Purpose
We need to improve pod scheduling on our Kubernetes clusters.

This PR is based on the work done in #353 

## Proposal
By setting resources requests without any limit, our pods are in
"Burstable" mode: we can define the minimum resources it requires upon
scheduling, while still allowing it to burst.

- [x] Rebase #353 with `migration-to-k8s`
- [x] Allow to use jinja in app defaults files
- [x]  Add missing apps
  - [x] ashley
  - [x] edxec
  - [x] elasticsearch
  - [x] etherpad
  - [x] flower
  - [x] kibana
  - [x] redis-sentinel
- [x] Add limits in cronjobs
- [x] Set default limits that reflect real usage.
 