### PR TITLE
⚡️(scripts) add docker registry to k3d local cluster

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -185,6 +185,32 @@ jobs:
               "${ARNOLD_IMAGE}" \
               ansible --version
 
+  test-k3d-cluster-registry:
+    <<: *defaults
+
+    steps:
+      - checkout
+      - *attach_workspace
+      - *ci_env
+      - *install_k8s_requirements
+
+      - run:
+          name: Test the k3d docker registry
+          command: |
+            # Create the cluster with the registry
+            MINIMUM_AVAILABLE_RWX_VOLUME=15 \
+            K3D_BIND_HOST_PORT_HTTP=80 \
+            K3D_BIND_HOST_PORT_HTTPS=443 \
+            K3D_REGISTRY_HOST=registry.127.0.0.1.nip.io \
+            K3D_ENABLE_REGISTRY=1 \
+              make cluster
+            # Pull a small docker image to tag and push
+            docker pull alpine:latest
+            docker tag alpine:latest registry.127.0.0.1.nip.io:5000/testimage:local
+            docker push registry.127.0.0.1.nip.io:5000/testimage:local
+            # Run this image in the cluster
+            kubectl run --image registry.127.0.0.1.nip.io:5000/testimage:local testimage --command -- tail -f /dev/null
+
   # Test the bootstrap playbook on the "hello" application
   # nota bene: we use a real OpenShift cluster installed in CircleCI's VM.
   test-bootstrap-hello:
@@ -834,6 +860,10 @@ workflows:
             - lint-docker
             - lint-ansible
             - lint-plugins
+          filters:
+            tags:
+              only: /.*/
+      - test-k3d-cluster-registry:
           filters:
             tags:
               only: /.*/

--- a/bin/init-cluster
+++ b/bin/init-cluster
@@ -11,6 +11,12 @@ K3D_CLUSTER_NAME="${1:-arnold}"
 K3D_BIND_HOST_PORT_HTTP="${K3D_BIND_HOST_PORT_HTTP:-8080}"
 K3D_BIND_HOST_PORT_HTTPS="${K3D_BIND_HOST_PORT_HTTPS:-8443}"
 
+# Cluster docker registry
+K3D_ENABLE_REGISTRY="${K3D_ENABLE_REGISTRY:-0}"
+K3D_REGISTRY_HOST="${K3D_REGISTRY_HOST:-registry.localhost}"
+K3D_REGISTRY_PORT="${K3D_REGISTRY_PORT:-5000}"
+K3D_REGISTRY_NAME="k3d-${K3D_REGISTRY_HOST}"
+
 # Arnold project root directory
 declare ARNOLD_ROOT
 ARNOLD_ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
@@ -52,6 +58,16 @@ fi
 
 if ! k3d cluster list "${K3D_CLUSTER_NAME}" &> /dev/null ; then
 
+  declare -a k3d_registry_option
+
+  # Create cluster docker registry
+  if [[ ${K3D_ENABLE_REGISTRY} -eq 1 ]]; then
+    if ! k3d registry list "${K3D_REGISTRY_NAME}" &> /dev/null ; then
+      k3d registry create "${K3D_REGISTRY_HOST}" --port "${K3D_REGISTRY_PORT}"
+    fi
+    k3d_registry_option=("--registry-use" "${K3D_REGISTRY_NAME}:${K3D_REGISTRY_PORT}")
+  fi
+
   # Ensure that the persistent volume storage directory exists on the host
   if [[ ! -d "${PERSISTENT_VOLUME_PATH}" ]] ; then
     mkdir -p "${PERSISTENT_VOLUME_PATH}"
@@ -62,14 +78,14 @@ if ! k3d cluster list "${K3D_CLUSTER_NAME}" &> /dev/null ; then
     -p "${K3D_BIND_HOST_PORT_HTTP}:80@loadbalancer" \
     -p "${K3D_BIND_HOST_PORT_HTTPS}:443@loadbalancer" \
     -v "${PERSISTENT_VOLUME_PATH}:/data/pv" \
-    --k3s-server-arg '--no-deploy=traefik'
+    --k3s-server-arg '--no-deploy=traefik' \
+    "${k3d_registry_option[@]}"
 else
   k3d cluster start "${K3D_CLUSTER_NAME}"
 fi
 
 KUBECONFIG=$(k3d kubeconfig write "${K3D_CLUSTER_NAME}")
 echo "K3d cluster configuration exported to ${KUBECONFIG}"
-
 
 # Pre-provision PersistentVolumes with RWX accessModes
 


### PR DESCRIPTION
## Purpose

When using arnold in a CI context for third-party apps deployable as trays, we often have to build a Docker image of the current source code state and test this code in a k8s context. To do so, we need a local registry to push our newly built image that will be deployed.

## Proposal

- [x] add _ad hoc_ registry creation option while creating the k3d cluster
