### PR TITLE
🔧(marsha) add x-forwarded-for header in nginx configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Marsha: add x-forwarded-for header in nginx configuration
+
 ### Changed
 
 - Upgrade `ansible` to `5.0.1`

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -36,6 +36,7 @@ server {
 
   location @proxy_to_marsha_app {
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     proxy_redirect off;
     proxy_pass http://marsha-backend;
@@ -43,6 +44,7 @@ server {
 
   location @proxy_to_marsha_xapi {
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
     proxy_redirect off;
     proxy_pass http://marsha-xapi;


### PR DESCRIPTION
## Purpose

The instruction to add the header x-forwarded-for to the application
backend was missing in the nginx configuration.

## Proposal

- [x] add x-forwarded-for header in nginx configuration