### PR TITLE
✨(prosody) allow to use websocket connection

### DIFF
--- a/apps/prosody/templates/services/app/configs/prosody.cfg.lua.j2
+++ b/apps/prosody/templates/services/app/configs/prosody.cfg.lua.j2
@@ -36,10 +36,19 @@ admins = { {{ prosody_general_admins | join(',') }} }
 -- Enable use of libevent for better performance under high load
 -- For more information see: https://prosody.im/doc/libevent
 use_libevent = {{ prosody_lua_libevent | lower }}
+network_settings = {
+  read_timeout = {{ prosody_network_settings_read_timeout }};
+}
 
-
+{% if prosody_use_bosh %}
 cross_domain_bosh = {{ prosody_cross_domain_bosh | lower }}
 consider_bosh_secure = {{ prosody_consider_bosh_secure | lower }}
+{% endif %}
+
+{% if prosody_use_websocket %}
+cross_domain_websocket = {{ prosody_cross_domain_websocket | lower }}
+consider_websocket_secure = {{ prosody_consider_websocket_secure | lower }}
+{% endif %}
 
 -- This is the list of modules Prosody will load on startup.
 -- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
@@ -143,7 +152,12 @@ certificates = "{{ prosody_vertificates_directory }}"
 
 VirtualHost "{{ prosody_host }}"
     modules_enabled = {
+{% if prosody_use_bosh %}
         "bosh";
+{% endif %}
+{% if prosody_use_websocket %}
+        "websocket";
+{% endif %}
     }
 
 

--- a/apps/prosody/templates/services/nginx/configs/prosody.conf.j2
+++ b/apps/prosody/templates/services/nginx/configs/prosody.conf.j2
@@ -3,6 +3,7 @@ server {
 	listen {{ prosody_nginx_port }};
   server_name localhost;
 
+{% if prosody_use_bosh %}
 	location /http-bind {
 {% if prosody_nginx_ip_whitelist | length > 0 %}
     if ($http_x_forwarded_for !~ ^({{ prosody_nginx_ip_whitelist | join("|") }})) {
@@ -17,4 +18,26 @@ server {
     proxy_buffering off;
     tcp_nodelay on;
 	}
+{% endif %}
+
+{% if prosody_use_websocket %}
+	location /xmpp-websocket {
+{% if prosody_nginx_ip_whitelist | length > 0 %}
+    if ($http_x_forwarded_for !~ ^({{ prosody_nginx_ip_whitelist | join("|") }})) {
+      return 403;
+    }
+{% endif %}
+
+    proxy_pass  http://prosody-app:{{ prosody_http_port }}/xmpp-websocket;
+    proxy_http_version 1.1;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Upgrade $http_upgrade;
+
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_read_timeout 86400;
+	}
+{% endif %}
 }

--- a/apps/prosody/vars/all/main.yml
+++ b/apps/prosody/vars/all/main.yml
@@ -7,8 +7,15 @@ prosody_image_name: "fundocker/prosody"
 prosody_image_tag: "latest"
 prosody_general_admins: []
 prosody_lua_libevent: true
+# bosh
+prosody_use_bosh: true
 prosody_cross_domain_bosh: true
 prosody_consider_bosh_secure: true
+# websocket
+prosody_use_websocket: false
+prosody_cross_domain_websocket: true
+prosody_consider_websocket_secure: true
+prosody_network_settings_read_timeout: 840
 prosody_general_modules_enabled:
   - roster
   - saslauth


### PR DESCRIPTION
## Purpose

We can configure prosody to use websocket connection and/or bosh
connection. New variable are instroduce the connection to use and how to
configure them.
Also, the read_timeout connection setting can be modified.

## Proposal

- [x] allow to use websocket connection
