### PR TITLE
Allow removing acme annotations for some prefixes and remove them completely for the flower app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - CLI: fix the `No such file or directory` error in the `vaults` command
 
+### Removed
+
+- Remove `acme` annotation from flower app ingress as it should not be accessible
+
 ## [5.25.0] - 2021-03-05
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- Allow deactivating `acme` ingress annotation for some blue/green prefixes
 - CLI: add `acme` command to create or update the namespace TLS certificate Issuer
 - Elasticsearch: add support for persistent volume to store indexes data
 - Prosody: create new application for this XMPP server

--- a/apps/ashley/templates/services/nginx/ingress.yml.j2
+++ b/apps/ashley/templates/services/nginx/ingress.yml.j2
@@ -12,7 +12,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ ashley_host | blue_green_host(prefix) }}"

--- a/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
@@ -12,7 +12,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "cms"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
   rules:

--- a/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
@@ -12,7 +12,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "lms"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
   rules:

--- a/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
@@ -12,7 +12,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "lms"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
   rules:

--- a/apps/edxec/templates/services/nginx/ingress.yml.j2
+++ b/apps/edxec/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ edxec_host | blue_green_host(prefix) }}"

--- a/apps/etherpad/templates/services/nginx/ingress.yml.j2
+++ b/apps/etherpad/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ etherpad_host | blue_green_host(prefix) }}"

--- a/apps/flower/templates/services/nginx/ingress_flower.yml.j2
+++ b/apps/flower/templates/services/nginx/ingress_flower.yml.j2
@@ -11,7 +11,9 @@ metadata:
     version: "{{ flower_nginx_image_tag }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ flower_host }}"

--- a/apps/flower/templates/services/nginx/ingress_flower.yml.j2
+++ b/apps/flower/templates/services/nginx/ingress_flower.yml.j2
@@ -10,10 +10,6 @@ metadata:
     service: "nginx"
     version: "{{ flower_nginx_image_tag }}"
     route_target_service: "app"
-  annotations:
-{% if prefix in acme_enabled_route_prefix %}
-    cert-manager.io/issuer: "{{ acme_issuer_name }}"
-{% endif %}
 spec:
   rules:
   - host: "{{ flower_host }}"

--- a/apps/hello/templates/services/app/ingress.yml.j2
+++ b/apps/hello/templates/services/app/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ hello_host | blue_green_host(prefix) }}"

--- a/apps/kibana/templates/services/nginx/ingress.yml.j2
+++ b/apps/kibana/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ kibana_host | blue_green_host(prefix) }}"

--- a/apps/mailcatcher/templates/services/app/ingress.yml.j2
+++ b/apps/mailcatcher/templates/services/app/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     version: "{{ mailcatcher_image_tag }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ mailcatcher_host }}"

--- a/apps/marsha/templates/services/nginx/ingress.yml.j2
+++ b/apps/marsha/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ marsha_host | blue_green_host(prefix) }}"

--- a/apps/nextcloud/templates/services/nginx/ingress.yml.j2
+++ b/apps/nextcloud/templates/services/nginx/ingress.yml.j2
@@ -12,7 +12,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ nextcloud_host | blue_green_host(prefix) }}"

--- a/apps/prosody/templates/services/nginx/ingress.yml.j2
+++ b/apps/prosody/templates/services/nginx/ingress.yml.j2
@@ -10,7 +10,9 @@ metadata:
     service: "nginx"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ prosody_host }}"

--- a/apps/richie/templates/services/nginx/ingress.yml.j2
+++ b/apps/richie/templates/services/nginx/ingress.yml.j2
@@ -11,7 +11,9 @@ metadata:
     route_prefix: "{{ prefix }}"
     route_target_service: "app"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ richie_host | blue_green_host(prefix) }}"

--- a/core_apps/redirect/templates/services/nginx/_redirected_ingress.yml.j2
+++ b/core_apps/redirect/templates/services/nginx/_redirected_ingress.yml.j2
@@ -9,7 +9,9 @@ metadata:
     version: "{{ redirect_nginx_image_tag }}"
     deployment_stamp: "{{ deployment_stamp }}"
   annotations:
+{% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
+{% endif %}
 spec:
   rules:
   - host: "{{ redirection_from | default('unknown') }}"


### PR DESCRIPTION
## Purpose

Acme annotations should not be set for ingresses which will not be reachable (either because no record is set in the DNS or because it is hidden behind authentication)

## Proposal

Port the `acme_enabled_route_prefix` variable and condition from the `master` branch as it was already done by @lunika [for OpenShift](https://github.com/openfun/arnold/pull/530) and lost while migrating to Kubernetes.

Completely remove annotations from the `flower` app as it is destined to be hidden behind an htaccess.

