### PR TITLE
🐛(apps) fix syntax error in nginx deployment templates

### DIFF
--- a/apps/ashley/templates/services/nginx/deploy.yml.j2
+++ b/apps/ashley/templates/services/nginx/deploy.yml.j2
@@ -68,6 +68,7 @@ spec:
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: ashley-htpasswd
 {% endif %}
+
           livenessProbe:
             httpGet:
               path: "{{ ashley_nginx_healthcheck_endpoint }}"

--- a/apps/edxapp/templates/services/nginx/deploy.yml.j2
+++ b/apps/edxapp/templates/services/nginx/deploy.yml.j2
@@ -60,10 +60,11 @@ spec:
             - mountPath: /data/export
               name: edxapp-v-export
               readOnly: true
-{% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
+            {% if activate_http_basic_auth or edxapp_activate_http_basic_auth -%}
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: edxapp-htpasswd
-{% endif %}
+            {% endif %}
+
           livenessProbe:
             httpGet:
               path: "{{ edxapp_nginx_healthcheck_endpoint }}"

--- a/apps/richie/templates/services/nginx/deploy.yml.j2
+++ b/apps/richie/templates/services/nginx/deploy.yml.j2
@@ -63,6 +63,7 @@ spec:
             - mountPath: "{{ http_basic_auth_user_file | dirname }}"
               name: richie-htpasswd
 {% endif %}
+
           livenessProbe:
             httpGet:
               path: "{{ richie_nginx_healthcheck_endpoint }}"


### PR DESCRIPTION
## Purpose

Some cleaning in commit 777d0103981714113871d364b444ecdef76387a1
introduced errors in nginx deployment template for edxapp, richie and
ashley. It can lead to a parse error when basic auth is enabled.

## Proposal

Revert changes introduced in 777d0103981714113871d364b444ecdef76387a1 in nginx deployment files that are not related to resource requests.
