### PR TITLE
✨(apps) define ingress class name to use on each ingress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Added
+
+- Define ingress class name to use on each ingress
+
 ### Changed
 
 - Upgrade `ansible` to `6.1.0`

--- a/apps/ashley/templates/services/nginx/ingress.yml.j2
+++ b/apps/ashley/templates/services/nginx/ingress.yml.j2
@@ -16,6 +16,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ ashley_ingress_class_name }}"
   rules:
   - host: "{{ ashley_host | blue_green_host(prefix) }}"
     http:

--- a/apps/ashley/vars/all/main.yml
+++ b/apps/ashley/vars/all/main.yml
@@ -1,8 +1,9 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 ashley_host: "ashley.{{ namespace_name }}.{{ domain_name }}"
 ashley_consumer_hosts: []
+ashley_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 ashley_nginx_image_name: "fundocker/openshift-nginx"

--- a/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_cms.yml.j2
@@ -17,6 +17,7 @@ metadata:
 {% endif %}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
+  ingressClassName: "{{ edxapp_cms_ingress_class_name }}"
   rules:
   - host: "{{ edxapp_cms_host | blue_green_host(prefix) }}"
     http:

--- a/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_lms.yml.j2
@@ -17,6 +17,7 @@ metadata:
 {% endif %}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
+  ingressClassName: "{{ edxapp_lms_ingress_class_name }}"
   rules:
   - host: "{{ edxapp_lms_host | blue_green_host(prefix) }}"
     http:

--- a/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
+++ b/apps/edxapp/templates/services/nginx/ingress_preview.yml.j2
@@ -17,6 +17,7 @@ metadata:
 {% endif %}
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ edxapp_routing_timeout | default("60") }}"
 spec:
+  ingressClassName: "{{ edxapp_preview_ingress_class_name }}"
   rules:
   - host: "{{ edxapp_preview_host | blue_green_host(prefix) }}"
     http:

--- a/apps/edxapp/vars/all/main.yml
+++ b/apps/edxapp/vars/all/main.yml
@@ -1,9 +1,12 @@
 # Application default configuration
 
-# -- routes
+# -- ingresses
 edxapp_cms_host: "cms.{{ namespace_name }}.{{ domain_name }}"
 edxapp_lms_host: "lms.{{ namespace_name }}.{{ domain_name }}"
 edxapp_preview_host: "preview.{{ namespace_name }}.{{ domain_name }}"
+edxapp_cms_ingress_class_name: "{{ default_ingress_class_name }}"
+edxapp_lms_ingress_class_name: "{{ default_ingress_class_name }}"
+edxapp_preview_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- edxapp (cms/lms)
 edxapp_image_name: "fundocker/edxapp"

--- a/apps/edxec/templates/services/nginx/ingress.yml.j2
+++ b/apps/edxec/templates/services/nginx/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ edxec_ingress_class_name }}"
   rules:
   - host: "{{ edxec_host | blue_green_host(prefix) }}"
     http:

--- a/apps/edxec/vars/all/main.yml
+++ b/apps/edxec/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- routes
+# -- ingresses
 edxec_host: "edxec.{{ namespace_name }}.{{ domain_name }}"
+edxec_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- edxec
 edxec_image_name: "fundocker/edxec"

--- a/apps/flower/templates/services/nginx/ingress_flower.yml.j2
+++ b/apps/flower/templates/services/nginx/ingress_flower.yml.j2
@@ -11,6 +11,7 @@ metadata:
     version: "{{ flower_nginx_image_tag }}"
     route_target_service: "app"
 spec:
+  ingressClassName: "{{ flower_ingress_class_name }}"
   rules:
   - host: "{{ flower_host }}"
     http:

--- a/apps/flower/vars/all/main.yml
+++ b/apps/flower/vars/all/main.yml
@@ -1,4 +1,6 @@
+# -- ingress
 flower_host: "flower.{{ namespace_name }}.{{ domain_name }}"
+flower_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 flower_nginx_image_name: "fundocker/openshift-nginx"

--- a/apps/hello/templates/services/app/ingress.yml.j2
+++ b/apps/hello/templates/services/app/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ hello_ingress_class_name }}"
   rules:
   - host: "{{ hello_host | blue_green_host(prefix) }}"
     http:

--- a/apps/hello/vars/all/main.yml
+++ b/apps/hello/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 hello_host: "hello.{{ namespace_name }}.{{ domain_name }}"
+hello_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- misc
 hello_app_port: "8080"

--- a/apps/kibana/templates/services/nginx/ingress.yml.j2
+++ b/apps/kibana/templates/services/nginx/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ kibana_ingress_class_name }}"
   rules:
   - host: "{{ kibana_host | blue_green_host(prefix) }}"
     http:

--- a/apps/kibana/vars/all/main.yml
+++ b/apps/kibana/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 kibana_host: "kibana.{{ namespace_name }}.{{ domain_name }}"
+kibana_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 kibana_nginx_image_name: "fundocker/openshift-nginx"

--- a/apps/mailcatcher/templates/services/app/ingress.yml.j2
+++ b/apps/mailcatcher/templates/services/app/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ mailcatcher_ingress_class_name }}"
   rules:
   - host: "{{ mailcatcher_host }}"
     http:

--- a/apps/mailcatcher/vars/all/main.yml
+++ b/apps/mailcatcher/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 mailcatcher_host: "mailcatcher.{{ namespace_name }}.{{ domain_name }}"
+mailcatcher_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- mailcatcher
 mailcatcher_image_name: "sj26/mailcatcher"

--- a/apps/marsha/templates/services/nginx/ingress.yml.j2
+++ b/apps/marsha/templates/services/nginx/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ marsha_ingress_class_name }}"
   rules:
   - host: "{{ marsha_host | blue_green_host(prefix) }}"
     http:

--- a/apps/marsha/vars/all/main.yml
+++ b/apps/marsha/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 marsha_host: "marsha.{{ namespace_name }}.{{ domain_name }}"
+marsha_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 marsha_nginx_image_name: "nginxinc/nginx-unprivileged"

--- a/apps/nextcloud/templates/services/nginx/ingress.yml.j2
+++ b/apps/nextcloud/templates/services/nginx/ingress.yml.j2
@@ -16,6 +16,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ nextcloud_ingress_class_name }}"
   rules:
   - host: "{{ nextcloud_host | blue_green_host(prefix) }}"
     http:

--- a/apps/nextcloud/vars/all/main.yml
+++ b/apps/nextcloud/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 nextcloud_host: "nextcloud.{{ namespace_name }}.{{ domain_name }}"
+nextcloud_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 nextcloud_nginx_image_name: "fundocker/openshift-nginx"

--- a/apps/prosody/templates/services/nginx/ingress.yml.j2
+++ b/apps/prosody/templates/services/nginx/ingress.yml.j2
@@ -16,6 +16,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "{{ prosody_nginx_proxy_read_timeout }}"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "{{ prosody_nginx_proxy_send_timeout }}"
 spec:
+  ingressClassName: "{{ prosody_ingress_class_name }}"
   rules:
   - host: "{{ prosody_host }}"
     http:

--- a/apps/prosody/vars/all/main.yml
+++ b/apps/prosody/vars/all/main.yml
@@ -1,5 +1,6 @@
-# -- route
+# -- ingress
 prosody_host: "prosody.{{ namespace_name }}.{{ domain_name }}"
+prosody_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- Prosody
 

--- a/apps/richie/templates/services/nginx/ingress.yml.j2
+++ b/apps/richie/templates/services/nginx/ingress.yml.j2
@@ -15,6 +15,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ richie_ingress_class_name }}"
   rules:
   - host: "{{ richie_host | blue_green_host(prefix) }}"
     http:

--- a/apps/richie/vars/all/main.yml
+++ b/apps/richie/vars/all/main.yml
@@ -1,7 +1,8 @@
 # Application default configuration
 
-# -- route
+# -- ingress
 richie_host: "richie.{{ namespace_name }}.{{ domain_name }}"
+richie_ingress_class_name: "{{ default_ingress_class_name }}"
 
 # -- nginx
 richie_nginx_image_name: "fundocker/richie-demo-nginx"

--- a/group_vars/all/main.yml
+++ b/group_vars/all/main.yml
@@ -181,3 +181,8 @@ container_gid: 0
 # directly.
 default_storage_class_rwx: "manual"
 default_storage_class_rwo: "local-path"
+
+# Ingress class name
+# A default ingress class name is not necessarily defined in a k8s cluster.
+# We can specify which one to use by defining the ingressClassName in the Ingress spec
+default_ingress_class_name: "nginx"


### PR DESCRIPTION
## Purpose

A default ingress class name is not necessarily defined in a k8s cluster. We can specify which one to use by defining the `ingressClassName` in the ingress spec. The ingress can be defined globally and/or at the application level.


## Proposal

- [x]  define ingress class name to use on each ingress
