### PR TITLE
🐛(cli) fix the vaults command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Replace `oc cluster` with k3d for local development
 - CLI: autodetect if we are within a terminal
 
+### Fixed
+
+- CLI: fix the `No such file or directory` error in the `vaults` command
+
 ## [5.25.0] - 2021-03-05
 
 ### Added

--- a/bin/arnold
+++ b/bin/arnold
@@ -740,7 +740,8 @@ function _vault(){
         return
     fi
 
-    _docker_run ansible-vault "${action}" "${vault_path}"
+    docker_vault_path=${vault_path//"${ARNOLD_PROJECT_PATH}"/"/app"}
+    _docker_run ansible-vault "${action}" "${docker_vault_path}"
 }
 
 

--- a/bin/arnold
+++ b/bin/arnold
@@ -199,7 +199,7 @@ COMMANDS:
   run               run any command in the container
   setup             create arnold-required folders and files
   vault             wrapper around Ansible's vault command
-  vaults            perform global actions for all namespace vaults
+  vaults            perform global actions for all vaults of the current namespace
   vault_pw          set a password to encrypt vault files with Ansible Vault
 
 > Deploy current namespace:


### PR DESCRIPTION
## Purpose

Arnold CLI's `vaults` command always fails with a "_No such file or directory_" error. It is due to the fact that the paths to vault files passed to the `ansible-vault` command are absolute paths computed on the docker host. And these paths are invalid inside the docker container.

Also, the second commit in this PR addresses the issue #651 .

## Proposal

- [x] Fix path to vault files
- [x] Update `vaults` command description (closes #651)
