### PR TITLE
Allow to configure nginx read and send timeout in prosody application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Added
 
 - Prosody: enable mod_smacks when websocket is enabled
+- Prosody: allow to configure nginx proxy read and send timeout
 
 ## [6.2.0] - 2021-09-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Prosody: enable mod_smacks when websocket is enabled
+
 ## [6.2.0] - 2021-09-14
 
 ### Added

--- a/apps/prosody/templates/services/app/configs/prosody.cfg.lua.j2
+++ b/apps/prosody/templates/services/app/configs/prosody.cfg.lua.j2
@@ -157,6 +157,7 @@ VirtualHost "{{ prosody_host }}"
 {% endif %}
 {% if prosody_use_websocket %}
         "websocket";
+        "smacks"; -- XEP-0198: Stream Management
 {% endif %}
     }
 

--- a/apps/prosody/templates/services/nginx/configs/prosody.conf.j2
+++ b/apps/prosody/templates/services/nginx/configs/prosody.conf.j2
@@ -37,7 +37,8 @@ server {
     proxy_set_header Host $host;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
-    proxy_read_timeout 86400;
+    proxy_read_timeout {{ prosody_nginx_proxy_read_timeout }};
+    proxy_send_timeout {{ prosody_nginx_proxy_send_timeout }};
 	}
 {% endif %}
 }

--- a/apps/prosody/templates/services/nginx/ingress.yml.j2
+++ b/apps/prosody/templates/services/nginx/ingress.yml.j2
@@ -13,6 +13,8 @@ metadata:
 {% if prefix in acme_enabled_route_prefix %}
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ prosody_nginx_proxy_read_timeout }}"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ prosody_nginx_proxy_send_timeout }}"
 spec:
   rules:
   - host: "{{ prosody_host }}"

--- a/apps/prosody/vars/all/main.yml
+++ b/apps/prosody/vars/all/main.yml
@@ -70,6 +70,8 @@ prosody_nginx_healthcheck_port: 5000
 prosody_nginx_healthcheck_endpoint: "/__healthcheck__"
 prosody_nginx_status_endpoint: "/__status__"
 prosody_nginx_ip_whitelist: []
+prosody_nginx_proxy_read_timeout: 86400
+prosody_nginx_proxy_send_timeout: 86400
 
 
 # -- resources requests


### PR DESCRIPTION
## Purpose

We need to configure the nginx read and send proxy timeout. We decided
to set the same value to the ingress controller.

## Proposal

- [x] enable mod_smacks when websocket is used
- [x] allow to configure nginx reand and send timeout