### PR TITLE
🐛(project) fix renovate configuration

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,15 @@
 {
-    "extends": [
-        "github>openfun/renovate-configuration"
-    ]
+    "extends": ["github>openfun/renovate-configuration"],
+    "enabledManagers": ["pip_requirements"],
+    "packageRules": [
+        {
+            "groupName": "python dependencies",
+            "matchManagers": ["pip_requirements"],
+            "schedule": ["before 7am on monday"],
+            "matchPackagePatterns": ["*"]
+        }
+    ],
+    "pip_requirements": {
+        "fileMatch": ["^requirements/.*\\.txt$"]
+    }
 }


### PR DESCRIPTION
## Purpose

Our dependencies are listed in requirement files with non-standard location patterns pre-configured in renovate. We should explicitly tell renovate where to find them.

## Proposal

- [x] switch to the `pip_requirements` match manager
