### PR TITLE
⬆️(project) upgrade ansible-lint to 5.3.2

### DIFF
--- a/requirements/development.txt
+++ b/requirements/development.txt
@@ -2,7 +2,7 @@
 yq==2.13.0
 
 # Quality
-ansible-lint==5.3.1
+ansible-lint==5.3.2
 black==21.10b0
 flake8==4.0.1
 isort==5.10.1


### PR DESCRIPTION
## Purpose

ansible-lint 5.3.1 has a compatibility issue with the rich package.
Version 5.3.2 of ansible-lint fixes this issue.

## Proposal

- [x] upgrade ansible-lint to 5.3.2