### PR TITLE
👷(circle) upgrade to large resource class machines

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,7 @@ aliases:
       # Prevent cache-related issues
       docker_layer_caching: false
     working_directory: ~/fun
+    resource_class: large
 
   - &ci_env
     run:


### PR DESCRIPTION
## Purpose

As recommended by CircleCI, it would be nice to move to large resource class for machine executors to improve global CI performances.

## Proposal

- [x] Update the default `resource_class` to `large`
