### PR TITLE
⬆️(project) upgrade base k3d and kubectl dependencies

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,15 +36,15 @@ aliases:
     run:
       name: Install the kubectl client and k3d
       command: |
-        export KUBECTL_RELEASE="v1.20.2"
+        export KUBECTL_RELEASE="v1.23.5"
         curl -Lo "${HOME}/bin/kubectl" "https://dl.k8s.io/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl"
         curl -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl.sha256"
         echo "$(</tmp/kubectl.sha256) ${HOME}/bin/kubectl" | sha256sum --check
         chmod 755 "${HOME}/bin/kubectl"
 
-        export K3D_RELEASE="v4.2.0"
-        curl -Lo "${HOME}/bin/k3d" "https://github.com/rancher/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
-        curl -sL https://github.com/rancher/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
+        export K3D_RELEASE="v4.4.8"
+        curl -Lo "${HOME}/bin/k3d" "https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
+        curl -sL https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
           grep _dist/k3d-linux-amd64 | \
           sed "s|_dist/k3d-linux-amd64|${HOME}/bin/k3d|" | \
           sha256sum --check

--- a/README.md
+++ b/README.md
@@ -16,17 +16,19 @@ to make Ansible talk with Kubernetes.
 
 - [Docker](https://docs.docker.com/engine/installation/): we use docker to
   develop and run Arnold. This is a strict requirement to use this project.
-- [Kubectl](https://kubernetes.io/docs/tasks/tools/):
+- [Kubectl](https://kubernetes.io/docs/tasks/tools/) (>`v.1.23.5`):
   This CLI is used to communicate with the running Kubernetes instance you
   will use.
 - [curl](https://curl.se/) is required by Arnold's CLI.
 
 Optionally:
 
-- [k3d](https://k3d.io/): This tool is used to setup and run a lightweight
-  Kubernetes cluster, in order to have a local environment (it is required to
-  complete below's quickstart instructions to avoid depending on an existing
-  Kubernetes cluster).
+- [k3d](https://k3d.io/) (`v4.4.8`, `5.x` releases are not compatible with our
+  CI docker versions see [this k3d
+  issue](https://github.com/k3d-io/k3d/issues/807)): This tool is used to setup
+  and run a lightweight Kubernetes cluster, in order to have a local
+  environment (it is required to complete below's quickstart instructions to
+  avoid depending on an existing Kubernetes cluster).
 - [gnupg](https://gnupg.org/) to encrypt Ansible vaults passwords and
   collaborate with your team.
 

--- a/group_vars/customer/eugene/ci/main.yml
+++ b/group_vars/customer/eugene/ci/main.yml
@@ -5,4 +5,4 @@ redirections:
       - "www.hello.{{ namespace_name }}.{{ domain_name }}"
 
 nextcloud_user_id: REPLACE_USER_ID
-
+prosody_storage: "sql"


### PR DESCRIPTION
## Purpose

The 5+ `k3d` releases break our cluster initialization script.

## Proposal

After investigation, CircleCI's VM `runc` release is not compatible with the latest 5.x `k3d` releases. We've upgraded `k3d` to the latest 4.x release and it seems stable for both Arnold and Arnold-apps CIs.

- [x] upgrade `k3d` base version to `4.4.8`
- [x] upgrade `kubectl` base version to `1.23.5`
- [x] fix cluster initialization script