### PR TITLE
Add RBAC built-in support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Implemented support for RBAC objects
+
 ### Changed
 
 - Upgrade `ansible` to `4.6.0`

--- a/apps/hello/templates/services/app/rbac-cluster-role-pod-reader.yml.j2
+++ b/apps/hello/templates/services/app/rbac-cluster-role-pod-reader.yml.j2
@@ -1,0 +1,11 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: hello
+  namespace: "{{ namespace_name }}"
+  name: pod-reader
+rules:
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get", "list"]

--- a/apps/hello/templates/services/app/rbac-role-binding-pod-reader.yml.j2
+++ b/apps/hello/templates/services/app/rbac-role-binding-pod-reader.yml.j2
@@ -1,0 +1,14 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: hello
+  name: read-pods
+  namespace: "{{ namespace_name }}"
+subjects:
+  - kind: ServiceAccount
+    name: default
+roleRef:
+  kind: Role
+  name: pod-reader
+  apiGroup: rbac.authorization.k8s.io

--- a/tasks/get_objects_for_app.yml
+++ b/tasks/get_objects_for_app.yml
@@ -23,6 +23,7 @@
     jobs: "{{ templates | map('regex_search', '.*/job_.*\\.yml\\.j2$') | select('string') | list }}"
     cronjobs: "{{ templates | map('regex_search', '.*/cronjob_.*\\.yml\\.j2$') | select('string') | list }}"
     ingresses: "{{ templates | map('regex_search', '.*/ingress.*\\.yml\\.j2$') | select('string') | list }}"
+    rbacs: "{{ templates | map('regex_search', '.*/rbac.*\\.yml\\.j2$') | select('string') | list }}"
   tags:
     - configmap
     - deploy
@@ -30,6 +31,7 @@
     - endpoint
     - job
     - ingress
+    - rbac
     - service
     - statefulset
 
@@ -104,3 +106,12 @@
   tags:
     - deploy
     - ingress
+
+- name: Display K8S rbac for this app
+  debug:
+    var: rbacs
+    verbosity: 2
+  when: rbacs is defined
+  tags:
+    - deploy
+    - rbac

--- a/tasks/manage_app.yml
+++ b/tasks/manage_app.yml
@@ -13,10 +13,12 @@
   with_items:
     - "{{ endpoints }}"
     - "{{ services }}"
+    - "{{ rbacs }}"
   tags:
     - deploy
     - endpoint
     - service
+    - rbac
 
 - name: Prepare jobs ordering & filtering
   set_fact:


### PR DESCRIPTION
## Purpose

Some apps may require additionnal permissions to run. Those permissions should be described in RBAC objects [1].

[1] https://kubernetes.io/docs/reference/access-authn-authz/rbac/

## Proposal

Arnold will now create every RBAC object whose definition file respects the following (glob) naming pattern: `rbac*.yml.j2` in the application service templates directory.

Depends on #688 