### PR TITLE
🐛(elasticsearch) fix data volume permissions

### DIFF
--- a/apps/elasticsearch/templates/services/app/job_01_set_index_template.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_01_set_index_template.yml.j2
@@ -68,5 +68,7 @@ spec:
             claimName: elasticsearch-pvc-bootstrap
 {% endif %}
       securityContext:
-        runAsUser: {{ container_uid }}
-        runAsGroup: {{ container_gid }}
+        runAsUser: {{ elasticsearch_container_uid }}
+        runAsGroup: {{ elasticsearch_container_gid }}
+        fsGroup: {{ elasticsearch_container_gid }}
+        fsGroupChangePolicy: "OnRootMismatch"

--- a/apps/elasticsearch/templates/services/app/job_02_set_passwords.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_02_set_passwords.yml.j2
@@ -54,6 +54,8 @@ spec:
           persistentVolumeClaim:
             claimName: elasticsearch-pvc-bootstrap
       securityContext:
-        runAsUser: {{ container_uid }}
-        runAsGroup: {{ container_gid }}
+        runAsUser: {{ elasticsearch_container_uid }}
+        runAsGroup: {{ elasticsearch_container_gid }}
+        fsGroup: {{ elasticsearch_container_gid }}
+        fsGroupChangePolicy: "OnRootMismatch"
 {% endif %}

--- a/apps/elasticsearch/templates/services/app/job_03_create_admin_user.yml.j2
+++ b/apps/elasticsearch/templates/services/app/job_03_create_admin_user.yml.j2
@@ -47,6 +47,8 @@ spec:
           resources: {{ elasticsearch_app_job_create_admin_user_resources }}
       restartPolicy: Never
       securityContext:
-        runAsUser: {{ container_uid }}
-        runAsGroup: {{ container_gid }}
+        runAsUser: {{ elasticsearch_container_uid }}
+        runAsGroup: {{ elasticsearch_container_gid }}
+        fsGroup: {{ elasticsearch_container_gid }}
+        fsGroupChangePolicy: "OnRootMismatch"
 {% endif %}

--- a/apps/elasticsearch/templates/services/app/sts.yml.j2
+++ b/apps/elasticsearch/templates/services/app/sts.yml.j2
@@ -175,8 +175,10 @@ spec:
           emptyDir: {}
 {% endif %}
       securityContext:
-        runAsUser: {{ container_uid }}
-        runAsGroup: {{ container_gid }}
+        runAsUser: {{ elasticsearch_container_uid }}
+        runAsGroup: {{ elasticsearch_container_gid }}
+        fsGroup: {{ elasticsearch_container_gid }}
+        fsGroupChangePolicy: "OnRootMismatch"
   volumeClaimTemplates:
   - metadata:
       name: elasticsearch-pvc-data

--- a/apps/elasticsearch/vars/all/main.yml
+++ b/apps/elasticsearch/vars/all/main.yml
@@ -2,6 +2,8 @@
 
 elasticsearch_image_name: "fundocker/openshift-elasticsearch"
 elasticsearch_image_tag: "6.6.2"
+elasticsearch_container_uid: {{ container_uid }}
+elasticsearch_container_gid: {{ container_gid }}
 
 # -- Node specific configuration
 


### PR DESCRIPTION
## Purpose

While using RWO storage classes/providers (e.g. `cinder-csi`), PVC may have wrong ownership and the user running in the container is not allowed to write to the elasticsearch data volume (can belong to `root`).

## Proposal

Properly setting the `fsGroup` in the security context of the pod fixes the issue.

For reference, see [k8s documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods)
