### PR TITLE
✨(project) allow to use the `deployment_stamp` variable in project variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 - Upgrade `ansible` to `5.6.0`
 - Upgrade `jmespath` to `1.0.0`
+- Allow to use the `deployment_stamp` variable in project variables
 
 ### Removed
 

--- a/create_redirect.yml
+++ b/create_redirect.yml
@@ -12,6 +12,11 @@
       ansible.builtin.debug: msg="==== Starting create_redirect playbook ===="
       tags: deploy
 
+    # Set the deployment stamp value that will be used to make created objects
+    # unique.
+    - name: Set deployment stamp
+      ansible.builtin.set_fact: deployment_stamp="d-{{ lookup('pipe', 'date +%y%m%d-%Hh%Mm%Ss') }}"
+
     - import_tasks: tasks/set_vars.yml
 
     - name: Lookup available core applications
@@ -29,11 +34,6 @@
       with_items: '{{ app | json_query("vars[?type==`all`]") }}'
 
     - import_tasks: tasks/get_objects_for_app.yml
-
-    # Set the deployment stamp value that will be used to make created objects
-    # unique.
-    - name: Set deployment stamp
-      ansible.builtin.set_fact: deployment_stamp="d-{{ lookup('pipe', 'date +%y%m%d-%Hh%Mm%Ss') }}"
 
     - import_tasks: tasks/create_app_config.yml
 

--- a/deploy.yml
+++ b/deploy.yml
@@ -14,12 +14,12 @@
       ansible.builtin.debug: msg="==== Starting deploy playbook ===="
       tags: deploy
 
-    - import_tasks: tasks/set_vars.yml
-
     # Set the deployment stamp value for this deployment
     - name: Set deployment stamp
       ansible.builtin.set_fact: deployment_stamp="d-{{ lookup('pipe', 'date +%y%m%d-%Hh%Mm%Ss') }}"
       tags: deploy
+
+    - import_tasks: tasks/set_vars.yml
 
     # Set the job stamp for this deployment
     - name: Set job stamp


### PR DESCRIPTION
## Purpose

We often need to configure applications given a deployment stack object name that depends on the deployment_stamp value.


## Proposal

Set the `deployment_stamp` variable before setting project variable to be able to access its value in Arnold's applications configuration.

Quick win. Huge improvement 🎉
