### PR TITLE
🔧(kibana) remove server UUID generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Remove UUID generation for kibana
+
 ## [6.17.0] - 2023-06-15
 
 ### Changed

--- a/apps/kibana/templates/services/app/configs/kibana.yml.j2
+++ b/apps/kibana/templates/services/app/configs/kibana.yml.j2
@@ -2,7 +2,6 @@
 
 # The server name/uuid should be unique for all replica
 server.name: ${HOSTNAME}
-server.uuid: ${SERVER_UUID}
 xpack.security.cookieName: "{{ kibana_host + '-' + deployment_stamp }}"
 
 # Accept requests from all hosts

--- a/apps/kibana/templates/services/app/deploy.yml.j2
+++ b/apps/kibana/templates/services/app/deploy.yml.j2
@@ -48,8 +48,6 @@ spec:
         - name: kibana
           image: "{{ kibana_image_name }}:{{ kibana_image_tag }}"
           imagePullPolicy: Always
-          command: ["/bin/bash"]
-          args: ["-c", "SERVER_UUID=$(uuidgen) /usr/local/bin/kibana-docker"]
           livenessProbe:
             exec:
               command:


### PR DESCRIPTION
## Purpose

Recent Kibana releases auto-generates a uuid to uniquely identify a server instance. It is no longer required to generate and set it manually.

## Proposal

- [x] remove server UUID generation mechanism
