### PR TITLE
Miscellaneous resources management fixes

### DIFF
--- a/apps/elasticsearch/vars/all/main.yml
+++ b/apps/elasticsearch/vars/all/main.yml
@@ -70,9 +70,13 @@ elasticsearch_app_resources:
     cpu: 10m
     memory: 512Mi
 
-elasticsearch_app_job_set_index_template_resources:
-  requests:
-    cpu: 10m
-    memory: 20Mi
-elasticsearch_app_job_set_passwords_resources: {{ elasticsearch_app_job_set_index_template_resources }}
-elasticsearch_app_job_create_admin_user_resources: {{ elasticsearch_app_job_set_index_template_resources }}
+{% set job_resources = {
+  "requests": {
+    "cpu": "10m",
+    "memory": "20Mi"
+  }
+} %}
+
+elasticsearch_app_job_set_index_template_resources: "{{ job_resources }}"
+elasticsearch_app_job_set_passwords_resources: "{{ job_resources }}"
+elasticsearch_app_job_create_admin_user_resources: "{{ job_resources }}"

--- a/core_apps/redirect/templates/services/nginx/deploy.yml.j2
+++ b/core_apps/redirect/templates/services/nginx/deploy.yml.j2
@@ -52,6 +52,7 @@ spec:
               port: {{ redirect_nginx_healthcheck_port }}
             initialDelaySeconds: 10
             periodSeconds: 5
+          resources: {{ redirect_nginx_resources }}
           volumeMounts:
             - mountPath: /etc/nginx/conf.d
               name: redirect-v-nginx

--- a/core_apps/redirect/vars/all/main.yml
+++ b/core_apps/redirect/vars/all/main.yml
@@ -7,3 +7,9 @@ redirect_nginx_replicas: 1
 redirect_nginx_port: 8999
 redirect_nginx_healthcheck_port: 5000
 redirect_nginx_healthcheck_endpoint: "/__healthcheck__"
+
+# -- resources requests
+redirect_nginx_resources:
+  requests:
+    cpu: 5m
+    memory: 20Mi


### PR DESCRIPTION
## Purpose

The goal of this PR is to solve problems about resources management that were discovered after merging #644 

- We are unable to deploy the `elasticsearch` application
- The `redirect` core_app has no resource request defined for the nginx deployment

## Proposal

- [x] Fix default variables definition in `elasticsearch`
- [x] Add resource management in the `redirect` core app
