### PR TITLE
⬆️(project) upgrade k3d release to v5.4.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ aliases:
   - &defaults
     # We use the machine executor, i.e. a VM, not a container
     machine:
-      image: ubuntu-2004:202201-02
+      image: ubuntu-2004:2022.07.1
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/fun
@@ -36,18 +36,16 @@ aliases:
     run:
       name: Install the kubectl client and k3d
       command: |
-        export KUBECTL_RELEASE="v1.23.5"
+        export KUBECTL_RELEASE="v1.25.2"
         curl -Lo "${HOME}/bin/kubectl" "https://dl.k8s.io/release/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl"
         curl -Lo /tmp/kubectl.sha256 "https://dl.k8s.io/${KUBECTL_RELEASE}/bin/linux/amd64/kubectl.sha256"
         echo "$(</tmp/kubectl.sha256) ${HOME}/bin/kubectl" | sha256sum --check
         chmod 755 "${HOME}/bin/kubectl"
 
-        export K3D_RELEASE="v4.4.8"
+        export K3D_RELEASE="v5.4.6"
         curl -Lo "${HOME}/bin/k3d" "https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/k3d-linux-amd64"
-        curl -sL https://github.com/k3d-io/k3d/releases/download/${K3D_RELEASE}/sha256sum.txt | \
-          grep _dist/k3d-linux-amd64 | \
-          sed "s|_dist/k3d-linux-amd64|${HOME}/bin/k3d|" | \
-          sha256sum --check
+        # FIXME
+        # Removed checksum checking: https://github.com/k3d-io/k3d/discussions/1037
         chmod 755 "${HOME}/bin/k3d"
 
   - &configure_sysctl_limits

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- Declare ingress class in core app redirections
+
 ## [6.13.0] - 2022-09-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ to make Ansible talk with Kubernetes.
 
 Optionally:
 
-- [k3d](https://k3d.io/) (`v4.4.8`, `5.x` releases are not compatible with our
-  CI docker versions see [this k3d
-  issue](https://github.com/k3d-io/k3d/issues/807)): This tool is used to setup
+- [k3d](https://k3d.io/) (>`v.5.0.0`): This tool is used to setup
   and run a lightweight Kubernetes cluster, in order to have a local
   environment (it is required to complete below's quickstart instructions to
   avoid depending on an existing Kubernetes cluster).

--- a/bin/init-cluster
+++ b/bin/init-cluster
@@ -25,8 +25,8 @@ ARNOLD_ROOT="$(dirname "$(dirname "$(readlink -f "$0")")")"
 declare -r PERSISTENT_VOLUME_PATH="${ARNOLD_ROOT}/k3d-storage"
 
 # Dependencies to download
-declare -r INGRESS_NGINX_DEPLOYMENT="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v0.43.0/deploy/static/provider/cloud/deploy.yaml"
-declare -r INGRESS_NGINX_DEPLOYMENT_SHA256="03d80b59660a1818dea0f1b3482aa59cfae2bebcc755b150920ddfa26017adc3"
+declare -r INGRESS_NGINX_DEPLOYMENT="https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.4.0/deploy/static/provider/cloud/deploy.yaml"
+declare -r INGRESS_NGINX_DEPLOYMENT_SHA256="dc953c685157918b08155bff23e526bb1298257fc4d92b94343020ace07b2280"
 
 # PersistentVolume provisionning.
 #
@@ -78,7 +78,7 @@ if ! k3d cluster list "${K3D_CLUSTER_NAME}" &> /dev/null ; then
     -p "${K3D_BIND_HOST_PORT_HTTP}:80@loadbalancer" \
     -p "${K3D_BIND_HOST_PORT_HTTPS}:443@loadbalancer" \
     -v "${PERSISTENT_VOLUME_PATH}:/data/pv" \
-    --k3s-server-arg '--no-deploy=traefik' \
+    --k3s-arg "--disable=traefik@server:0" \
     "${k3d_registry_option[@]}"
 else
   k3d cluster start "${K3D_CLUSTER_NAME}"
@@ -143,7 +143,9 @@ if ! kubectl --kubeconfig="${KUBECONFIG}" get ns ingress-nginx &> /dev/null ; th
   kubectl --kubeconfig="${KUBECONFIG}" apply -f "${nginx_controller}"
   echo "Waiting for nginx-controller to be up and running... "
   kubectl --kubeconfig="${KUBECONFIG}" --namespace ingress-nginx wait \
-    --for=condition=available deploy/ingress-nginx-controller --timeout=90s \
+      --for=condition=ready pod \
+      --selector=app.kubernetes.io/component=controller \
+      --timeout=120s \
     && echo "nginx-controller is ready" \
     || echo "timeout! Please wait a little before deploying an app with arnold."
 else
@@ -159,10 +161,19 @@ items:
   metadata:
     name: arnold
     namespace: default
+- apiVersion: v1
+  kind: Secret
+  metadata:
+    name: arnold-sa-token
+    namespace: default
+    annotations:
+      kubernetes.io/service-account.name: arnold
+  type: kubernetes.io/service-account-token
 - apiVersion: rbac.authorization.k8s.io/v1
   kind: ClusterRoleBinding
   metadata:
     name: arnold-cluster-admin
+    namespace: default
   roleRef:
     apiGroup: rbac.authorization.k8s.io
     kind: ClusterRole

--- a/core_apps/redirect/templates/services/nginx/_redirected_ingress.yml.j2
+++ b/core_apps/redirect/templates/services/nginx/_redirected_ingress.yml.j2
@@ -13,6 +13,7 @@ metadata:
     cert-manager.io/issuer: "{{ acme_issuer_name }}"
 {% endif %}
 spec:
+  ingressClassName: "{{ default_ingress_class_name }}"
   rules:
   - host: "{{ redirection_from | default('unknown') }}"
     http:


### PR DESCRIPTION
## Purpose

Now that CircleCI docker version is compatible with recent k3d releases, it's time to move on!

## Proposal

- [x] upgrade `k3d` to `v5.4.6`

During this work I had to fix a recent regression with redirection ingresses not defining explicitly their `ingressClassName`.

Reference issue: https://github.com/k3d-io/k3d/issues/807
