### PR TITLE
✨(elasticsearch) add support for persistent volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - CLI: add `acme` command to create or update the namespace TLS certificate Issuer
+- Elasticsearch: add support for persistent volume to store indexes data
 
 ### Changed
 

--- a/apps/elasticsearch/templates/services/app/sts.yml.j2
+++ b/apps/elasticsearch/templates/services/app/sts.yml.j2
@@ -96,6 +96,10 @@ spec:
               protocol: TCP
               name: "comm-port"
           volumeMounts:
+{% if elasticsearch_persistent_volume_enabled %}
+            - name: elasticsearch-pvc-data
+              mountPath: /usr/share/elasticsearch/data
+{% endif %}
 {% if elasticsearch_security_enabled %}
             - name: config-dir
               mountPath: /usr/share/elasticsearch/config
@@ -173,3 +177,14 @@ spec:
       securityContext:
         runAsUser: {{ container_uid }}
         runAsGroup: {{ container_gid }}
+  volumeClaimTemplates:
+  - metadata:
+      name: elasticsearch-pvc-data
+      labels:
+        app: elasticsearch
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      storageClassName: "{{ elasticsearch_persistent_volume_storageclass }}"
+      resources:
+        requests:
+          storage: {{ elasticsearch_persistent_volume_size }}

--- a/apps/elasticsearch/vars/all/main.yml
+++ b/apps/elasticsearch/vars/all/main.yml
@@ -64,6 +64,12 @@ elasticsearch_ca_secret_name: "elasticsearch-ca-{{ elasticsearch_vault_checksum 
 elasticsearch_certificates_passwords_secret_name: "elasticsearch-certificates-passwords-{{ elasticsearch_vault_checksum | default('unset-yet') }}"
 elasticsearch_credentials_secret_name: "elasticsearch-credentials-{{ elasticsearch_vault_checksum | default('unset-yet') }}"
 
+# Persistent storage for elasticsearch index data
+# By default, persistent storage is disabled.
+elasticsearch_persistent_volume_enabled: false
+elasticsearch_persistent_volume_size: 1Gi
+elasticsearch_persistent_volume_storageclass: "{{ default_storage_class_rwo }}"
+
 # -- resources requests
 elasticsearch_app_resources:
   requests:


### PR DESCRIPTION
## Purpose

We would like to store elasticsearch data on a persistent volume, with
a customisable storage class.

## Proposal

- [x] Introduce 3 ansible variables : 
 - **elasticsearch_persistent_volume_enabled** (disabled by default)
 - **elasticsearch_persistent_volume_size**
 - **elasticsearch_persistent_volume_storageclass**
- [x] Use the `volumeClaimTemplates` feature in the StatefullSet to create one pvc per ES node
