### PR TITLE
🐛(apps) skip app filtering when `apps_filter` is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Fixed
+
+- App filtering when `apps_filter` variable is set but empty
+
 ## [6.19.1] - 2023-09-15
 
 ### Fixed

--- a/tasks/set_vars.yml
+++ b/tasks/set_vars.yml
@@ -118,7 +118,7 @@
     # We use escaped double quotes in the first regex_replace filter to be able
     # to add single quotes around app name in the query
     apps_filter_query: "[?{{ apps_filter.split(',') | map('regex_replace', '([\\w-]+)', \"name=='\\1'\") | join(' || ') }}]" # noqa jinja[spacing]
-  when: apps_filter is defined
+  when: apps_filter is defined and apps_filter | length > 1
 
 - name: Filter apps
   ansible.builtin.set_fact:


### PR DESCRIPTION
## Purpose

The `set_vars` playbook attempted to filter apps even when no specific apps were provided for filtering (e.g. with an empty `apps_filter`). 

## Proposal

Thus, we now require the `apps_filter` extra var to be defined and not empty.