### PR TITLE
✨(marsha) configure nginx to handle websocket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Marsha: configure nginx to handle websockets in a dedicated location
+
 ## [6.9.0] - 2022-01-17
 
 ### Changed

--- a/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
+++ b/apps/marsha/templates/services/nginx/configs/marsha.conf.j2
@@ -61,6 +61,19 @@ server {
     try_files $uri @proxy_to_marsha_app;
   }
 
+  location /ws/ {
+    proxy_pass http://marsha-backend;
+
+    proxy_http_version 1.1;
+    proxy_set_header Connection "Upgrade";
+    proxy_set_header Upgrade $http_upgrade;
+
+    proxy_buffering off;
+    proxy_set_header Host $host;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+  }
+
   location /xapi {
 {% if http_basic_auth_enabled and bypass_htaccess %}
     if ($http_x_forwarded_for !~ ^({{ marsha_nginx_bypass_htaccess_ip_whitelist | join("|") }})) {


### PR DESCRIPTION
## Purpose

Marsha supports websocket. We need to configure Nginx to manage this
connection. All websockets begin with `/ws/`, a new location block is
created responsible to deal with the Connection and Upgrade header

## Proposal

- [x] configure nginx to manage websocket