### PR TITLE
🔧(project) replace pyup with renovate for dependencies updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,7 +31,6 @@ docs
 .pytest_cache
 .pylint.d
 .pylintrc
-.pyup.yml
 .gitlint
 bin/
 !bin/arnold

--- a/.pyup.yml
+++ b/.pyup.yml
@@ -1,1 +1,0 @@
-schedule: "every week"

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,5 @@
+{
+    "extends": [
+        "github>openfun/renovate-configuration"
+    ]
+}


### PR DESCRIPTION
## Purpose

We decided to migrate to renovate bot to manage all our dependencies on openfun projects.

## Proposal

- [x] remove PyUP configuration
- [x] add base openfun renovate configuration
