### PR TITLE
⬆️(apps) use batch/v1 api in cronjob manifests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 ### Changed
 
 - Upgrade `ansible` to `7.2.0`
+- Use batch/v1 api in cronjob_pipeline manifest
 
 ## [6.16.0] - 2023-02-02
 

--- a/apps/ashley/templates/services/app/cronjob_update_index.yml.j2
+++ b/apps/ashley/templates/services/app/cronjob_update_index.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   labels:

--- a/apps/hello/templates/services/app/cronjob_hello.yml.j2
+++ b/apps/hello/templates/services/app/cronjob_hello.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: "cronjob-hello-{{ deployment_stamp }}"

--- a/apps/nextcloud/templates/services/app/cronjob_cron.yml.j2
+++ b/apps/nextcloud/templates/services/app/cronjob_cron.yml.j2
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: nextcloud-cron-{{ deployment_stamp }}

--- a/tasks/delete_app.yml
+++ b/tasks/delete_app.yml
@@ -12,7 +12,7 @@
     - { kind:  "ReplicationController", api_version: "v1" }
     - { kind:  "StatefulSet", api_version: "v1" }
     - { kind:  "Job", api_version: "v1" }
-    - { kind:  "CronJob", api_version: "v1beta1" }
+    - { kind:  "CronJob", api_version: "v1" }
     # Pods must be deleted after all kind of objects that can spawn new pods
     - { kind:  "Pod", api_version: "v1" }
     - { kind:  "Service", api_version: "v1" }


### PR DESCRIPTION
## Purpose

The bach/v1beta1 API is deprecated since kubernets 1.21 and is removed in version 1.25. We can upgrade the manifests to use it now.


## Proposal

- [x] use batch/v1 api in cronjob manifests
