### PR TITLE
🐛(elasticsearch) fix stateful set pvc creation deactivation

### DIFF
--- a/apps/elasticsearch/templates/services/app/sts.yml.j2
+++ b/apps/elasticsearch/templates/services/app/sts.yml.j2
@@ -179,6 +179,7 @@ spec:
         runAsGroup: {{ elasticsearch_container_gid }}
         fsGroup: {{ elasticsearch_container_gid }}
         fsGroupChangePolicy: "OnRootMismatch"
+{% if elasticsearch_persistent_volume_enabled %}
   volumeClaimTemplates:
   - metadata:
       name: elasticsearch-pvc-data
@@ -190,3 +191,4 @@ spec:
       resources:
         requests:
           storage: {{ elasticsearch_persistent_volume_size }}
+{% endif %}


### PR DESCRIPTION

## Purpose

PVC can be deactivated for an Elasticsearch stateful set. In this case the volumes should not be created.

After deploying the Ashley which contains an Elasticsearch to our new Kubernetes cluster, we noticed that the PVC were created.

## Proposal

Add a condition to skip creating the PVC in case the feature is disabled.
