### PR TITLE
⚡️(kibana) add kibana 7.8+ compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 - Authentication in `arnold` CLI must be done with a service account
 - Replace `oc cluster` with k3d for local development
 - CLI: autodetect if we are within a terminal
+- Update Kibana user name to `kibana_system` for recent releases compatibility
+- Removed python dependency for Kibana probes
 
 ### Fixed
 

--- a/apps/elasticsearch/vars/vault/main.yml.j2
+++ b/apps/elasticsearch/vars/vault/main.yml.j2
@@ -14,7 +14,7 @@ SSL_CERTIFICATE_PASSWORD: {{ lookup('password', '/dev/null length=50') }}
 ELASTIC_USERNAME: "elastic"
 ELASTIC_PASSWORD: "{{ lookup('password', '/dev/null length=50') }}"
 ELASTIC_BOOTSTRAP_PASSWORD: "{{ lookup('password', '/dev/null length=50') }}"
-KIBANA_USERNAME: "kibana"
+KIBANA_USERNAME: "kibana_system"
 KIBANA_PASSWORD: "{{ lookup('password', '/dev/null length=50') }}"
 LOGSTASH_USERNAME: "logstash_system"
 LOGSTASH_PASSWORD: "{{ lookup('password', '/dev/null length=50') }}"

--- a/apps/kibana/templates/services/app/configs/status-probe.sh.j2
+++ b/apps/kibana/templates/services/app/configs/status-probe.sh.j2
@@ -12,7 +12,7 @@ curl -sS \
   -u "${KIBANA_ELASTIC_USERNAME}:${KIBANA_ELASTIC_PASSWORD}" \
 {% endif %}
   "http://localhost:{{ kibana_app_port }}/api/status" | \
-  python -m json.tool > /tmp/status.json
+  tr "," "\n" > /tmp/status.json
 
 if [[ ${check} -eq 1 ]]; then
   grep "state" /tmp/status.json | \

--- a/apps/kibana/vars/vault/main.yml.j2
+++ b/apps/kibana/vars/vault/main.yml.j2
@@ -2,7 +2,7 @@
 # env_type: {{ env_type }}
 
 # elastic
-KIBANA_ELASTIC_USERNAME: kibana
+KIBANA_ELASTIC_USERNAME: kibana_system
 # Paste the password set for the kibana user in your elasticsearch cluster
 KIBANA_ELASTIC_PASSWORD: null
 


### PR DESCRIPTION
## Purpose

The elasticsearch `kibana` user is now deprecated and should be named `kibana_system` instead.

Recent kibana docker images (7.12+) no longer ship a python distribution, breaking the status probe.

## Proposal

- [x] rename Kibana user in `elasticsearch` and `kibana` applications vaults
- [x] use `tr` instead of python in the `kibana` status probe
