### PR TITLE
🛂(cli) use github token to avoid rate limiting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-### Changed
+### Added
+
+- Use Gitlab token when call the Github's API
 
 ## [6.19.0] - 2023-09-01
 

--- a/bin/arnold
+++ b/bin/arnold
@@ -254,9 +254,14 @@ function _get_log_level_name() {
 
 # Get the latest Arnold release by querying Github's API
 function _get_latest_release() {
+  local auth_header=()
+  if [ -n "$GITHUB_TOKEN" ]; then
+    auth_header=(-H "Authorization: Bearer $GITHUB_TOKEN")
+  fi
+
   if ! curl \
       -s \
-      -H "Accept: application/vnd.github.v3+json" \
+      -H "Accept: application/vnd.github.v3+json" "${auth_header[@]}" \
       "https://api.github.com/repos/openfun/arnold/releases?per_page=1" ; then
     log debug "Cannot get latest release from GitHub.com"
   fi


### PR DESCRIPTION
## Purpose

If we execute a lot of Arnold command, this will reach the Github API rate limiting. 
When we reach the limit Arnold will fail because it can parse the Github response and stop with this error
```
jq: error (at <stdin>:1): Cannot index object with number
```

## Proposal

Use the environment variable ``GITHUB_TOKEN`` to authenticate to the Github API and increase the API rate limiting.  