### PR TITLE
✨(marsha) Use unprivileged image provided by Nginx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Marsha: configure nginx to handle websockets in a dedicated location
 
+### Changed
+
+- Marsha: use image nginxinc/nginx-unprivileged to run Nginx
+
 ## [6.9.0] - 2022-01-17
 
 ### Changed

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -4,8 +4,8 @@
 marsha_host: "marsha.{{ namespace_name }}.{{ domain_name }}"
 
 # -- nginx
-marsha_nginx_image_name: "fundocker/openshift-nginx"
-marsha_nginx_image_tag: "1.13"
+marsha_nginx_image_name: "nginxinc/nginx-unprivileged"
+marsha_nginx_image_tag: "1.20"
 marsha_nginx_port: 8061
 marsha_nginx_replicas: 1
 marsha_nginx_htpasswd_secret_name: "marsha-htpasswd"


### PR DESCRIPTION
## Purpose

Since now we were using our own image to run an unprivileged nginx
instance. In fact Nginx provides its own unprivileged nginx docker image.
This image is well maintained with new versions. We switch to this image
and upgrade to a mor recent version.

## Proposal

- [x] Use unprivileged image provided by Nginx