### PR TITLE
👷(circleci) migrate to machine image stable release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ aliases:
   - &defaults
     # We use the machine executor, i.e. a VM, not a container
     machine:
+      image: ubuntu-2004:202201-02
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/fun
@@ -744,6 +745,7 @@ jobs:
   hub:
     # We use the machine executor, i.e. a VM, not a container
     machine:
+      image: ubuntu-2004:202201-02
       # Prevent cache-related issues
       docker_layer_caching: false
 

--- a/bin/ci
+++ b/bin/ci
@@ -108,7 +108,7 @@ function route(){
   url="${PROTOCOL}://${subdomain}${SERVICE}.${ARNOLD_NAMESPACE}.${K8S_DOMAIN}.nip.io:${PORT}${URL_PATH}"
   cmd="curl -vLk --header 'Accept: ${ACCEPT_HEADER}' ${url}"
   # shellcheck disable=SC2016
-  test_='grep "HTTP/1.1 200 OK" /tmp/${random}.err && grep "${CONTENT}" /tmp/${random}.out'
+  test_='grep "HTTP/2 200" /tmp/${random}.err && grep "${CONTENT}" /tmp/${random}.out'
 
   echo "with url : ${url}"
 


### PR DESCRIPTION
## Purpose

CircleCI will soon deprecate default base image for the machine executor.

## Proposal

We need to explicitly switch to the latest image stable release.

For more information about this migration please, refer to the migration guide:

https://circleci.com/docs/2.0/images/linux-vm/14.04-to-20.04-migration/
