### PR TITLE
🔧(fun) avoid search indexing for attestations files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+### Changed
+
+- Avoid indexing of attestations files with a nginx rule
+
 ## [6.23.0] - 2024-10-01
 
 ### Changed

--- a/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
+++ b/apps/edxapp/templates/services/nginx/configs/lms.conf.j2
@@ -100,6 +100,7 @@ server {
     access_log off;
     expires {{ edxapp_nginx_lms_media_cache_expires }};
     add_header Cache-Control public;
+    add_header X-Robots-Tag "noindex, nofollow";
     root /data/media;
     try_files /$file =404;
   }

--- a/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
+++ b/apps/edxec/templates/services/nginx/configs/edxec.conf.j2
@@ -81,6 +81,7 @@ server {
     access_log off;
     expires {{ edxec_nginx_media_cache_expires }};
     add_header Cache-Control public;
+    add_header X-Robots-Tag "noindex, nofollow";
     root /data/media/;
     try_files /$file =404;
   }

--- a/apps/richie/templates/services/nginx/configs/richie.conf.j2
+++ b/apps/richie/templates/services/nginx/configs/richie.conf.j2
@@ -73,6 +73,7 @@ server {
     access_log off;
     expires {{ richie_nginx_media_cache_expires }};
     add_header Cache-Control public;
+    add_header X-Robots-Tag "noindex, nofollow";
     root /data/media;
     try_files /$file =404;
   }


### PR DESCRIPTION
## Purpose

As the media/attestations pdf files contain users PII, they should not be indexed by search engines.
Adding a nginx rule to add a robots tag header.